### PR TITLE
Navigate back when QR code scan succeeds or fails

### DIFF
--- a/App/navigators/ScanStack.tsx
+++ b/App/navigators/ScanStack.tsx
@@ -4,7 +4,7 @@ import { createStackNavigator } from '@react-navigation/stack'
 import defaultStackOptions from './defaultStackOptions'
 import Scan from '../screens/Scan'
 
-type ScanStackParams = {
+export type ScanStackParams = {
   Scan: undefined
 }
 

--- a/App/screens/Scan.tsx
+++ b/App/screens/Scan.tsx
@@ -6,8 +6,14 @@ import { QRScanner, Pending, Success, Failure } from 'components'
 import type { BarCodeReadEvent } from 'react-native-camera'
 
 import { ConnectionState } from '@aries-framework/core'
+import { StackNavigationProp } from '@react-navigation/stack'
+import { ScanStackParams } from 'navigators/ScanStack'
 
-const Scan: React.FC = () => {
+interface Props {
+  navigation: StackNavigationProp<ScanStackParams, 'Scan'>
+}
+
+const Scan: React.FC<Props> = ({ navigation }) => {
   const { agent } = useAgent()
 
   const [modalVisible, setModalVisible] = useState<'pending' | 'success' | 'failure' | ''>('')
@@ -27,19 +33,23 @@ const Scan: React.FC = () => {
       const connectionRecord = await agent?.connections.receiveInvitationFromUrl(event.data, {
         autoAcceptConnection: true,
       })
-
       setConnectionId(connectionRecord.id)
     } catch {
       setModalVisible('failure')
     }
   }
 
+  const exitCodeScan = () => {
+    setModalVisible('')
+    navigation.goBack()
+  }
+
   return (
     <View>
       <QRScanner handleCodeScan={handleCodeScan} />
       <Pending visible={modalVisible === 'pending'} />
-      <Success visible={modalVisible === 'success'} onPress={() => setModalVisible('')} />
-      <Failure visible={modalVisible === 'failure'} onPress={() => setModalVisible('')} />
+      <Success visible={modalVisible === 'success'} onPress={exitCodeScan} />
+      <Failure visible={modalVisible === 'failure'} onPress={exitCodeScan} />
     </View>
   )
 }


### PR DESCRIPTION
Signed-off-by: Akiff Manji <akiff.manji@gmail.com>

# Summary of Changes

* Adds logic to navigate back to previous screen when QR code scanning completes and modal is dismissed

# Related Issues

#103 

# Pull Request Checklist

This is just a reminder about the most common mistakes. Please make sure that you tick all _appropriate_ boxes. But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [ ] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this).
- [ ] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components.
- [ ] Run prettier: `npm run style-format`
- [ ] Updated **documentation** for changed code and new or modified features.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

_PR template adapted from the Python attrs project._
