### PR TITLE
build: update react-native-reanimated to 2.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "react-native-get-random-values": "^1.7.0",
         "react-native-keychain": "^6.2.0",
         "react-native-qrcode-svg": "^6.0.6",
-        "react-native-reanimated": "2.3.0-beta.2",
+        "react-native-reanimated": "^2.2.4",
         "react-native-safe-area-context": "^3.2.0",
         "react-native-screens": "^3.3.0",
         "react-native-svg": "^12.1.0",
@@ -14780,15 +14780,13 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "2.3.0-beta.2",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.3.0-beta.2.tgz",
-      "integrity": "sha512-J0cBgOh0O05fNtGgHgrWfKtsYtzcAIhdNju6GVbRo6mVPp1jnuNmNQ2Dd7yXAF54+waj4w4h4pfP9D5J6EixkQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.2.4.tgz",
+      "integrity": "sha512-Nn648MfEEnTCEiWsl1YmfkojiLyV0NMY0EiRdDRbZNfJVfxBuyqhCxI/4Jd7aBi162qpgf8XK2mByYgvF4zLrQ==",
       "dependencies": {
         "@babel/plugin-transform-object-assign": "^7.10.4",
-        "invariant": "^2.2.4",
-        "lodash.isequal": "^4.5.0",
+        "fbjs": "^3.0.0",
         "mockdate": "^3.0.2",
-        "react-native-screens": "^3.4.0",
         "string-hash-64": "^1.0.3"
       },
       "peerDependencies": {
@@ -28729,15 +28727,13 @@
       }
     },
     "react-native-reanimated": {
-      "version": "2.3.0-beta.2",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.3.0-beta.2.tgz",
-      "integrity": "sha512-J0cBgOh0O05fNtGgHgrWfKtsYtzcAIhdNju6GVbRo6mVPp1jnuNmNQ2Dd7yXAF54+waj4w4h4pfP9D5J6EixkQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.2.4.tgz",
+      "integrity": "sha512-Nn648MfEEnTCEiWsl1YmfkojiLyV0NMY0EiRdDRbZNfJVfxBuyqhCxI/4Jd7aBi162qpgf8XK2mByYgvF4zLrQ==",
       "requires": {
         "@babel/plugin-transform-object-assign": "^7.10.4",
-        "invariant": "^2.2.4",
-        "lodash.isequal": "^4.5.0",
+        "fbjs": "^3.0.0",
         "mockdate": "^3.0.2",
-        "react-native-screens": "^3.4.0",
         "string-hash-64": "^1.0.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-native-get-random-values": "^1.7.0",
     "react-native-keychain": "^6.2.0",
     "react-native-qrcode-svg": "^6.0.6",
-    "react-native-reanimated": "2.3.0-beta.2",
+    "react-native-reanimated": "^2.2.4",
     "react-native-safe-area-context": "^3.2.0",
     "react-native-screens": "^3.3.0",
     "react-native-svg": "^12.1.0",


### PR DESCRIPTION
# Summary of Changes

Update react-native-reanimated to 2.2.4.
Using version 2.2.2 or 2.3.0-beta.2 resulted in an error
>Attempt to invoke virtual method 'java.lang.Object java.lang.ref.WeakReference.get()' on a null object reference

as follows:
![Screenshot](https://user-images.githubusercontent.com/1348549/140004628-84ab93cd-28f1-4d6b-a436-5cb2284cfc5e.png)


# Related Issues

N/A

# Pull Request Checklist

This is just a reminder about the most common mistakes. Please make sure that you tick all _appropriate_ boxes. But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this).
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components.
- [x] Run prettier: `npm run style-format`
- [x] Updated **documentation** for changed code and new or modified features.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

