### PR TITLE
Fix PIN create and enter contrast

### DIFF
--- a/App/components/inputs/TextInput.tsx
+++ b/App/components/inputs/TextInput.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
-import { View, Text, StyleSheet, TextInput as TI, TextInputProps } from 'react-native'
+import { View, Text, StyleSheet, TextInput as RNTextInput, TextInputProps } from 'react-native'
 
-import { Colors, borderRadius } from '../../theme'
+import { Colors, TextTheme, borderRadius } from '../../theme'
 
 interface Props extends TextInputProps {
   label: string
@@ -9,18 +9,17 @@ interface Props extends TextInputProps {
 
 const styles = StyleSheet.create({
   container: {
-    width: '90%',
     marginVertical: 10,
   },
   label: {
-    color: Colors.primary,
-    margin: 2,
+    ...TextTheme.label,
+    marginBottom: 3,
   },
   textInput: {
     padding: 10,
     borderRadius,
     fontSize: 16,
-    backgroundColor: Colors.shadow,
+    backgroundColor: Colors.backgroundLight,
     color: Colors.text,
     borderWidth: 2,
     borderColor: 'transparent',
@@ -33,7 +32,7 @@ const TextInput: React.FC<Props> = ({ label, ...textInputProps }) => {
   return (
     <View style={styles.container}>
       <Text style={styles.label}>{label}</Text>
-      <TI
+      <RNTextInput
         style={[styles.textInput, focused && { borderColor: Colors.primary }]}
         selectionColor={Colors.primary}
         onFocus={() => setFocused(true)}

--- a/App/components/inputs/TextInput.tsx
+++ b/App/components/inputs/TextInput.tsx
@@ -19,10 +19,10 @@ const styles = StyleSheet.create({
     padding: 10,
     borderRadius,
     fontSize: 16,
-    backgroundColor: Colors.backgroundLight,
+    backgroundColor: Colors.background,
     color: Colors.text,
     borderWidth: 2,
-    borderColor: 'transparent',
+    borderColor: Colors.transparent,
   },
 })
 

--- a/App/screens/PinCreate.tsx
+++ b/App/screens/PinCreate.tsx
@@ -2,14 +2,14 @@ import React, { useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Alert, Keyboard, StyleSheet } from 'react-native'
 import * as Keychain from 'react-native-keychain'
+import { SafeAreaView } from 'react-native-safe-area-context'
 
 import { Context } from '../store/Store'
 import { DispatchAction } from '../store/reducer'
+import { Colors } from '../theme'
 
 import { Button, TextInput } from 'components'
 import { ButtonType } from 'components/buttons/Button'
-import { SafeAreaView } from 'react-native-safe-area-context'
-import { Colors } from '../theme'
 
 interface PinCreateProps {
   setAuthenticated: React.Dispatch<React.SetStateAction<boolean>>

--- a/App/screens/PinCreate.tsx
+++ b/App/screens/PinCreate.tsx
@@ -61,6 +61,7 @@ const PinCreate: React.FC<PinCreateProps> = ({ setAuthenticated }) => {
       <TextInput
         label={t('Global.EnterPin')}
         placeholder={t('Global.6DigitPin')}
+        placeholderTextColor={Colors.lightGrey}
         accessible={true}
         accessibilityLabel={t('Global.EnterPin')}
         maxLength={6}
@@ -75,6 +76,7 @@ const PinCreate: React.FC<PinCreateProps> = ({ setAuthenticated }) => {
         accessible={true}
         accessibilityLabel={t('PinCreate.ReenterPin')}
         placeholder={t('Global.6DigitPin')}
+        placeholderTextColor={Colors.lightGrey}
         maxLength={6}
         keyboardType="numeric"
         secureTextEntry

--- a/App/screens/PinCreate.tsx
+++ b/App/screens/PinCreate.tsx
@@ -1,16 +1,26 @@
 import React, { useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Alert, Keyboard } from 'react-native'
+import { Alert, Keyboard, StyleSheet } from 'react-native'
 import * as Keychain from 'react-native-keychain'
 
 import { Context } from '../store/Store'
 import { DispatchAction } from '../store/reducer'
 
-import { Button, SafeAreaScrollView, TextInput } from 'components'
+import { Button, TextInput } from 'components'
+import { ButtonType } from 'components/buttons/Button'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { Colors } from '../theme'
 
 interface PinCreateProps {
   setAuthenticated: React.Dispatch<React.SetStateAction<boolean>>
 }
+
+const style = StyleSheet.create({
+  container: {
+    backgroundColor: Colors.background,
+    margin: 20,
+  },
+})
 
 const PinCreate: React.FC<PinCreateProps> = ({ setAuthenticated }) => {
   const [pin, setPin] = useState('')
@@ -47,7 +57,7 @@ const PinCreate: React.FC<PinCreateProps> = ({ setAuthenticated }) => {
   }
 
   return (
-    <SafeAreaScrollView>
+    <SafeAreaView style={[style.container]}>
       <TextInput
         label={t('Global.EnterPin')}
         placeholder={t('Global.6DigitPin')}
@@ -79,12 +89,13 @@ const PinCreate: React.FC<PinCreateProps> = ({ setAuthenticated }) => {
       <Button
         title={t('PinCreate.Create')}
         accessibilityLabel={t('PinCreate.Create')}
+        buttonType={ButtonType.Primary}
         onPress={() => {
           Keyboard.dismiss()
           confirmEntry(pin, pinTwo)
         }}
       />
-    </SafeAreaScrollView>
+    </SafeAreaView>
   )
 }
 

--- a/App/screens/PinEnter.tsx
+++ b/App/screens/PinEnter.tsx
@@ -3,8 +3,9 @@ import { useTranslation } from 'react-i18next'
 import { Alert, Keyboard, SafeAreaView, StyleSheet } from 'react-native'
 import * as Keychain from 'react-native-keychain'
 
-import { TextInput, Button } from 'components'
 import { Colors } from '../theme'
+
+import { TextInput, Button } from 'components'
 
 interface PinEnterProps {
   setAuthenticated: React.Dispatch<React.SetStateAction<boolean>>

--- a/App/screens/PinEnter.tsx
+++ b/App/screens/PinEnter.tsx
@@ -38,6 +38,7 @@ const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated }) => {
         accessible={true}
         accessibilityLabel={t('Global.EnterPin')}
         placeholder={t('Global.6DigitPin')}
+        placeholderTextColor={Colors.lightGrey}
         autoFocus
         maxLength={6}
         keyboardType="numeric"

--- a/App/screens/PinEnter.tsx
+++ b/App/screens/PinEnter.tsx
@@ -1,13 +1,21 @@
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Alert, Keyboard } from 'react-native'
+import { Alert, Keyboard, SafeAreaView, StyleSheet } from 'react-native'
 import * as Keychain from 'react-native-keychain'
 
-import { TextInput, SafeAreaScrollView, Button } from 'components'
+import { TextInput, Button } from 'components'
+import { Colors } from '../theme'
 
 interface PinEnterProps {
   setAuthenticated: React.Dispatch<React.SetStateAction<boolean>>
 }
+
+const style = StyleSheet.create({
+  container: {
+    backgroundColor: Colors.background,
+    margin: 20,
+  },
+})
 
 const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated }) => {
   const [pin, setPin] = useState('')
@@ -23,7 +31,7 @@ const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated }) => {
   }
 
   return (
-    <SafeAreaScrollView>
+    <SafeAreaView style={[style.container]}>
       <TextInput
         label={t('Global.EnterPin')}
         accessible={true}
@@ -49,7 +57,7 @@ const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated }) => {
           checkPin(pin)
         }}
       />
-    </SafeAreaScrollView>
+    </SafeAreaView>
   )
 }
 

--- a/App/theme.ts
+++ b/App/theme.ts
@@ -9,6 +9,8 @@ export const borderRadius = 4
 export const BaseColors: BaseColor = {
   black: '#000000',
   darkGrey: '#1C1C1E',
+  lightGrey: '#D3D3D3',
+  lightGreyAlt: '#F2F2F2',
   green: '#2D6E35',
   red: '#DE3333',
   white: '#FFFFFF',


### PR DESCRIPTION
# Summary of Changes

Because of the original two color pallet it was hard to change the theme and not run into contrast issues with the PIN entry screens. This change just better uses the updated pallet for a more uniform look and allows for more options when changing the color pallet.

I didn't change too much in the way of theme because these screens will be redone as Ontario comes up with a new and better way to use biometrics with a PIN override if not available.

![IMG_5780](https://user-images.githubusercontent.com/390891/151063931-382b3d8c-69cf-4a5b-a681-4171f12dd132.PNG)



# Related Issues

n/a

# Pull Request Checklist

This is just a reminder about the most common mistakes. Please make sure that you tick all _appropriate_ boxes. But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this).
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components.
- [x] Run prettier: `npm run style-format`
- [x] Updated **documentation** for changed code and new or modified features.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

_PR template adapted from the Python attrs project._
