### PR TITLE
Activate get started button in on-boarding carousel

### DIFF
--- a/App/components/buttons/Button.tsx
+++ b/App/components/buttons/Button.tsx
@@ -10,16 +10,14 @@ export enum ButtonType {
 
 interface ButtonProps {
   title: string
+  buttonType: ButtonType
   accessibilityLabel?: string
   onPress?: () => void
   disabled?: boolean
-  buttonType?: ButtonType
 }
 
-const Button: React.FC<ButtonProps> = ({ title, accessibilityLabel, onPress, disabled = false, buttonType }) => {
+const Button: React.FC<ButtonProps> = ({ title, buttonType, accessibilityLabel, onPress, disabled = false }) => {
   const accessible = accessibilityLabel && accessibilityLabel !== '' ? true : false
-  // Keep this until entire app using ENUM to style.
-  const myButtonType = buttonType ? buttonType : ButtonType.Primary
 
   return (
     <TouchableOpacity
@@ -27,17 +25,16 @@ const Button: React.FC<ButtonProps> = ({ title, accessibilityLabel, onPress, dis
       accessible={accessible}
       accessibilityLabel={accessibilityLabel}
       style={[
-        myButtonType === ButtonType.Primary ? Buttons.primary : Buttons.secondary,
-        disabled && (myButtonType === ButtonType.Primary ? Buttons.primaryDisabled : Buttons.secondaryDisabled),
+        buttonType === ButtonType.Primary ? Buttons.primary : Buttons.secondary,
+        disabled && (buttonType === ButtonType.Primary ? Buttons.primaryDisabled : Buttons.secondaryDisabled),
       ]}
       disabled={disabled}
       activeOpacity={heavyOpacity}
     >
       <Text
         style={[
-          myButtonType === ButtonType.Primary ? Buttons.primaryText : Buttons.secondaryText,
-          disabled &&
-            (myButtonType === ButtonType.Primary ? Buttons.primaryTextDisabled : Buttons.secondaryTextDisabled),
+          buttonType === ButtonType.Primary ? Buttons.primaryText : Buttons.secondaryText,
+          disabled && (buttonType === ButtonType.Primary ? Buttons.primaryTextDisabled : Buttons.secondaryTextDisabled),
         ]}
       >
         {title}

--- a/App/components/buttons/Button.tsx
+++ b/App/components/buttons/Button.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { Text, StyleSheet, TouchableOpacity } from 'react-native'
+import { Text, TouchableOpacity } from 'react-native'
 
-import { Colors, Buttons, heavyOpacity } from '../../theme'
+import { Buttons, heavyOpacity } from '../../theme'
 
 export enum ButtonType {
   Primary,
@@ -13,34 +13,10 @@ interface ButtonProps {
   accessibilityLabel?: string
   onPress?: () => void
   disabled?: boolean
-  neutral?: true
-  negative?: true
   buttonType?: ButtonType
 }
 
-//TODO:(jl) I think these styles should go into the button and
-//be used as an ENUM to select the look of the button.
-const styles = StyleSheet.create({
-  disabled: {
-    backgroundColor: Colors.shadow,
-  },
-  neutral: {
-    backgroundColor: Colors.text,
-  },
-  negative: {
-    backgroundColor: 'red',
-  },
-})
-
-const Button: React.FC<ButtonProps> = ({
-  title,
-  accessibilityLabel,
-  onPress,
-  disabled = false,
-  neutral = false,
-  negative = false,
-  buttonType,
-}) => {
+const Button: React.FC<ButtonProps> = ({ title, accessibilityLabel, onPress, disabled = false, buttonType }) => {
   const accessible = accessibilityLabel && accessibilityLabel !== '' ? true : false
   // Keep this until entire app using ENUM to style.
   const myButtonType = buttonType ? buttonType : ButtonType.Primary
@@ -53,8 +29,6 @@ const Button: React.FC<ButtonProps> = ({
       style={[
         myButtonType === ButtonType.Primary ? Buttons.primary : Buttons.secondary,
         disabled && (myButtonType === ButtonType.Primary ? Buttons.primaryDisabled : Buttons.secondaryDisabled),
-        neutral && styles.neutral,
-        negative && styles.negative,
       ]}
       disabled={disabled}
       activeOpacity={heavyOpacity}
@@ -64,7 +38,6 @@ const Button: React.FC<ButtonProps> = ({
           myButtonType === ButtonType.Primary ? Buttons.primaryText : Buttons.secondaryText,
           disabled &&
             (myButtonType === ButtonType.Primary ? Buttons.primaryTextDisabled : Buttons.secondaryTextDisabled),
-          neutral && { color: Colors.shadow },
         ]}
       >
         {title}

--- a/App/components/texts/InfoTextBox.tsx
+++ b/App/components/texts/InfoTextBox.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { StyleSheet, Text, View } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
-import { Colors, TextTheme } from '../../theme'
+import { TextBoxTheme, TextTheme } from '../../theme'
 
 export interface TextBoxProps {
   children: string
@@ -14,10 +14,10 @@ const offset = 10
 const style = StyleSheet.create({
   container: {
     flexDirection: 'row',
-    backgroundColor: Colors.backgroundLight,
+    backgroundColor: TextBoxTheme.background,
     borderRadius: 5,
     borderWidth: 1,
-    borderColor: Colors.borderLight,
+    borderColor: TextBoxTheme.border,
     padding: 10,
   },
   headerText: {
@@ -33,7 +33,7 @@ const InfoTextBox: React.FC<TextBoxProps> = ({ children }) => {
   return (
     <View style={[style.container]}>
       <View style={[style.icon]}>
-        <Icon name={'info'} size={iconSize} color={Colors.textColor} />
+        <Icon name={'info'} size={iconSize} color={TextBoxTheme.text} />
       </View>
       <Text
         style={[

--- a/App/navigators/RootStack.tsx
+++ b/App/navigators/RootStack.tsx
@@ -19,8 +19,7 @@ import ScanStack from './ScanStack'
 import TabStack from './TabStack'
 import defaultStackOptions from './defaultStackOptions'
 
-type GenericFn = () => void
-type StateFn = React.Dispatch<React.SetStateAction<boolean>>
+import { GenericFn, StateFn } from 'types/fn'
 
 const authStack = (setAuthenticated: StateFn) => {
   const Stack = createStackNavigator()
@@ -63,6 +62,7 @@ const onboardingStack = (onSkipTouched: GenericFn, setAuthenticated: StateFn) =>
           headerLeft: () => false,
           headerRight: () => {
             return (
+              // TODO:(jl) Create new type of button component
               <TouchableOpacity onPress={onSkipTouched} style={{ marginRight: 14 }}>
                 <View style={{ flexDirection: 'row', alignItems: 'center' }}>
                   <Text style={{ color: Colors.white, fontWeight: 'bold', marginRight: 4 }}>Skip</Text>
@@ -74,7 +74,13 @@ const onboardingStack = (onSkipTouched: GenericFn, setAuthenticated: StateFn) =>
         })}
       >
         {(props) => (
-          <Onboarding {...props} nextButtonText={'Next'} previousButtonText={'Back'} pages={pages} style={carousel} />
+          <Onboarding
+            {...props}
+            nextButtonText={'Next'}
+            previousButtonText={'Back'}
+            pages={pages(onSkipTouched)}
+            style={carousel}
+          />
         )}
       </Stack.Screen>
       <Stack.Screen

--- a/App/screens/OnboardingPages.tsx
+++ b/App/screens/OnboardingPages.tsx
@@ -1,14 +1,17 @@
 import React from 'react'
-import { StyleSheet, Text, TouchableHighlight, View } from 'react-native'
+import { StyleSheet, Text, View } from 'react-native'
 import { SvgProps } from 'react-native-svg'
-import Toast from 'react-native-toast-message'
 
 import CredentialList from '../assets/img/credential-list.svg'
 import ScanShare from '../assets/img/scan-share.svg'
 import SecureImage from '../assets/img/secure-image.svg'
-import { Colors, Buttons } from '../theme'
+import { Colors } from '../theme'
 
 import { OnboardingStyleSheet } from './Onboarding'
+
+import { Button } from 'components'
+import { ButtonType } from 'components/buttons/Button'
+import { GenericFn } from 'types/fn'
 
 const imageDisplayOptions = {
   fill: Colors.text,
@@ -72,39 +75,30 @@ const defaultStyle = StyleSheet.create({
   },
 })
 
-const getStartedTouched = async () => {
-  Toast.show({
-    type: 'success',
-    text1: 'Not Implemented',
-  })
+const customPages = (onTutorialCompleted: GenericFn) => {
+  return (
+    <>
+      <View style={{ alignItems: 'center' }}>
+        <SecureImage {...imageDisplayOptions} />
+      </View>
+      <View style={{ marginLeft: 20, marginRight: 20, marginTop: 30 }}>
+        <Text style={[defaultStyle.headerText, { fontSize: 18 }]}>Ornare suspendisse sed nisi lacus</Text>
+        <Text style={[defaultStyle.bodyText, { marginTop: 20 }]}>
+          Enim facilisis gravida neque convallis a cras semper. Suscipit adipiscing bibendum est ultricies integer quis
+          auctor elit sed.
+        </Text>
+      </View>
+      <View style={{ marginTop: 'auto', marginBottom: 20, paddingHorizontal: 20 }}>
+        <Button
+          title={'Get Started!'}
+          accessibilityLabel={'Get Started'}
+          onPress={onTutorialCompleted}
+          buttonType={ButtonType.Primary}
+        />
+      </View>
+    </>
+  )
 }
-
-const CustomPageElement = (
-  <>
-    <View style={{ alignItems: 'center' }}>
-      <SecureImage {...imageDisplayOptions} />
-    </View>
-    <View style={{ marginLeft: 20, marginRight: 20, marginTop: 30 }}>
-      <Text style={[defaultStyle.headerText, { fontSize: 18 }]}>Ornare suspendisse sed nisi lacus</Text>
-      <Text style={[defaultStyle.bodyText, { marginTop: 20 }]}>
-        Enim facilisis gravida neque convallis a cras semper. Suscipit adipiscing bibendum est ultricies integer quis
-        auctor elit sed.
-      </Text>
-    </View>
-    <View style={{ marginTop: 'auto', marginBottom: 20 }}>
-      <TouchableHighlight
-        testID={'dismissButton'}
-        accessible={true}
-        accessibilityLabel={'Get Started'}
-        style={[Buttons.primary, { marginLeft: 20, marginRight: 20 }]}
-        underlayColor={Colors.primaryActive}
-        onPress={getStartedTouched}
-      >
-        <Text style={Buttons.primaryText}>Get Started!</Text>
-      </TouchableHighlight>
-    </View>
-  </>
-)
 
 const guides: Array<{ image: React.FC<SvgProps>; title: string; body: string }> = [
   {
@@ -131,4 +125,6 @@ const createPageWith = (image: React.FC<SvgProps>, title: string, body: string) 
   )
 }
 
-export const pages: Array<Element> = [...guides.map((g) => createPageWith(g.image, g.title, g.body)), CustomPageElement]
+export const pages = (onTutorialCompleted: GenericFn): Array<Element> => {
+  return [...guides.map((g) => createPageWith(g.image, g.title, g.body)), customPages(onTutorialCompleted)]
+}

--- a/App/screens/PinEnter.tsx
+++ b/App/screens/PinEnter.tsx
@@ -6,6 +6,7 @@ import * as Keychain from 'react-native-keychain'
 import { Colors } from '../theme'
 
 import { TextInput, Button } from 'components'
+import { ButtonType } from 'components/buttons/Button'
 
 interface PinEnterProps {
   setAuthenticated: React.Dispatch<React.SetStateAction<boolean>>
@@ -53,6 +54,7 @@ const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated }) => {
       />
       <Button
         title={t('Global.Submit')}
+        buttonType={ButtonType.Primary}
         accessibilityLabel={t('Global.Submit')}
         onPress={() => {
           Keyboard.dismiss()

--- a/App/theme.ts
+++ b/App/theme.ts
@@ -91,6 +91,12 @@ interface SingleSelectBlockTheme {
   background: string
 }
 
+interface TextBoxTheme {
+  background: string
+  border: string
+  text: string
+}
+
 export const Colors: ColorTheme = {
   accent: BaseColors.yellow,
   background: BaseColors.black,
@@ -130,6 +136,12 @@ export const SettingsTheme: SettingsTheme = {
 
 export const SingleSelectBlockTheme: SingleSelectBlockTheme = {
   background: Colors.shadow,
+}
+
+export const TextBoxTheme: TextBoxTheme = {
+  background: Colors.darkGreenLightTransparent,
+  border: Colors.borderLight,
+  text: Colors.text,
 }
 
 export const TextTheme: TextTheme = {

--- a/App/types/fn.ts
+++ b/App/types/fn.ts
@@ -1,0 +1,2 @@
+export type GenericFn = () => void
+export type StateFn = React.Dispatch<React.SetStateAction<boolean>>

--- a/__tests__/components/Button.test.tsx
+++ b/__tests__/components/Button.test.tsx
@@ -3,8 +3,6 @@ import renderer from 'react-test-renderer'
 
 import Button, { ButtonType } from '../../App/components/buttons/Button'
 
-// jest.mock('react-native-vector-icons/MaterialIcons', () => 'Icon')
-
 describe('Button Component', () => {
   it('Primary renders correctly', () => {
     const tree = renderer

--- a/__tests__/components/Button.test.tsx
+++ b/__tests__/components/Button.test.tsx
@@ -1,41 +1,35 @@
 import React from 'react'
-import renderer from 'react-test-renderer'
+import { create } from 'react-test-renderer'
 
 import Button, { ButtonType } from '../../App/components/buttons/Button'
 
 describe('Button Component', () => {
   it('Primary renders correctly', () => {
-    const tree = renderer
-      // @ts-ignore
-      .create(
-        <Button
-          title={'Hello Primary'}
-          accessibilityLabel={'primary'}
-          onPress={() => {
-            return
-          }}
-          buttonType={ButtonType.Primary}
-        />
-      )
-      .toJSON()
+    const tree = create(
+      <Button
+        title={'Hello Primary'}
+        accessibilityLabel={'primary'}
+        onPress={() => {
+          return
+        }}
+        buttonType={ButtonType.Primary}
+      />
+    ).toJSON()
 
     expect(tree).toMatchSnapshot()
   })
 
   it('Secondary renders correctly', () => {
-    const tree = renderer
-      // @ts-ignore
-      .create(
-        <Button
-          title={'Hello Secondary'}
-          accessibilityLabel={'secondary'}
-          onPress={() => {
-            return
-          }}
-          buttonType={ButtonType.Secondary}
-        />
-      )
-      .toJSON()
+    const tree = create(
+      <Button
+        title={'Hello Secondary'}
+        accessibilityLabel={'secondary'}
+        onPress={() => {
+          return
+        }}
+        buttonType={ButtonType.Secondary}
+      />
+    ).toJSON()
 
     expect(tree).toMatchSnapshot()
   })

--- a/__tests__/components/Button.test.tsx
+++ b/__tests__/components/Button.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+
+import Button, { ButtonType } from '../../App/components/buttons/Button'
+
+// jest.mock('react-native-vector-icons/MaterialIcons', () => 'Icon')
+
+describe('Button Component', () => {
+  it('Primary renders correctly', () => {
+    const tree = renderer
+      // @ts-ignore
+      .create(
+        <Button
+          title={'Hello Primary'}
+          accessibilityLabel={'primary'}
+          onPress={() => {
+            return
+          }}
+          buttonType={ButtonType.Primary}
+        />
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('Secondary renders correctly', () => {
+    const tree = renderer
+      // @ts-ignore
+      .create(
+        <Button
+          title={'Hello Secondary'}
+          accessibilityLabel={'secondary'}
+          onPress={() => {
+            return
+          }}
+          buttonType={ButtonType.Secondary}
+        />
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/__tests__/components/CheckBoxRow.test.tsx
+++ b/__tests__/components/CheckBoxRow.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import renderer from 'react-test-renderer'
+import { create } from 'react-test-renderer'
 
 import CheckBoxRow from '../../App/components/inputs/CheckBoxRow'
 
@@ -7,11 +7,10 @@ jest.mock('react-native-vector-icons/MaterialIcons', () => 'Icon')
 
 describe('CheckBoxRow Component', () => {
   it('Renders correctly', () => {
-    const tree = renderer
-      // @ts-ignore
+    const tree = create(
       // eslint-disable-next-line
-      .create(<CheckBoxRow title={'Hello Fried'} accessibilityLabel={'Hey'} checked={true} onPress={() => {}} />)
-      .toJSON()
+      <CheckBoxRow title={'Hello Fried'} accessibilityLabel={'Hey'} checked={true} onPress={() => {}} />
+    ).toJSON()
 
     expect(tree).toMatchSnapshot()
   })

--- a/__tests__/components/HighlightTextBox.test.tsx
+++ b/__tests__/components/HighlightTextBox.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import renderer from 'react-test-renderer'
+import { create } from 'react-test-renderer'
 
 import HighlightTextBox from '../../App/components/texts/HighlightTextBox'
 
@@ -7,10 +7,7 @@ jest.mock('react-native-vector-icons/MaterialIcons', () => 'Icon')
 
 describe('InfoTextBox Component', () => {
   it('Renders correctly', () => {
-    const tree = renderer
-      // @ts-ignore
-      .create(<HighlightTextBox text="Hello World" />)
-      .toJSON()
+    const tree = create(<HighlightTextBox>Hello World</HighlightTextBox>).toJSON()
 
     expect(tree).toMatchSnapshot()
   })

--- a/__tests__/components/InfoTextBox.test.tsx
+++ b/__tests__/components/InfoTextBox.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import renderer from 'react-test-renderer'
+import { create } from 'react-test-renderer'
 
 import InfoTextBox from '../../App/components/texts/InfoTextBox'
 
@@ -7,10 +7,7 @@ jest.mock('react-native-vector-icons/MaterialIcons', () => 'Icon')
 
 describe('InfoTextBox Component', () => {
   it('Renders correctly', () => {
-    const tree = renderer
-      // @ts-ignore
-      .create(<InfoTextBox text="Hello World" />)
-      .toJSON()
+    const tree = create(<InfoTextBox>Hello World</InfoTextBox>).toJSON()
 
     expect(tree).toMatchSnapshot()
   })

--- a/__tests__/components/__snapshots__/Button.test.tsx.snap
+++ b/__tests__/components/__snapshots__/Button.test.tsx.snap
@@ -1,0 +1,95 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Button Component Primary renders correctly 1`] = `
+<View
+  accessibilityLabel="primary"
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  nativeID="animatedComponent"
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "backgroundColor": "#35823F",
+      "borderRadius": 4,
+      "opacity": 1,
+      "padding": 16,
+    }
+  }
+>
+  <Text
+    style={
+      Array [
+        Object {
+          "color": "#FFFFFF",
+          "fontSize": 18,
+          "fontWeight": "bold",
+          "textAlign": "center",
+        },
+        false,
+      ]
+    }
+  >
+    Hello Primary
+  </Text>
+</View>
+`;
+
+exports[`Button Component Secondary renders correctly 1`] = `
+<View
+  accessibilityLabel="secondary"
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  nativeID="animatedComponent"
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "backgroundColor": "#FFFFFF",
+      "borderColor": "#35823F",
+      "borderRadius": 4,
+      "borderWidth": 2,
+      "opacity": 1,
+      "padding": 16,
+    }
+  }
+>
+  <Text
+    style={
+      Array [
+        Object {
+          "color": "#35823F",
+          "fontSize": 18,
+          "fontWeight": "bold",
+          "textAlign": "center",
+        },
+        false,
+      ]
+    }
+  >
+    Hello Secondary
+  </Text>
+</View>
+`;

--- a/__tests__/components/__snapshots__/HighlightTextBox.test.tsx.snap
+++ b/__tests__/components/__snapshots__/HighlightTextBox.test.tsx.snap
@@ -37,6 +37,8 @@ exports[`InfoTextBox Component Renders correctly 1`] = `
         },
       ]
     }
-  />
+  >
+    Hello World
+  </Text>
 </View>
 `;

--- a/__tests__/components/__snapshots__/InfoTextBox.test.tsx.snap
+++ b/__tests__/components/__snapshots__/InfoTextBox.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`InfoTextBox Component Renders correctly 1`] = `
   style={
     Array [
       Object {
-        "backgroundColor": undefined,
+        "backgroundColor": "rgba(53, 130, 63, 0.7)",
         "borderColor": undefined,
         "borderRadius": 5,
         "borderWidth": 1,
@@ -25,6 +25,7 @@ exports[`InfoTextBox Component Renders correctly 1`] = `
     }
   >
     <Icon
+      color="#FFFFFF"
       name="info"
       size={30}
     />
@@ -43,6 +44,8 @@ exports[`InfoTextBox Component Renders correctly 1`] = `
         },
       ]
     }
-  />
+  >
+    Hello World
+  </Text>
 </View>
 `;

--- a/__tests__/screens/CredentialOffer.test.tsx
+++ b/__tests__/screens/CredentialOffer.test.tsx
@@ -8,13 +8,16 @@ import Button from 'components/buttons/Button'
 import NotificationModal from 'components/modals/NotificationModal'
 
 const mockT = jest.fn((key: string) => key)
+const mockNavigate = jest.fn()
+const mockGoBack = jest.fn()
+const mockPop = jest.fn()
+
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: mockT }),
 }))
 
-const mockNavigate = jest.fn()
-const mockGoBack = jest.fn()
-const mockPop = jest.fn()
+jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper')
+
 jest.mock('@react-navigation/core', () => {
   const module = jest.requireActual('@react-navigation/core')
   return {


### PR DESCRIPTION
# Summary of Changes

- Enable the on-boaridng "Get Started" button to complete the tutorial screens;
- Add tests for Button component;
- Remove dead props for Button component (cleanup);
- Debug and fix warning (__Animated: `useNativeDriver` is not supported__) with test run. 
- Cleaned up ambiguity with `create` in some tests

# Related Issues

Please reference here any issue #'s that are relevant to this PR, or simply enter "N/A" if this PR does not relate to any existing issues.

# Pull Request Checklist

This is just a reminder about the most common mistakes. Please make sure that you tick all _appropriate_ boxes. But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this).
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components.
- [x] Run prettier: `npm run style-format`
- [x] Updated **documentation** for changed code and new or modified features.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

_PR template adapted from the Python attrs project._
