### PR TITLE
Hide skip button on last page of on-boarding tutorial

### DIFF
--- a/App/components/buttons/HeaderRight.tsx
+++ b/App/components/buttons/HeaderRight.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { Text, TouchableOpacity, View } from 'react-native'
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 
 import Arrow from '../../assets/icons/large-arrow.svg'
-import { Colors } from '../../theme'
+import { ColorPallet, Colors, TextTheme } from '../../theme'
 
 interface HeaderButtonProps {
   title: string
@@ -11,17 +11,39 @@ interface HeaderButtonProps {
   disabled?: boolean
 }
 
+const style = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  touchableArea: {
+    marginRight: 14,
+  },
+  title: {
+    ...TextTheme.label,
+    marginRight: 4,
+  },
+  icon: {
+    transform: [{ rotate: '180deg' }],
+  },
+})
+
 const HeaderRight: React.FC<HeaderButtonProps> = ({ title, accessibilityLabel, onPress, disabled = false }) => {
   return (
     <TouchableOpacity
       accessibilityLabel={accessibilityLabel}
       onPress={onPress}
-      style={{ marginRight: 14 }}
+      style={[style.touchableArea]}
       disabled={disabled}
     >
-      <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-        <Text style={{ color: Colors.white, fontWeight: 'bold', marginRight: 4 }}>{title}</Text>
-        <Arrow height={15} width={15} fill={Colors.white} style={{ transform: [{ rotate: '180deg' }] }} />
+      <View style={style.container}>
+        <Text style={[style.title]}>{title}</Text>
+        <Arrow
+          height={TextTheme.label.fontSize}
+          width={TextTheme.label.fontSize}
+          fill={TextTheme.label.color}
+          style={[style.icon]}
+        />
       </View>
     </TouchableOpacity>
   )

--- a/App/components/buttons/HeaderRight.tsx
+++ b/App/components/buttons/HeaderRight.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 
 import Arrow from '../../assets/icons/large-arrow.svg'
-import { ColorPallet, Colors, TextTheme } from '../../theme'
+import { TextTheme } from '../../theme'
 
 interface HeaderButtonProps {
   title: string

--- a/App/components/buttons/HeaderRight.tsx
+++ b/App/components/buttons/HeaderRight.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Text, TouchableOpacity, View } from 'react-native'
+
+import Arrow from '../../assets/icons/large-arrow.svg'
+import { Colors } from '../../theme'
+
+interface HeaderButtonProps {
+  title: string
+  accessibilityLabel?: string
+  onPress?: () => void
+  disabled?: boolean
+}
+
+const HeaderRight: React.FC<HeaderButtonProps> = ({ title, accessibilityLabel, onPress, disabled = false }) => {
+  return (
+    <TouchableOpacity
+      accessibilityLabel={accessibilityLabel}
+      onPress={onPress}
+      style={{ marginRight: 14 }}
+      disabled={disabled}
+    >
+      <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+        <Text style={{ color: Colors.white, fontWeight: 'bold', marginRight: 4 }}>{title}</Text>
+        <Arrow height={15} width={15} fill={Colors.white} style={{ transform: [{ rotate: '180deg' }] }} />
+      </View>
+    </TouchableOpacity>
+  )
+}
+
+export default HeaderRight

--- a/App/localization/en/index.ts
+++ b/App/localization/en/index.ts
@@ -155,6 +155,10 @@ const translation = {
     "Hide": "Hide",
     "Show": "Show",
     "HideAll": "Hide all"
+  },
+  "Screens": {
+    "Onboarding": "Onboarding",
+    "Terms": "Terms & Conditions"
   }
 }
 export default translation

--- a/App/navigators/RootStack.tsx
+++ b/App/navigators/RootStack.tsx
@@ -14,6 +14,7 @@ import Terms from '../screens/Terms'
 import { Context } from '../store/Store'
 import { DispatchAction } from '../store/reducer'
 import { Colors } from '../theme'
+import { GenericFn, StateFn } from '../types/fn'
 import { AuthenticateStackParams, Screens, Stacks } from '../types/navigators'
 
 import ConnectStack from './ConnectStack'
@@ -21,8 +22,6 @@ import ContactStack from './ContactStack'
 import SettingStack from './SettingStack'
 import TabStack from './TabStack'
 import defaultStackOptions from './defaultStackOptions'
-
-import { GenericFn, StateFn } from 'types/fn'
 
 const RootStack: React.FC = () => {
   const [authenticated, setAuthenticated] = useState(false)
@@ -64,7 +63,7 @@ const RootStack: React.FC = () => {
         <Stack.Screen
           name={Screens.Onboarding}
           options={() => ({
-            title: 'Onboarding',
+            title: t('Screens.Onboarding'),
             headerTintColor: Colors.white,
             headerShown: true,
             gestureEnabled: false,
@@ -99,7 +98,7 @@ const RootStack: React.FC = () => {
         <Stack.Screen
           name={Screens.Terms}
           options={() => ({
-            title: 'Terms & Conditions',
+            title: t('Screens.Terms'),
             headerTintColor: Colors.white,
             headerShown: true,
             headerLeft: () => false,

--- a/App/navigators/RootStack.tsx
+++ b/App/navigators/RootStack.tsx
@@ -2,9 +2,7 @@ import { useNavigation } from '@react-navigation/core'
 import { createStackNavigator, StackNavigationProp } from '@react-navigation/stack'
 import React, { useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Text, TouchableOpacity, View } from 'react-native'
 
-import Arrow from '../assets/icons/large-arrow.svg'
 import Onboarding from '../screens/Onboarding'
 import { pages, carousel } from '../screens/OnboardingPages'
 import PinCreate from '../screens/PinCreate'
@@ -14,7 +12,7 @@ import Terms from '../screens/Terms'
 import { Context } from '../store/Store'
 import { DispatchAction } from '../store/reducer'
 import { Colors } from '../theme'
-import { GenericFn, StateFn } from '../types/fn'
+import { StateFn } from '../types/fn'
 import { AuthenticateStackParams, Screens, Stacks } from '../types/navigators'
 
 import ConnectStack from './ConnectStack'
@@ -26,8 +24,17 @@ import defaultStackOptions from './defaultStackOptions'
 const RootStack: React.FC = () => {
   const [authenticated, setAuthenticated] = useState(false)
   const [state, dispatch] = useContext(Context)
-  const navigation = useNavigation<StackNavigationProp<AuthenticateStackParams>>()
   const { t } = useTranslation()
+  const navigation = useNavigation<StackNavigationProp<AuthenticateStackParams>>()
+
+  const onTutorialCompleted = () => {
+    dispatch({
+      type: DispatchAction.SetTutorialCompletionStatus,
+      payload: [{ DidCompleteTutorial: true }],
+    })
+
+    navigation.navigate(Screens.Terms)
+  }
 
   const authStack = (setAuthenticated: StateFn) => {
     const Stack = createStackNavigator()
@@ -54,7 +61,7 @@ const RootStack: React.FC = () => {
     )
   }
 
-  const onboardingStack = (onSkipTouched: GenericFn, setAuthenticated: StateFn) => {
+  const onboardingStack = (setAuthenticated: StateFn) => {
     const Stack = createStackNavigator()
 
     return (
@@ -68,21 +75,6 @@ const RootStack: React.FC = () => {
             headerShown: true,
             gestureEnabled: false,
             headerLeft: () => false,
-            headerRight: () => {
-              return (
-                // TODO:(jl) Create new type of button component
-                <TouchableOpacity
-                  accessibilityLabel={t('Global.Skip')}
-                  onPress={onSkipTouched}
-                  style={{ marginRight: 14 }}
-                >
-                  <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-                    <Text style={{ color: Colors.white, fontWeight: 'bold', marginRight: 4 }}>Skip</Text>
-                    <Arrow height={15} width={15} fill={Colors.white} style={{ transform: [{ rotate: '180deg' }] }} />
-                  </View>
-                </TouchableOpacity>
-              )
-            },
           })}
         >
           {(props) => (
@@ -90,7 +82,7 @@ const RootStack: React.FC = () => {
               {...props}
               nextButtonText={'Next'}
               previousButtonText={'Back'}
-              pages={pages(onSkipTouched)}
+              pages={pages(onTutorialCompleted)}
               style={carousel}
             />
           )}
@@ -113,20 +105,11 @@ const RootStack: React.FC = () => {
     )
   }
 
-  const onSkipTouched = () => {
-    dispatch({
-      type: DispatchAction.SetTutorialCompletionStatus,
-      payload: [{ DidCompleteTutorial: true }],
-    })
-
-    navigation.navigate(Screens.Terms)
-  }
-
   if (state.onboarding.DidAgreeToTerms && state.onboarding.DidCompleteTutorial && state.onboarding.DidCreatePIN) {
     return authenticated ? mainStack() : authStack(setAuthenticated)
   }
 
-  return onboardingStack(onSkipTouched, setAuthenticated)
+  return onboardingStack(setAuthenticated)
 }
 
 export default RootStack

--- a/App/screens/Onboarding.tsx
+++ b/App/screens/Onboarding.tsx
@@ -1,4 +1,5 @@
-import { useFocusEffect, useNavigation } from '@react-navigation/native'
+import { useNavigation } from '@react-navigation/core'
+import { useFocusEffect } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React, { Ref, useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'

--- a/__mocks__/@react-navigation/core.ts
+++ b/__mocks__/@react-navigation/core.ts
@@ -2,6 +2,7 @@ const navigation = {
   navigate: jest.fn(),
   goBack: jest.fn(),
   pop: jest.fn(),
+  setOptions: jest.fn(),
 }
 
 const useNavigation = () => {

--- a/__tests__/components/HeaderRight.test.tsx
+++ b/__tests__/components/HeaderRight.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react-native'
+import React from 'react'
+
+import HeaderRight from '../../App/components/buttons/HeaderRight'
+
+describe('Header Right Button Component', () => {
+  test('Renders correctly', () => {
+    const tree = render(
+      <HeaderRight
+        title={'Hello Header'}
+        accessibilityLabel={'Hello'}
+        onPress={() => {
+          return
+        }}
+      />
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/__tests__/components/__snapshots__/HeaderRight.test.tsx.snap
+++ b/__tests__/components/__snapshots__/HeaderRight.test.tsx.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Header Right Button Component Renders correctly 1`] = `
+<View
+  accessibilityLabel="Hello"
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  nativeID="animatedComponent"
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "marginRight": 14,
+      "opacity": 1,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+      }
+    }
+  >
+    <Text
+      style={
+        Object {
+          "color": "#FFFFFF",
+          "fontWeight": "bold",
+          "marginRight": 4,
+        }
+      }
+    >
+      Hello Header
+    </Text>
+    <
+      fill="#FFFFFF"
+      height={15}
+      style={
+        Object {
+          "transform": Array [
+            Object {
+              "rotate": "180deg",
+            },
+          ],
+        }
+      }
+      width={15}
+    />
+  </View>
+</View>
+`;

--- a/__tests__/components/__snapshots__/HeaderRight.test.tsx.snap
+++ b/__tests__/components/__snapshots__/HeaderRight.test.tsx.snap
@@ -36,28 +36,33 @@ exports[`Header Right Button Component Renders correctly 1`] = `
   >
     <Text
       style={
-        Object {
-          "color": "#FFFFFF",
-          "fontWeight": "bold",
-          "marginRight": 4,
-        }
+        Array [
+          Object {
+            "color": "#FFFFFF",
+            "fontSize": 14,
+            "fontWeight": "bold",
+            "marginRight": 4,
+          },
+        ]
       }
     >
       Hello Header
     </Text>
     <
       fill="#FFFFFF"
-      height={15}
+      height={14}
       style={
-        Object {
-          "transform": Array [
-            Object {
-              "rotate": "180deg",
-            },
-          ],
-        }
+        Array [
+          Object {
+            "transform": Array [
+              Object {
+                "rotate": "180deg",
+              },
+            ],
+          },
+        ]
       }
-      width={15}
+      width={14}
     />
   </View>
 </View>

--- a/__tests__/screens/Onboarding.test.tsx
+++ b/__tests__/screens/Onboarding.test.tsx
@@ -1,11 +1,9 @@
+import { render } from '@testing-library/react-native'
 import React from 'react'
 import { StyleSheet, Text } from 'react-native'
-import { create } from 'react-test-renderer'
 
 import Onboarding, { OnboardingStyleSheet } from '../../App/screens/Onboarding'
 import { Colors } from '../../App/theme'
-
-const markTutorialFin = jest.fn()
 
 export const carousel: OnboardingStyleSheet = StyleSheet.create({
   container: {
@@ -49,7 +47,7 @@ const pages = [
 
 describe('Onboarding', () => {
   it('Renders correctly', () => {
-    const tree = create(<Onboarding pages={pages} onOnboardingDismissed={markTutorialFin} style={carousel} />).toJSON()
+    const tree = render(<Onboarding pages={pages} nextButtonText="Next" previousButtonText="Back" style={carousel} />)
 
     expect(tree).toMatchSnapshot()
   })
@@ -62,9 +60,11 @@ describe('Onboarding', () => {
   //   expect(markTutorialFin).toBeCalledTimes(1)
   // })
 
-  it('Pages exist', () => {
-    const tree = create(<Onboarding pages={pages} onOnboardingDismissed={markTutorialFin} style={carousel} />)
-    const foundPages = tree.root!.findAllByType(Text).filter((e: any) => e.props.testID === 'bodyText')
+  it('Pages exist', async () => {
+    const { findAllByTestId } = render(
+      <Onboarding pages={pages} nextButtonText="Next" previousButtonText="Back" style={carousel} />
+    )
+    const foundPages = await findAllByTestId('bodyText')
 
     expect(foundPages.length).toBe(2)
   })

--- a/__tests__/screens/__snapshots__/Onboarding.test.tsx.snap
+++ b/__tests__/screens/__snapshots__/Onboarding.test.tsx.snap
@@ -178,7 +178,9 @@ exports[`Onboarding Renders correctly 1`] = `
             },
           ]
         }
-      />
+      >
+        Back
+      </Text>
     </View>
     <View
       style={
@@ -275,7 +277,9 @@ exports[`Onboarding Renders correctly 1`] = `
             },
           ]
         }
-      />
+      >
+        Next
+      </Text>
     </View>
   </View>
 </RNCSafeAreaView>


### PR DESCRIPTION
# Summary of Changes

Hide the skip button on the last on-boarding tutorial screen. As part of this, I was able to move some logic from the RootStack to a better location in OnBoarding.

# Related Issues

n/a

# Pull Request Checklist

This is just a reminder about the most common mistakes. Please make sure that you tick all _appropriate_ boxes. But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this).
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components.
- [x] Run prettier: `npm run style-format`
- [x] Updated **documentation** for changed code and new or modified features.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

_PR template adapted from the Python attrs project._
