### PR TITLE
Add test ID to on-boarding screens

### DIFF
--- a/App/components/buttons/Button.tsx
+++ b/App/components/buttons/Button.tsx
@@ -12,18 +12,27 @@ interface ButtonProps {
   title: string
   buttonType: ButtonType
   accessibilityLabel?: string
+  testID?: string
   onPress?: () => void
   disabled?: boolean
 }
 
-const Button: React.FC<ButtonProps> = ({ title, buttonType, accessibilityLabel, onPress, disabled = false }) => {
+const Button: React.FC<ButtonProps> = ({
+  title,
+  buttonType,
+  accessibilityLabel,
+  testID,
+  onPress,
+  disabled = false,
+}) => {
   const accessible = accessibilityLabel && accessibilityLabel !== '' ? true : false
 
   return (
     <TouchableOpacity
       onPress={onPress}
-      accessible={accessible}
       accessibilityLabel={accessibilityLabel}
+      accessible={accessible}
+      testID={testID}
       style={[
         buttonType === ButtonType.Primary ? Buttons.primary : Buttons.secondary,
         disabled && (buttonType === ButtonType.Primary ? Buttons.primaryDisabled : Buttons.secondaryDisabled),

--- a/App/components/buttons/HeaderRight.tsx
+++ b/App/components/buttons/HeaderRight.tsx
@@ -6,6 +6,7 @@ import { ColorPallet, TextTheme } from '../../theme'
 
 interface HeaderButtonProps {
   title: string
+  testID?: string
   accessibilityLabel?: string
   onPress?: () => void
   disabled?: boolean
@@ -29,10 +30,14 @@ const style = StyleSheet.create({
   },
 })
 
-const HeaderRight: React.FC<HeaderButtonProps> = ({ title, accessibilityLabel, onPress, disabled = false }) => {
+const HeaderRight: React.FC<HeaderButtonProps> = ({ title, testID, accessibilityLabel, onPress, disabled = false }) => {
+  const accessible = accessibilityLabel && accessibilityLabel !== '' ? true : false
+
   return (
     <TouchableOpacity
       accessibilityLabel={accessibilityLabel}
+      accessible={accessible}
+      testID={testID}
       onPress={onPress}
       style={[style.touchableArea]}
       disabled={disabled}

--- a/App/components/inputs/CheckBoxRow.tsx
+++ b/App/components/inputs/CheckBoxRow.tsx
@@ -7,6 +7,7 @@ import { Colors, TextTheme } from '../../theme'
 interface Props {
   title: string
   accessibilityLabel?: string
+  testID?: string
   checked: boolean
   onPress: () => void
 }
@@ -25,12 +26,12 @@ const style = StyleSheet.create({
   },
 })
 
-const CheckBoxRow: React.FC<Props> = ({ title, accessibilityLabel, checked, onPress }) => {
+const CheckBoxRow: React.FC<Props> = ({ title, accessibilityLabel, testID, checked, onPress }) => {
   const accessible = accessibilityLabel && accessibilityLabel !== '' ? true : false
 
   return (
     <View style={style.container}>
-      <TouchableOpacity accessible={accessible} accessibilityLabel={accessibilityLabel} onPress={onPress}>
+      <TouchableOpacity accessibilityLabel={accessibilityLabel} testID={testID} onPress={onPress}>
         {checked ? (
           <Icon name={'check-box'} size={36} color={Colors.primary} />
         ) : (

--- a/App/components/misc/Pagination.tsx
+++ b/App/components/misc/Pagination.tsx
@@ -4,6 +4,7 @@ import { Animated, Text, TouchableOpacity, View } from 'react-native'
 import { ScalingDot } from 'react-native-animated-pagination-dots'
 
 import { Colors } from '../../theme'
+import { testIdWithKey } from '../../utils/testable'
 
 interface IPaginationStyleSheet {
   pagerContainer: Record<string, any>
@@ -51,12 +52,7 @@ export const Pagination: React.FC<IPaginationProps> = ({
 
   return (
     <View style={style.pagerContainer}>
-      <TouchableOpacity
-        accessible={true}
-        accessibilityLabel={t('Global.Back')}
-        accessibilityElementsHidden={false}
-        onPress={previous}
-      >
+      <TouchableOpacity accessibilityLabel={t('Global.Back')} testID={testIdWithKey('Back')} onPress={previous}>
         <Text
           style={[
             style.pagerNavigationButton,
@@ -76,7 +72,7 @@ export const Pagination: React.FC<IPaginationProps> = ({
         dotStyle={style.pagerDot}
         containerStyle={style.pagerPosition}
       />
-      <TouchableOpacity testID={'nextButtonX'} accessible={true} accessibilityLabel={t('Global.Next')} onPress={next}>
+      <TouchableOpacity accessibilityLabel={t('Global.Next')} testID={testIdWithKey('Next')} onPress={next}>
         <Text
           style={[
             style.pagerNavigationButton,

--- a/App/constants.ts
+++ b/App/constants.ts
@@ -2,6 +2,10 @@ import { IndyCredentialMetadata } from '@aries-framework/core/build/types'
 
 export const defaultLanguage = 'en'
 
+// Used to property prefix TestIDs so they can be looked up
+// by on-device automated testing systems like SauceLabs.
+export const testIdPrefix = 'com.example:id/'
+
 export enum LocalStorageKeys {
   Onboarding = 'OnboardingState',
 }

--- a/App/constants.ts
+++ b/App/constants.ts
@@ -4,7 +4,7 @@ export const defaultLanguage = 'en'
 
 // Used to property prefix TestIDs so they can be looked up
 // by on-device automated testing systems like SauceLabs.
-export const testIdPrefix = 'com.example:id/'
+export const testIdPrefix = 'com.ariesbifold:id/'
 
 export enum LocalStorageKeys {
   Onboarding = 'OnboardingState',

--- a/App/localization/en/index.ts
+++ b/App/localization/en/index.ts
@@ -161,4 +161,5 @@ const translation = {
     "Terms": "Terms & Conditions"
   }
 }
+
 export default translation

--- a/App/screens/Onboarding.tsx
+++ b/App/screens/Onboarding.tsx
@@ -11,6 +11,7 @@ import { Pagination } from '../components/misc/Pagination'
 import { Context } from '../store/Store'
 import { DispatchAction } from '../store/reducer'
 import { AuthenticateStackParams, Screens } from '../types/navigators'
+import { testIdWithKey } from '../utils/testable'
 
 const { width } = Dimensions.get('window')
 
@@ -92,7 +93,9 @@ const Onboarding: React.FC<OnboardingProps> = ({ pages, nextButtonText, previous
 
   useEffect(() => {
     navigation.setOptions({
-      headerRight: () => <HeaderRight title={t('Global.Skip')} onPress={onSkipTouched} />,
+      headerRight: () => (
+        <HeaderRight title={t('Global.Skip')} testID={testIdWithKey('Skip')} onPress={onSkipTouched} />
+      ),
     })
 
     if (activeIndex + 1 === pages.length) {

--- a/App/screens/OnboardingPages.tsx
+++ b/App/screens/OnboardingPages.tsx
@@ -5,13 +5,12 @@ import { SvgProps } from 'react-native-svg'
 import CredentialList from '../assets/img/credential-list.svg'
 import ScanShare from '../assets/img/scan-share.svg'
 import SecureImage from '../assets/img/secure-image.svg'
+import Button, { ButtonType } from '../components/buttons/Button'
 import { Colors } from '../theme'
+import { GenericFn } from '../types/fn'
+import { testIdWithKey } from '../utils/testable'
 
 import { OnboardingStyleSheet } from './Onboarding'
-
-import { Button } from 'components'
-import { ButtonType } from 'components/buttons/Button'
-import { GenericFn } from 'types/fn'
 
 const imageDisplayOptions = {
   fill: Colors.text,
@@ -91,8 +90,9 @@ const customPages = (onTutorialCompleted: GenericFn) => {
       </View>
       <View style={{ marginTop: 'auto', marginBottom: 20, paddingHorizontal: 20 }}>
         <Button
-          title={'Get Started!'}
+          title={'Get Started'}
           accessibilityLabel={'Get Started'}
+          testID={testIdWithKey('GetStarted')}
           onPress={onTutorialCompleted}
           buttonType={ButtonType.Primary}
         />

--- a/App/screens/PinCreate.tsx
+++ b/App/screens/PinCreate.tsx
@@ -4,12 +4,12 @@ import { Alert, Keyboard, StyleSheet } from 'react-native'
 import * as Keychain from 'react-native-keychain'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
+import Button, { ButtonType } from '../components/buttons/Button'
+import TextInput from '../components/inputs/TextInput'
 import { Context } from '../store/Store'
 import { DispatchAction } from '../store/reducer'
 import { Colors } from '../theme'
-
-import { Button, TextInput } from 'components'
-import { ButtonType } from 'components/buttons/Button'
+import { testIdWithKey } from '../utils/testable'
 
 interface PinCreateProps {
   setAuthenticated: React.Dispatch<React.SetStateAction<boolean>>
@@ -59,11 +59,11 @@ const PinCreate: React.FC<PinCreateProps> = ({ setAuthenticated }) => {
   return (
     <SafeAreaView style={[style.container]}>
       <TextInput
+        accessibilityLabel={t('Global.EnterPin')}
+        testID={testIdWithKey('EnterPin')}
         label={t('Global.EnterPin')}
         placeholder={t('Global.6DigitPin')}
         placeholderTextColor={Colors.lightGrey}
-        accessible={true}
-        accessibilityLabel={t('Global.EnterPin')}
         maxLength={6}
         autoFocus
         keyboardType="numeric"
@@ -72,9 +72,9 @@ const PinCreate: React.FC<PinCreateProps> = ({ setAuthenticated }) => {
         onChangeText={setPin}
       />
       <TextInput
-        label={t('PinCreate.ReenterPin')}
-        accessible={true}
         accessibilityLabel={t('PinCreate.ReenterPin')}
+        testID={testIdWithKey('ReenterPin')}
+        label={t('PinCreate.ReenterPin')}
         placeholder={t('Global.6DigitPin')}
         placeholderTextColor={Colors.lightGrey}
         maxLength={6}
@@ -91,6 +91,7 @@ const PinCreate: React.FC<PinCreateProps> = ({ setAuthenticated }) => {
       <Button
         title={t('PinCreate.Create')}
         accessibilityLabel={t('PinCreate.Create')}
+        testID={testIdWithKey('Create')}
         buttonType={ButtonType.Primary}
         onPress={() => {
           Keyboard.dismiss()

--- a/App/screens/PinEnter.tsx
+++ b/App/screens/PinEnter.tsx
@@ -4,10 +4,10 @@ import { Alert, Keyboard, StyleSheet } from 'react-native'
 import * as Keychain from 'react-native-keychain'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
+import Button, { ButtonType } from '../components/buttons/Button'
+import TextInput from '../components/inputs/TextInput'
 import { Colors } from '../theme'
-
-import { TextInput, Button } from 'components'
-import { ButtonType } from 'components/buttons/Button'
+import { testIdWithKey } from '../utils/testable'
 
 interface PinEnterProps {
   setAuthenticated: React.Dispatch<React.SetStateAction<boolean>>
@@ -36,9 +36,9 @@ const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated }) => {
   return (
     <SafeAreaView style={[style.container]}>
       <TextInput
-        label={t('Global.EnterPin')}
-        accessible={true}
         accessibilityLabel={t('Global.EnterPin')}
+        testID={testIdWithKey('EnterPin')}
+        label={t('Global.EnterPin')}
         placeholder={t('Global.6DigitPin')}
         placeholderTextColor={Colors.lightGrey}
         autoFocus
@@ -56,6 +56,7 @@ const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated }) => {
       <Button
         title={t('Global.Submit')}
         buttonType={ButtonType.Primary}
+        testID={testIdWithKey('Submit')}
         accessibilityLabel={t('Global.Submit')}
         onPress={() => {
           Keyboard.dismiss()

--- a/App/screens/Terms.tsx
+++ b/App/screens/Terms.tsx
@@ -5,15 +5,15 @@ import { useTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
-import { ButtonType } from '../components/buttons/Button'
+import Button, { ButtonType } from '../components/buttons/Button'
+import CheckBoxRow from '../components/inputs/CheckBoxRow'
+import HighlightTextBox from '../components/texts/HighlightTextBox'
+import InfoTextBox from '../components/texts/InfoTextBox'
 import { Context } from '../store/Store'
 import { DispatchAction } from '../store/reducer'
 import { Colors, TextTheme } from '../theme'
 import { AuthenticateStackParams, Screens } from '../types/navigators'
-
-import { Button, CheckBoxRow } from 'components'
-import HighlightTextBox from 'components/texts/HighlightTextBox'
-import InfoTextBox from 'components/texts/InfoTextBox'
+import { testIdWithKey } from '../utils/testable'
 
 const style = StyleSheet.create({
   container: {
@@ -83,6 +83,7 @@ const Terms: React.FC = () => {
           <CheckBoxRow
             title={t('Terms.Attestation')}
             accessibilityLabel={t('Terms.IAgree')}
+            testID={testIdWithKey('IAgree')}
             checked={checked}
             onPress={() => setChecked(!checked)}
           />
@@ -90,6 +91,7 @@ const Terms: React.FC = () => {
             <Button
               title={t('Global.Continue')}
               accessibilityLabel={t('Global.Continue')}
+              testID={testIdWithKey('Continue')}
               disabled={!checked}
               onPress={onSubmitPressed}
               buttonType={ButtonType.Primary}
@@ -99,6 +101,7 @@ const Terms: React.FC = () => {
             <Button
               title={t('Global.Back')}
               accessibilityLabel={t('Global.Back')}
+              testID={testIdWithKey('Back')}
               onPress={onBackPressed}
               buttonType={ButtonType.Secondary}
             />

--- a/App/utils/testable.ts
+++ b/App/utils/testable.ts
@@ -1,0 +1,5 @@
+import { testIdPrefix } from '../constants'
+
+export const testIdWithKey = (key: string): string => {
+  return `${testIdPrefix}${key}`
+}

--- a/__tests__/__snapshots__/testable.test.ts.snap
+++ b/__tests__/__snapshots__/testable.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Testable Produces the correct testID 1`] = `"com.example:id/blarb"`;
+exports[`Testable Produces the correct testID 1`] = `"com.ariesbifold:id/blarb"`;

--- a/__tests__/__snapshots__/testable.test.ts.snap
+++ b/__tests__/__snapshots__/testable.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testable Produces the correct testID 1`] = `"com.example:id/blarb"`;

--- a/__tests__/components/HeaderRight.test.tsx
+++ b/__tests__/components/HeaderRight.test.tsx
@@ -8,6 +8,7 @@ describe('Header Right Button Component', () => {
     const tree = render(
       <HeaderRight
         title={'Hello Header'}
+        testID={'TestID.Button'}
         accessibilityLabel={'Hello'}
         onPress={() => {
           return

--- a/__tests__/components/__snapshots__/HeaderRight.test.tsx.snap
+++ b/__tests__/components/__snapshots__/HeaderRight.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`Header Right Button Component Renders correctly 1`] = `
       "opacity": 1,
     }
   }
+  testID="TestID.Button"
 >
   <View
     style={

--- a/__tests__/screens/__snapshots__/Onboarding.test.tsx.snap
+++ b/__tests__/screens/__snapshots__/Onboarding.test.tsx.snap
@@ -145,7 +145,6 @@ exports[`Onboarding Renders correctly 1`] = `
     }
   >
     <View
-      accessibilityElementsHidden={false}
       accessibilityLabel="Global.Back"
       accessible={true}
       collapsable={false}
@@ -163,6 +162,7 @@ exports[`Onboarding Renders correctly 1`] = `
           "opacity": 1,
         }
       }
+      testID="com.example:id/Back"
     >
       <Text
         style={
@@ -261,7 +261,7 @@ exports[`Onboarding Renders correctly 1`] = `
           "opacity": 1,
         }
       }
-      testID="nextButtonX"
+      testID="com.example:id/Next"
     >
       <Text
         style={

--- a/__tests__/screens/__snapshots__/Onboarding.test.tsx.snap
+++ b/__tests__/screens/__snapshots__/Onboarding.test.tsx.snap
@@ -162,7 +162,7 @@ exports[`Onboarding Renders correctly 1`] = `
           "opacity": 1,
         }
       }
-      testID="com.example:id/Back"
+      testID="com.ariesbifold:id/Back"
     >
       <Text
         style={
@@ -261,7 +261,7 @@ exports[`Onboarding Renders correctly 1`] = `
           "opacity": 1,
         }
       }
-      testID="com.example:id/Next"
+      testID="com.ariesbifold:id/Next"
     >
       <Text
         style={

--- a/__tests__/testable.test.ts
+++ b/__tests__/testable.test.ts
@@ -1,0 +1,10 @@
+import { testIdWithKey } from '../App/utils/testable'
+
+describe('Testable', () => {
+  it('Produces the correct testID', () => {
+    const key = 'blarb'
+    const result = testIdWithKey(key)
+
+    expect(result).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
# Summary of Changes

Adds test ID to components that are intractable as part of automated testing (Buttons, TextInput, etc). Screens updated include:

- Tutorial Carousel
- Terms and Conditions
- PIN Creation
- PIN Entry

Once we test to make sure this is a viable approach other components in the app will be updated to include `testID`. Sauce lab prefers the Android Package ID be used in the format `ca.package.bla.MyCoolApp:id/UniqueKeyHere` where `UniqueKeyHere` can uniquely identify a component but the remaining is constant. The function `testIdWithKey` is used to abstract this a little so it can:

- The package ID can be changed quickly and easily be teams to fork and need to update to their own package ID (everyone who wants to ship to iTunes or Google Play;
- We don't need to go through the entire app to tweak the format if SauceLabs et al change things;
- We don't need to add it to translations (another option I tried) because this stuff will never be visible to humans.

# Related Issues

n/a

# Pull Request Checklist

This is just a reminder about the most common mistakes. Please make sure that you tick all _appropriate_ boxes. But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this).
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components.
- [x] Run prettier: `npm run style-format`
- [x] Updated **documentation** for changed code and new or modified features.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

_PR template adapted from the Python attrs project._
