### PR TITLE
Display revoked status in proof request

### DIFF
--- a/App/localization/en/index.ts
+++ b/App/localization/en/index.ts
@@ -67,6 +67,7 @@ const translation = {
     "PrivacyPolicy": "Privacy policy",
     "TermsAndConditions": "Terms and conditions",
     "RemoveFromWallet": "Remove from wallet",
+    "Revoked": "Revoked"
   },
   "Home": {
     "Welcome": "Welcome",

--- a/App/screens/ProofRequest.tsx
+++ b/App/screens/ProofRequest.tsx
@@ -16,7 +16,12 @@ import { ColorPallet, TextTheme } from '../theme'
 import { BifoldError } from '../types/error'
 import { HomeStackParams, Screens } from '../types/navigators'
 import { Attribute } from '../types/record'
-import { connectionRecordFromId, firstMatchingCredentialAttributeValue, getConnectionName } from '../utils/helpers'
+import {
+  connectionRecordFromId,
+  firstAttributeCredential,
+  getConnectionName,
+  valueFromAttributeCredential,
+} from '../utils/helpers'
 
 import Button, { ButtonType } from 'components/buttons/Button'
 import NotificationModal from 'components/modals/NotificationModal'
@@ -223,48 +228,55 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
         )}
         attributes={retrievedCredentialAttributes.map(([name, values]) => ({
           name,
-          value: firstMatchingCredentialAttributeValue(name, values),
+          value: firstAttributeCredential(values),
           values,
         }))}
-        attribute={(attribute) => (
-          <RecordAttribute
-            attribute={attribute}
-            attributeValue={(attribute: ProofRequestAttribute) => (
-              <>
-                {attribute?.values?.length ? (
-                  <Text style={TextTheme.normal}>{attribute.value}</Text>
-                ) : (
-                  <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-                    <Icon
-                      style={{ paddingTop: 2, paddingHorizontal: 2 }}
-                      name="close"
-                      color={ColorPallet.semantic.error}
-                      size={TextTheme.normal.fontSize}
-                    ></Icon>
-                    <Text style={[TextTheme.normal, { color: ColorPallet.semantic.error }]}>
-                      {t('ProofRequest.NotAvailableInYourWallet')}
+        attribute={(attribute) => {
+          return (
+            <RecordAttribute
+              attribute={attribute}
+              attributeValue={(attribute: ProofRequestAttribute) => (
+                <>
+                  {!attribute?.values?.length || (attribute?.value as RequestedAttribute)?.revoked ? (
+                    <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                      <Icon
+                        style={{ paddingTop: 2, paddingHorizontal: 2 }}
+                        name="close"
+                        color={ColorPallet.semantic.error}
+                        size={TextTheme.normal.fontSize}
+                      ></Icon>
+
+                      <Text style={[TextTheme.normal, { color: ColorPallet.semantic.error }]}>
+                        {(attribute?.value as RequestedAttribute)?.revoked
+                          ? t('CredentialDetails.Revoked')
+                          : t('ProofRequest.NotAvailableInYourWallet')}
+                      </Text>
+                    </View>
+                  ) : (
+                    <Text style={TextTheme.normal}>
+                      {valueFromAttributeCredential(attribute.name, attribute.value as RequestedAttribute)}
                     </Text>
-                  </View>
-                )}
-                {attribute?.values?.length ? (
-                  <TouchableOpacity
-                    activeOpacity={1}
-                    onPress={() =>
-                      navigation.navigate(Screens.ProofRequestAttributeDetails, {
-                        proofId,
-                        attributeName: attribute.name,
-                        attributeCredentials: attribute.values || [],
-                      })
-                    }
-                    style={styles.link}
-                  >
-                    <Text style={TextTheme.normal}>{t('ProofRequest.Details')}</Text>
-                  </TouchableOpacity>
-                ) : null}
-              </>
-            )}
-          />
-        )}
+                  )}
+                  {attribute?.values?.length ? (
+                    <TouchableOpacity
+                      activeOpacity={1}
+                      onPress={() =>
+                        navigation.navigate(Screens.ProofRequestAttributeDetails, {
+                          proofId,
+                          attributeName: attribute.name,
+                          attributeCredentials: attribute.values || [],
+                        })
+                      }
+                      style={styles.link}
+                    >
+                      <Text style={TextTheme.normal}>{t('ProofRequest.Details')}</Text>
+                    </TouchableOpacity>
+                  ) : null}
+                </>
+              )}
+            />
+          )
+        }}
       />
       <NotificationModal
         title={t('ProofRequest.SendingTheInformationSecurely')}

--- a/App/screens/ProofRequestAttributeDetails.tsx
+++ b/App/screens/ProofRequestAttributeDetails.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FlatList, StyleSheet, Text, View } from 'react-native'
 import Toast from 'react-native-toast-message'
+import Icon from 'react-native-vector-icons/MaterialIcons'
 
 import Title from '../components/texts/Title'
 import { ToastType } from '../components/toast/BaseToast'
@@ -13,10 +14,11 @@ import { ColorPallet, TextTheme } from '../theme'
 import { HomeStackParams, Screens } from '../types/navigators'
 import {
   connectionRecordFromId,
-  firstMatchingCredentialAttributeValue,
+  firstAttributeCredential,
   getConnectionName,
   parsedSchema,
   proofRecordFromId,
+  valueFromAttributeCredential,
 } from '../utils/helpers'
 
 type ProofRequestAttributeDetailsProps = StackScreenProps<HomeStackParams, Screens.ProofRequestAttributeDetails>
@@ -124,6 +126,8 @@ const ProofRequestAttributeDetails: React.FC<ProofRequestAttributeDetailsProps> 
     credentialIds.includes(credential.credentialId || credential.id)
   )
 
+  const attributeCredential = firstAttributeCredential(attributeCredentials) as RequestedAttribute
+
   return (
     <FlatList
       ListHeaderComponent={() => (
@@ -141,11 +145,25 @@ const ProofRequestAttributeDetails: React.FC<ProofRequestAttributeDetailsProps> 
       renderItem={({ item: credential }) => (
         <View style={styles.listItem}>
           <Text style={TextTheme.normal}>{parsedSchema(credential).name}</Text>
-          <Text style={TextTheme.normal}>
-            {t('CredentialDetails.Issued')} {credential.createdAt.toLocaleDateString('en-CA', dateFormatOptions)}
-          </Text>
+          {attributeCredential.revoked ? (
+            <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+              <Icon
+                style={{ paddingTop: 2, paddingHorizontal: 2 }}
+                name="close"
+                color={ColorPallet.semantic.error}
+                size={TextTheme.normal.fontSize}
+              ></Icon>
+              <Text style={[TextTheme.normal, { color: ColorPallet.semantic.error }]}>
+                {t('CredentialDetails.Revoked')}
+              </Text>
+            </View>
+          ) : (
+            <Text style={TextTheme.normal}>
+              {t('CredentialDetails.Issued')} {credential.createdAt.toLocaleDateString('en-CA', dateFormatOptions)}
+            </Text>
+          )}
           <Title style={{ paddingVertical: 16 }}>
-            {firstMatchingCredentialAttributeValue(attributeName, attributeCredentials)}
+            {valueFromAttributeCredential(attributeName, attributeCredential)}
           </Title>
         </View>
       )}

--- a/App/types/record.ts
+++ b/App/types/record.ts
@@ -1,4 +1,6 @@
+import { RequestedAttribute } from '@aries-framework/core'
+
 export interface Attribute {
   name: string
-  value: string
+  value: RequestedAttribute | string | null
 }

--- a/App/utils/helpers.ts
+++ b/App/utils/helpers.ts
@@ -6,7 +6,6 @@ import {
   RequestedAttribute,
 } from '@aries-framework/core'
 import { useConnectionById, useCredentialById, useProofById } from '@aries-framework/react-hooks'
-import startCase from 'lodash.startcase'
 import { parseUrl } from 'query-string'
 
 export function parseSchema(schemaId?: string): { name: string; version: string } {
@@ -71,18 +70,31 @@ export function getConnectionName(connection: ConnectionRecord | void): string |
   return connection?.alias || connection?.invitation?.label
 }
 
-export function firstMatchingCredentialAttributeValue(attributeName: string, attributes: RequestedAttribute[]): string {
+export function firstAttributeCredential(attributes: RequestedAttribute[], revoked = true): RequestedAttribute | null {
   if (!attributes.length) {
+    return null
+  }
+
+  let first = null
+  const firstNonRevoked = attributes.filter((attribute) => !attribute.revoked)[0]
+  if (firstNonRevoked) {
+    first = firstNonRevoked
+  } else if (attributes.length && revoked) {
+    first = attributes[0]
+  }
+
+  if (!first?.credentialInfo) {
+    return null
+  }
+
+  return first
+}
+
+export const valueFromAttributeCredential = (name: string, credential: RequestedAttribute) => {
+  if (!credential) {
     return ''
   }
-  const firstMatchingCredential = attributes[0].credentialInfo
-  if (!firstMatchingCredential) {
-    return ''
-  }
-  const match = Object.entries(firstMatchingCredential.attributes).find(
-    ([n]) => startCase(n) === startCase(attributeName)
-  )
-  return match?.length ? match[1] : ''
+  return credential.credentialInfo?.attributes[name]
 }
 
 export const isRedirection = (url: string): boolean => {

--- a/__tests__/screens/ProofRequest.test.tsx
+++ b/__tests__/screens/ProofRequest.test.tsx
@@ -190,7 +190,7 @@ describe('displays a proof request screen', () => {
       const timeLabel = getByText(/Time/, { exact: false })
       const timeValue = queryByText(testTime, { exact: false })
       const detailsLinks = getAllByText('ProofRequest.Details', { exact: false })
-      const shareButton = getByText('Global.Share', { exact: false })
+      const shareButton = queryByText('Global.Share', { exact: false })
       const declineButton = getByText('Global.Decline', { exact: false })
 
       expect(contact).not.toBeNull()
@@ -207,7 +207,7 @@ describe('displays a proof request screen', () => {
       expect(missingClaim).not.toBeNull()
       expect(missingClaim).toBeTruthy()
       expect(detailsLinks.length).toBe(1)
-      expect(shareButton).not.toBeNull()
+      expect(shareButton).toBeNull()
       expect(declineButton).not.toBeNull()
     })
   })


### PR DESCRIPTION
# Summary of Changes

This PR adds the ability to display the revocation status of credentials in a proof request. Proof requests are now strictly declinable in the case where a valid credential is unavailable to satisfy a proof request.

# Related Issues

N/A

# Pull Request Checklist

This is just a reminder about the most common mistakes. Please make sure that you tick all _appropriate_ boxes. But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [ ] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this).
- [ ] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components.
- [ ] Run prettier: `npm run style-format`
- [ ] Updated **documentation** for changed code and new or modified features.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

_PR template adapted from the Python attrs project._
