### PR TITLE
Dynamic status bar style on modals

### DIFF
--- a/core/App/screens/CredentialOfferAccept.tsx
+++ b/core/App/screens/CredentialOfferAccept.tsx
@@ -3,7 +3,7 @@ import { useCredentialById } from '@aries-framework/react-hooks'
 import { useNavigation } from '@react-navigation/core'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Modal, StyleSheet, Text, View } from 'react-native'
+import { Modal, StatusBar, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import CredentialAdded from '../components/animated/CredentialAdded'
@@ -11,6 +11,7 @@ import CredentialPending from '../components/animated/CredentialPending'
 import Button, { ButtonType } from '../components/buttons/Button'
 import { useTheme } from '../contexts/theme'
 import { Screens, TabStacks } from '../types/navigators'
+import { statusBarStyleForColor } from '../utils/luminance'
 import { testIdWithKey } from '../utils/testable'
 
 const connectionTimerDelay = 5000 // in ms
@@ -107,6 +108,7 @@ const CredentialOfferAccept: React.FC<CredentialOfferAcceptProps> = ({ visible, 
 
   return (
     <Modal visible={visible} transparent={true} animationType={'none'}>
+      <StatusBar barStyle={statusBarStyleForColor(styles.container.backgroundColor)} />
       <SafeAreaView style={[styles.container]}>
         <View style={[styles.messageContainer]}>
           {credentialDeliveryStatus === DeliveryStatus.Pending && (

--- a/core/App/screens/CredentialOfferDecline.tsx
+++ b/core/App/screens/CredentialOfferDecline.tsx
@@ -12,6 +12,7 @@ import InfoBox, { InfoBoxType } from '../components/misc/InfoBox'
 import { useTheme } from '../contexts/theme'
 import { GenericFn } from '../types/fn'
 import { Screens, TabStacks } from '../types/navigators'
+import { statusBarStyleForColor } from '../utils/luminance'
 import { testIdWithKey } from '../utils/testable'
 
 export interface CredentialOfferDeclineProps {
@@ -73,7 +74,7 @@ const CredentialOfferDecline: React.FC<CredentialOfferDeclineProps> = ({
 
   return (
     <Modal visible={modalVisible} transparent={true} animationType={'none'}>
-      <StatusBar barStyle="light-content" hidden={false} translucent={false} />
+      <StatusBar barStyle={statusBarStyleForColor(styles.container.backgroundColor)} />
       <SafeAreaView style={[styles.container]}>
         <View style={[{ marginTop: 25 }]}>
           {!didDeclineOffer && (

--- a/core/App/screens/CredentialOfferDecline.tsx
+++ b/core/App/screens/CredentialOfferDecline.tsx
@@ -2,7 +2,7 @@ import { useCredentialById } from '@aries-framework/react-hooks'
 import { useNavigation } from '@react-navigation/core'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Modal, StyleSheet, Text, View } from 'react-native'
+import { Modal, StatusBar, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import CredentialDeclined from '../assets/img/credential-declined.svg'
@@ -73,6 +73,7 @@ const CredentialOfferDecline: React.FC<CredentialOfferDeclineProps> = ({
 
   return (
     <Modal visible={modalVisible} transparent={true} animationType={'none'}>
+      <StatusBar barStyle="light-content" hidden={false} translucent={false} />
       <SafeAreaView style={[styles.container]}>
         <View style={[{ marginTop: 25 }]}>
           {!didDeclineOffer && (

--- a/core/App/screens/ProofRequestAccepted.tsx
+++ b/core/App/screens/ProofRequestAccepted.tsx
@@ -3,7 +3,7 @@ import { useProofById } from '@aries-framework/react-hooks'
 import { useNavigation } from '@react-navigation/core'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Modal, StyleSheet, Text, View } from 'react-native'
+import { Modal, StatusBar, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import SendingProof from '../components/animated/SendingProof'
@@ -11,6 +11,7 @@ import SentProof from '../components/animated/SentProof'
 import Button, { ButtonType } from '../components/buttons/Button'
 import { useTheme } from '../contexts/theme'
 import { Screens, TabStacks } from '../types/navigators'
+import { statusBarStyleForColor } from '../utils/luminance'
 import { testIdWithKey } from '../utils/testable'
 
 const connectionTimerDelay = 5000 // in ms
@@ -100,6 +101,7 @@ const ProofRequestAccept: React.FC<ProofRequestAcceptProps> = ({ visible, proofI
 
   return (
     <Modal visible={visible} transparent={true} animationType={'none'}>
+      <StatusBar barStyle={statusBarStyleForColor(styles.container.backgroundColor)} />
       <SafeAreaView style={[styles.container]}>
         <View style={[styles.messageContainer]}>
           {proofDeliveryStatus === ProofState.RequestReceived && (

--- a/core/App/screens/ProofRequestDeclined.tsx
+++ b/core/App/screens/ProofRequestDeclined.tsx
@@ -11,6 +11,7 @@ import InfoBox, { InfoBoxType } from '../components/misc/InfoBox'
 import { useTheme } from '../contexts/theme'
 import { GenericFn } from '../types/fn'
 import { Screens, TabStacks } from '../types/navigators'
+import { statusBarStyleForColor } from '../utils/luminance'
 import { testIdWithKey } from '../utils/testable'
 
 export interface ProofRequestDeclinedProps {
@@ -72,9 +73,7 @@ const ProofRequestDeclined: React.FC<ProofRequestDeclinedProps> = ({
 
   return (
     <Modal visible={modalVisible} transparent={true} animationType={'none'} statusBarTranslucent>
-      {/* <StatusBar barStyle="light-content" hidden={false} backgroundColor={'red'} translucent={true} /> */}
-      {/* <View style={{ backgroundColor: 'red', minHeight: 55, minWidth: 200 }} /> */}
-      <StatusBar barStyle="dark-content" />
+      <StatusBar barStyle={statusBarStyleForColor(styles.container.backgroundColor)} />
       <SafeAreaView style={[styles.container]}>
         <View style={[{ marginTop: 25 }]}>
           {!didDeclineOffer && (

--- a/core/App/screens/ProofRequestDeclined.tsx
+++ b/core/App/screens/ProofRequestDeclined.tsx
@@ -2,7 +2,7 @@ import { useProofById } from '@aries-framework/react-hooks'
 import { useNavigation } from '@react-navigation/core'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Modal, StyleSheet, Text, View } from 'react-native'
+import { Modal, StatusBar, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import PRDeclined from '../assets/img/proof-declined.svg'
@@ -71,7 +71,10 @@ const ProofRequestDeclined: React.FC<ProofRequestDeclinedProps> = ({
   })
 
   return (
-    <Modal visible={modalVisible} transparent={true} animationType={'none'}>
+    <Modal visible={modalVisible} transparent={true} animationType={'none'} statusBarTranslucent>
+      {/* <StatusBar barStyle="light-content" hidden={false} backgroundColor={'red'} translucent={true} /> */}
+      {/* <View style={{ backgroundColor: 'red', minHeight: 55, minWidth: 200 }} /> */}
+      <StatusBar barStyle="dark-content" />
       <SafeAreaView style={[styles.container]}>
         <View style={[{ marginTop: 25 }]}>
           {!didDeclineOffer && (
@@ -109,7 +112,7 @@ const ProofRequestDeclined: React.FC<ProofRequestDeclinedProps> = ({
                   style={[TextTheme.headingThree, styles.messageText]}
                   testID={testIdWithKey('ProofRequestDeclined')}
                 >
-                  {t('ProofRequest.ProofRequestDeclined')}
+                  2{t('ProofRequest.ProofRequestDeclined')}
                 </Text>
                 <PRDeclined style={[styles.image]} {...imageDisplayOptions} />
               </View>

--- a/core/App/utils/luminance.ts
+++ b/core/App/utils/luminance.ts
@@ -1,0 +1,28 @@
+export enum StatusBarStyles {
+  Light = 'light-content',
+  Dark = 'dark-content',
+}
+
+export const luminanceForHexColour = (hex: string): number | undefined => {
+  if (!/^#([A-Fa-f0-9]{6})$/.test(hex)) {
+    return
+  }
+
+  const hexAsNumber = Number(`0x${hex.slice(1)}`)
+  const [r, g, b] = [(hexAsNumber >> 16) & 255, (hexAsNumber >> 8) & 255, hexAsNumber & 255]
+  // Scalars below defined [here](https://en.wikipedia.org/wiki/Relative_luminance)
+  const y = 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+  return Math.round(y)
+}
+
+export const statusBarStyleForColor = (hex: string): StatusBarStyles | undefined => {
+  const rgbMidPoint = 255 / 2
+  const y = luminanceForHexColour(hex)
+
+  if (typeof y === 'undefined') {
+    return
+  }
+
+  return y <= rgbMidPoint ? StatusBarStyles.Light : StatusBarStyles.Dark
+}

--- a/core/__tests__/luminance.test.ts
+++ b/core/__tests__/luminance.test.ts
@@ -1,0 +1,35 @@
+import { luminanceForHexColour, statusBarStyleForColor } from '../App/utils/luminance'
+
+describe('Luminance', () => {
+  it('Non-hex color strings are not processed', () => {
+    const colour = '23 Dogs'
+    const result = luminanceForHexColour(colour)
+
+    expect(result).toBeUndefined()
+  })
+
+  it('Compute the luminance for a hex color string', () => {
+    const colour = '#3399FF'
+    const result = luminanceForHexColour(colour)
+
+    expect(result).toEqual(139)
+  })
+
+  it('Dark hex should yield light style', () => {
+    // colours https://www.color-hex.com/
+    const eggplant = '#673147'
+    const black = '#000000'
+
+    expect(statusBarStyleForColor(black)).toEqual('light-content')
+    expect(statusBarStyleForColor(eggplant)).toEqual('light-content')
+  })
+
+  it('Light hex should yield dark style', () => {
+    // colours https://www.color-hex.com/
+    const salmon = '#ff7f50'
+    const white = '#FFFFFF'
+
+    expect(statusBarStyleForColor(salmon)).toEqual('dark-content')
+    expect(statusBarStyleForColor(white)).toEqual('dark-content')
+  })
+})


### PR DESCRIPTION
# Summary of Changes

Depending on the theme the status bar style (light or dark) may not look very nice on the modals. In the current bifold its decent because `light-content` looks good on both green and black. When alternative themes are used with light background, the modals don't have a contrasting top bar and `light-content` looks bleached out.

This PR uses [luminance](https://en.wikipedia.org/wiki/Relative_luminance) to determine if the background is light or dark and choose the best status bar style. I think it matches up with Apples HIG on the subject found [here](https://developer.apple.com/design/human-interface-guidelines/ios/bars/status-bars/). Alternatively, we can hide it.


# Related Issues

n/a

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
