### PR TITLE
Update loading activity indicator

### DIFF
--- a/core/App/components/animated/LoadingIndicator.tsx
+++ b/core/App/components/animated/LoadingIndicator.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useRef } from 'react'
+import { View, StyleSheet, Animated, Image } from 'react-native'
+
+import ActivityIndicator from '../../assets/img/activity-indicator-circle.svg'
+import { useTheme } from '../../contexts/theme'
+import { testIdWithKey } from '../../utils/testable'
+
+const LoadingIndicator: React.FC = () => {
+  const { ColorPallet, Assets } = useTheme()
+  const rotationAnim = useRef(new Animated.Value(0)).current
+  const timing: Animated.TimingAnimationConfig = {
+    toValue: 1,
+    duration: 2000,
+    useNativeDriver: true,
+  }
+  const rotation = rotationAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['0deg', '360deg'],
+  })
+  const style = StyleSheet.create({
+    animation: {
+      position: 'absolute',
+    },
+  })
+  const imageDisplayOptions = {
+    fill: ColorPallet.notification.infoText,
+    height: 200,
+    width: 200,
+  }
+
+  useEffect(() => {
+    Animated.loop(Animated.timing(rotationAnim, timing)).start()
+  }, [rotationAnim])
+
+  return (
+    <View style={{ alignItems: 'center', justifyContent: 'center' }} testID={testIdWithKey('LoadingActivityIndicator')}>
+      <Image source={Assets.img.logoLarge} testID={testIdWithKey('LoadingActivityIndicatorX')} />
+      <Animated.View style={[style.animation, { transform: [{ rotate: rotation }] }]}>
+        <ActivityIndicator {...imageDisplayOptions} />
+      </Animated.View>
+    </View>
+  )
+}
+
+export default LoadingIndicator

--- a/core/App/components/modals/LoadingModal.tsx
+++ b/core/App/components/modals/LoadingModal.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import { ActivityIndicator, Dimensions, Image, Modal, SafeAreaView, StyleSheet } from 'react-native'
+import { Dimensions, Modal, SafeAreaView, StyleSheet } from 'react-native'
 
 import { useTheme } from '../../contexts/theme'
-import { testIdWithKey } from '../../utils/testable'
+import LoadingIndicator from '../animated/LoadingIndicator'
 
 const { height } = Dimensions.get('window')
 
 const LoadingModal: React.FC = () => {
-  const { ColorPallet, Assets } = useTheme()
+  const { ColorPallet } = useTheme()
   const styles = StyleSheet.create({
     container: {
       minHeight: height,
@@ -19,10 +19,9 @@ const LoadingModal: React.FC = () => {
   })
 
   return (
-    <Modal visible={true} transparent={true} testID={testIdWithKey('LoadingModalScreen')}>
+    <Modal visible={true} transparent={true}>
       <SafeAreaView style={[styles.container]}>
-        <Image source={Assets.img.logoLarge} />
-        <ActivityIndicator color={ColorPallet.grayscale.white} testID={testIdWithKey('LoadingActivityIndicator')} />
+        <LoadingIndicator />
       </SafeAreaView>
     </Modal>
   )

--- a/core/__tests__/screens/LoadingModal.test.tsx
+++ b/core/__tests__/screens/LoadingModal.test.tsx
@@ -1,9 +1,4 @@
-import { CredentialRecord, CredentialState } from '@aries-framework/core'
-import { useCredentialById } from '@aries-framework/react-hooks'
-import { useNavigation } from '@react-navigation/core'
-import { render, waitFor, fireEvent } from '@testing-library/react-native'
-import fs from 'fs'
-import path from 'path'
+import { render } from '@testing-library/react-native'
 import React from 'react'
 
 import LoadingModal from '../../App/components/modals/LoadingModal'
@@ -19,10 +14,8 @@ describe('displays loading screen', () => {
   test('contains testIDs', () => {
     const tree = render(<LoadingModal />)
 
-    const loadingModalScreenID = tree.getByTestId(testIdWithKey('LoadingModalScreen'))
     const loadingActivityIndicatorID = tree.getByTestId(testIdWithKey('LoadingActivityIndicator'))
 
-    expect(loadingModalScreenID).not.toBeNull()
     expect(loadingActivityIndicatorID).not.toBeNull()
   })
 })

--- a/core/__tests__/screens/LoadingModal.test.tsx
+++ b/core/__tests__/screens/LoadingModal.test.tsx
@@ -4,6 +4,8 @@ import React from 'react'
 import LoadingModal from '../../App/components/modals/LoadingModal'
 import { testIdWithKey } from '../../App/utils/testable'
 
+jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper')
+
 describe('displays loading screen', () => {
   test('renders correctly', () => {
     const tree = render(<LoadingModal />)

--- a/core/__tests__/screens/__snapshots__/LoadingModal.test.tsx.snap
+++ b/core/__tests__/screens/__snapshots__/LoadingModal.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`displays loading screen renders correctly 1`] = `
 <Modal
   hardwareAccelerated={false}
-  testID="com.ariesbifold:id/LoadingModalScreen"
   transparent={true}
   visible={true}
 >
@@ -21,17 +20,44 @@ exports[`displays loading screen renders correctly 1`] = `
       ]
     }
   >
-    <Image
-      source={
+    <View
+      style={
         Object {
-          "default": "",
+          "alignItems": "center",
+          "justifyContent": "center",
         }
       }
-    />
-    <ActivityIndicator
-      color="#FFFFFF"
       testID="com.ariesbifold:id/LoadingActivityIndicator"
-    />
+    >
+      <Image
+        source={
+          Object {
+            "default": "",
+          }
+        }
+        testID="com.ariesbifold:id/LoadingActivityIndicatorX"
+      />
+      <View
+        collapsable={false}
+        nativeID="animatedComponent"
+        style={
+          Object {
+            "position": "absolute",
+            "transform": Array [
+              Object {
+                "rotate": "0deg",
+              },
+            ],
+          }
+        }
+      >
+        <
+          fill="#FFFFFF"
+          height={200}
+          width={200}
+        />
+      </View>
+    </View>
   </RCTSafeAreaView>
 </Modal>
 `;


### PR DESCRIPTION
# Summary of Changes

The loading activity built into RN looks like a refresh icon on Android. This update uses one of our animations to indicating something is going on. It also makes some changes to testID; they were not being picked up on Android for the built in RN activity indicator.

# Related Issues

n/a

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
