### PR TITLE
fix: connect to ledgers on startup in iOS release environments

### DIFF
--- a/app/ios/AriesBifold/main.m
+++ b/app/ios/AriesBifold/main.m
@@ -3,6 +3,34 @@
 #import "AppDelegate.h"
 
 int main(int argc, char * argv[]) {
+  struct rlimit rlim;
+  unsigned long long NEW_SOFT_LIMIT = 1024;
+
+  //Fetch existing file limits, adjust file limits if possible
+  if (getrlimit(RLIMIT_NOFILE, &rlim) == 0) {
+    NSLog(@"Current soft RLimit: %llu", rlim.rlim_cur);
+    NSLog(@"Current hard RLimit: %llu", rlim.rlim_max);
+
+    // Adjust only if the limit is less than NEW_SOFT_LIMIT
+    if(rlim.rlim_cur < NEW_SOFT_LIMIT){
+      rlim.rlim_cur = NEW_SOFT_LIMIT;
+    }
+
+    if (setrlimit(RLIMIT_NOFILE, &rlim) == -1) {
+      NSLog(@"Can't set RLimits");
+    }
+  } else {
+    NSLog(@"Can't fetch RLimits");
+  }
+
+  // Re-fetch file limits
+  if (getrlimit(RLIMIT_NOFILE, &rlim) == 0) {
+    NSLog(@"New soft RLimit: %llu", rlim.rlim_cur);
+    NSLog(@"New hard RLimit: %llu", rlim.rlim_max);
+  } else {
+    NSLog(@"Can't fetch RLimits");
+  }
+  
   @autoreleasepool {
     return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
   }

--- a/core/App/navigators/RootStack.tsx
+++ b/core/App/navigators/RootStack.tsx
@@ -85,7 +85,7 @@ const RootStack: React.FC<RootStackProps> = (props: RootStackProps) => {
           autoAcceptCredentials: AutoAcceptCredential.ContentApproved,
           logger: new ConsoleLogger(LogLevel.trace),
           indyLedgers,
-          connectToIndyLedgersOnStartup: false,
+          connectToIndyLedgersOnStartup: true,
         },
         agentDependencies
       )


### PR DESCRIPTION
Signed-off-by: James Ebert <jamesebert.k@gmail.com>

# Summary of Changes

As I mentioned in this morning's Bifold User Group call, here's the fix we've identified for allowing us to connect to multiple ledgers at agent initialization in iOS release environments ([AFJ issue #647](https://github.com/hyperledger/aries-framework-javascript/issues/647)). This should improve the first issuance time performance (to match that of subsequent issuances). I've got more documentation and notes to add (hence the draft status), but if I could get a test to ensure this works on your end first @jleach that'd be really helpful.

# Related Issues

https://github.com/hyperledger/aries-framework-javascript/issues/647

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
