### PR TITLE
Allow errors to show technical message on demand

### DIFF
--- a/core/App/components/misc/InfoBox.tsx
+++ b/core/App/components/misc/InfoBox.tsx
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, View, Text, Dimensions } from 'react-native'
+import { TouchableOpacity } from 'react-native-gesture-handler'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
 import { useTheme } from '../../contexts/theme'
@@ -21,8 +22,8 @@ export enum InfoBoxType {
 interface BifoldErrorProps {
   notificationType: InfoBoxType
   title: string
-  message: string
-  code?: number
+  description: string
+  message?: string
   onCallToActionPressed?: GenericFn
   onCallToActionLabel?: string
 }
@@ -30,13 +31,14 @@ interface BifoldErrorProps {
 const InfoBox: React.FC<BifoldErrorProps> = ({
   notificationType,
   title,
+  description,
   message,
-  code,
   onCallToActionPressed,
   onCallToActionLabel,
 }) => {
   const { t } = useTranslation()
   const { TextTheme, ColorPallet } = useTheme()
+  const [showDetails, setShowDetails] = useState<boolean>(false)
   const styles = StyleSheet.create({
     container: {
       backgroundColor: ColorPallet.notification.info,
@@ -73,6 +75,11 @@ const InfoBox: React.FC<BifoldErrorProps> = ({
     icon: {
       marginRight: 10,
       alignSelf: 'center',
+    },
+    showDetailsText: {
+      ...TextTheme.title,
+      fontWeight: 'normal',
+      color: ColorPallet.brand.link,
     },
   })
   let iconName = 'info'
@@ -152,7 +159,11 @@ const InfoBox: React.FC<BifoldErrorProps> = ({
       break
 
     default:
-      throw new Error('InfoTextBoxIIType needs to be set correctly')
+      throw new Error('InfoTextBoxType needs to be set correctly')
+  }
+
+  const onShowDetailsTouched = () => {
+    setShowDetails(true)
   }
 
   return (
@@ -167,12 +178,20 @@ const InfoBox: React.FC<BifoldErrorProps> = ({
       </View>
       <View style={styles.bodyContainer}>
         <Text style={styles.bodyText} testID={testIdWithKey('BodyText')}>
-          {message}
+          {showDetails ? message : description}
         </Text>
-        {code && (
-          <Text style={[styles.bodyText, { marginTop: 0, marginBottom: 24 }]} testID={testIdWithKey('ErrorCode')}>{`${t(
-            'Global.ErrorCode'
-          )} ${code}`}</Text>
+        {message && !showDetails && (
+          <TouchableOpacity
+            accessibilityLabel={t('Global.ShowDetails')}
+            testID={testIdWithKey('ShowDetails')}
+            style={{ marginVertical: 14 }}
+            onPress={onShowDetailsTouched}
+          >
+            <View style={{ flexDirection: 'row' }}>
+              <Text style={styles.showDetailsText}>{t('Global.ShowDetails')} </Text>
+              <Icon name="chevron-right" size={iconSize} color={ColorPallet.brand.link} />
+            </View>
+          </TouchableOpacity>
         )}
         {onCallToActionPressed && (
           <Button

--- a/core/App/components/modals/ErrorModal.tsx
+++ b/core/App/components/modals/ErrorModal.tsx
@@ -1,14 +1,14 @@
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Dimensions, Modal, StyleSheet } from 'react-native'
+import { Dimensions, Modal, StyleSheet, StatusBar } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
+import { BifoldError } from '../../../lib/commonjs/types/error'
 import { useStore } from '../../contexts/store'
 import { useTheme } from '../../contexts/theme'
 import InfoBox, { InfoBoxType } from '../misc/InfoBox'
 
 const { height } = Dimensions.get('window')
-const genericErrorCode = 1024
 
 const ErrorModal: React.FC = () => {
   const { t } = useTranslation()
@@ -27,8 +27,9 @@ const ErrorModal: React.FC = () => {
       backgroundColor: ColorPallet.brand.primaryBackground,
     },
   })
+
   useEffect(() => {
-    if (state.error && state.error.title && state.error.message && state.error.code) {
+    if (state.error && state.error.title && state.error.message) {
       setModalVisible(true)
 
       return
@@ -37,14 +38,23 @@ const ErrorModal: React.FC = () => {
     setModalVisible(false)
   }, [state])
 
+  const formattedMessageForError = (err: BifoldError | null): string | undefined => {
+    if (!err) {
+      return undefined
+    }
+
+    return `${t('Error.ErrorCode')} ${err.code} - ${err.message}`
+  }
+
   return (
     <Modal visible={modalVisible} transparent={true}>
+      <StatusBar hidden={true} />
       <SafeAreaView style={[styles.container]}>
         <InfoBox
           notificationType={InfoBoxType.Error}
           title={state.error ? state.error.title : t('Error.Unknown')}
-          message={state.error ? state.error.message : t('Error.Problem')}
-          code={state.error ? state.error.code : genericErrorCode}
+          description={state.error ? state.error.description : t('Error.Problem')}
+          message={formattedMessageForError(state.error)}
           onCallToActionPressed={onDismissModalTouched}
         />
       </SafeAreaView>

--- a/core/App/localization/en/index.ts
+++ b/core/App/localization/en/index.ts
@@ -27,7 +27,8 @@ const translation = {
     "Okay": "Okay",
     "GoBack": "Go Back",
     "GetStarted": "Get Started",
-    "Dismiss": "Dismiss"
+    "Dismiss": "Dismiss",
+    "ShowDetails": "Show Details",
   },
   "Language": {
     "English": "English",
@@ -36,6 +37,7 @@ const translation = {
   "Error": {
     "Unknown": "Unknown Error",
     "Problem": "A problem has occurred",
+    "ErrorCode": "Error code",
   },
   "StatusMessages": {
     "InitAgent": "Initializing agent .."

--- a/core/App/localization/fr/index.ts
+++ b/core/App/localization/fr/index.ts
@@ -27,7 +27,8 @@ const translation = {
         "Okay": "Ok",
         "GoBack": "Retour",
         "GetStarted": "Commencer",
-        "Dismiss": "Rejeter"
+        "Dismiss": "Rejeter",
+        "ShowDetails": "Show Details",
     },
     "Language": {
         "English": "Anglais",
@@ -35,7 +36,8 @@ const translation = {
     },
     "Error": {
         "Unknown": "Erreur inconnue",
-        "Problem": "Un problème est survenu"
+        "Problem": "Un problème est survenu",
+        "ErrorCode": "Error code",
     },
     "StatusMessages": {
         "InitAgent": "Initialisation de l'agent ..."

--- a/core/App/localization/fr/index.ts
+++ b/core/App/localization/fr/index.ts
@@ -28,7 +28,7 @@ const translation = {
         "GoBack": "Retour",
         "GetStarted": "Commencer",
         "Dismiss": "Rejeter",
-        "ShowDetails": "Show Details",
+        "ShowDetails": "Afficher les détails",
     },
     "Language": {
         "English": "Anglais",
@@ -37,7 +37,7 @@ const translation = {
     "Error": {
         "Unknown": "Erreur inconnue",
         "Problem": "Un problème est survenu",
-        "ErrorCode": "Error code",
+        "ErrorCode": "Code d'erreur",
     },
     "StatusMessages": {
         "InitAgent": "Initialisation de l'agent ..."

--- a/core/App/screens/CredentialDetails.tsx
+++ b/core/App/screens/CredentialDetails.tsx
@@ -104,7 +104,7 @@ const CredentialDetails: React.FC<CredentialDetailsProps> = ({ navigation, route
               <InfoBox
                 notificationType={InfoBoxType.Warn}
                 title={t('CredentialDetails.CredentialRevokedMessageTitle')}
-                message={t('CredentialDetails.CredentialRevokedMessageBody')}
+                description={t('CredentialDetails.CredentialRevokedMessageBody')}
                 onCallToActionLabel={t('Global.Dismiss')}
                 onCallToActionPressed={() => dismissRevokedMessage(credential)}
               />

--- a/core/App/screens/CredentialOffer.tsx
+++ b/core/App/screens/CredentialOffer.tsx
@@ -96,7 +96,7 @@ const CredentialOffer: React.FC<CredentialOfferProps> = ({ route }) => {
       const error = new BifoldError(
         'Unable to reject offer',
         'There was a problem while rejecting the credential offer.',
-        1024
+        1025
       )
       dispatch({
         type: DispatchAction.ERROR_ADDED,

--- a/core/App/screens/CredentialOffer.tsx
+++ b/core/App/screens/CredentialOffer.tsx
@@ -1,3 +1,4 @@
+import { AriesFrameworkError } from '@aries-framework/core'
 import { useAgent, useCredentialById } from '@aries-framework/react-hooks'
 import { StackScreenProps } from '@react-navigation/stack'
 import React, { useState } from 'react'
@@ -66,11 +67,12 @@ const CredentialOffer: React.FC<CredentialOfferProps> = ({ route }) => {
       setAcceptModalVisible(true)
 
       await agent.credentials.acceptOffer(credential.id)
-    } catch (e: unknown) {
+    } catch (err: unknown) {
       setButtonsVisible(true)
       const error = new BifoldError(
         'Unable to accept offer',
         'There was a problem while accepting the credential offer.',
+        (err as Error).message,
         1024
       )
       dispatch({
@@ -92,12 +94,14 @@ const CredentialOffer: React.FC<CredentialOfferProps> = ({ route }) => {
     try {
       await agent.credentials.declineOffer(credential.id)
       setDidDeclineOffer(true)
-    } catch (e: unknown) {
+    } catch (err: unknown) {
       const error = new BifoldError(
         'Unable to reject offer',
         'There was a problem while rejecting the credential offer.',
+        (err as Error).message,
         1025
       )
+
       dispatch({
         type: DispatchAction.ERROR_ADDED,
         payload: [{ error }],

--- a/core/App/screens/CredentialOfferDecline.tsx
+++ b/core/App/screens/CredentialOfferDecline.tsx
@@ -86,7 +86,7 @@ const CredentialOfferDecline: React.FC<CredentialOfferDeclineProps> = ({
               <InfoBox
                 notificationType={InfoBoxType.Warn}
                 title={t('CredentialOffer.ConfirmDeclinedTitle')}
-                message={t('CredentialOffer.ConfirmDeclinedMessage')}
+                description={t('CredentialOffer.ConfirmDeclinedMessage')}
               />
               <CredentialCard credential={credential} style={{ marginVertical: 25 }} />
               <View>

--- a/core/App/screens/ProofRequest.tsx
+++ b/core/App/screens/ProofRequest.tsx
@@ -141,10 +141,11 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
         setAttributes(attributes)
         setPredicates(predicates)
       })
-      .catch(() => {
+      .catch((err: unknown) => {
         const error = new BifoldError(
           'Unable to update retrieved credentials',
           'There was a problem while updating retrieved credentials.',
+          (err as Error).message,
           1026
         )
         dispatch({
@@ -204,12 +205,14 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
         throw new Error(t('ProofRequest.RequestedCredentialsCouldNotBeFound'))
       }
       await agent.proofs.acceptRequest(proof.id, automaticRequestedCreds)
-    } catch (e: unknown) {
+    } catch (err: unknown) {
       setButtonsVisible(true)
       setPendingModalVisible(false)
+
       const error = new BifoldError(
         'Unable to accept proof request',
         'There was a problem while accepting the proof request.',
+        (err as Error).message,
         1027
       )
       dispatch({
@@ -231,10 +234,11 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
     try {
       await agent.proofs.declineRequest(proof.id)
       setDidDeclineProofRequest(true)
-    } catch (e: unknown) {
+    } catch (err: unknown) {
       const error = new BifoldError(
         'Unable to reject offer',
         'There was a problem while rejecting the credential offer.',
+        (err as Error).message,
         1028
       )
       dispatch({

--- a/core/App/screens/ProofRequest.tsx
+++ b/core/App/screens/ProofRequest.tsx
@@ -210,7 +210,7 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
       const error = new BifoldError(
         'Unable to accept proof request',
         'There was a problem while accepting the proof request.',
-        1025
+        1027
       )
       dispatch({
         type: DispatchAction.ERROR_ADDED,
@@ -235,7 +235,7 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
       const error = new BifoldError(
         'Unable to reject offer',
         'There was a problem while rejecting the credential offer.',
-        1024
+        1028
       )
       dispatch({
         type: DispatchAction.ERROR_ADDED,

--- a/core/App/screens/ProofRequestAttributeDetails.tsx
+++ b/core/App/screens/ProofRequestAttributeDetails.tsx
@@ -73,10 +73,11 @@ const ProofRequestAttributeDetails: React.FC<ProofRequestAttributeDetailsProps> 
       .then((credentials) => {
         setCredentials(credentials)
       })
-      .catch(() => {
+      .catch((err: unknown) => {
         const error = new BifoldError(
           'Unable to update retrieved credentials',
           'There was a problem while updating retrieved credentials.',
+          (err as Error).message,
           1029
         )
         dispatch({

--- a/core/App/screens/ProofRequestAttributeDetails.tsx
+++ b/core/App/screens/ProofRequestAttributeDetails.tsx
@@ -77,7 +77,7 @@ const ProofRequestAttributeDetails: React.FC<ProofRequestAttributeDetailsProps> 
         const error = new BifoldError(
           'Unable to update retrieved credentials',
           'There was a problem while updating retrieved credentials.',
-          1026
+          1029
         )
         dispatch({
           type: DispatchAction.ERROR_ADDED,

--- a/core/App/screens/ProofRequestDeclined.tsx
+++ b/core/App/screens/ProofRequestDeclined.tsx
@@ -85,7 +85,7 @@ const ProofRequestDeclined: React.FC<ProofRequestDeclinedProps> = ({
               <InfoBox
                 notificationType={InfoBoxType.Warn}
                 title={t('ProofRequest.ConfirmDeclinedTitle')}
-                message={t('ProofRequest.ConfirmDeclinedMessage')}
+                description={t('ProofRequest.ConfirmDeclinedMessage')}
               />
               <View style={{ marginVertical: 25 }}>
                 <Button

--- a/core/App/screens/Scan.tsx
+++ b/core/App/screens/Scan.tsx
@@ -3,12 +3,12 @@ import type { BarCodeReadEvent } from 'react-native-camera'
 import { Agent } from '@aries-framework/core'
 import { useAgent } from '@aries-framework/react-hooks'
 import { StackScreenProps } from '@react-navigation/stack'
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import QRScanner from '../components/misc/QRScanner'
 import { BifoldError, QrCodeScanError } from '../types/error'
-import { ConnectStackParams, Screens, Stacks, TabStacks } from '../types/navigators'
+import { ConnectStackParams, Screens, Stacks } from '../types/navigators'
 import { isRedirection } from '../utils/helpers'
 
 type ScanProps = StackScreenProps<ConnectStackParams>
@@ -34,7 +34,7 @@ const Scan: React.FC<ScanProps> = ({ navigation }) => {
       const error = new BifoldError(
         'Unable to accept connection',
         'There was a problem while accepting the connection redirection',
-        1024.1
+        1030
       )
       throw error
     }
@@ -49,10 +49,10 @@ const Scan: React.FC<ScanProps> = ({ navigation }) => {
         throw new BifoldError(
           'Unable to accept connection',
           'There was a problem while accepting the connection.',
-          1024.2
+          1031
         )
       }
-      //setConnectionId(connectionRecord.id)
+
       navigation.getParent()?.navigate(Stacks.ConnectionStack, {
         screen: Screens.Connection,
         params: { connectionId: connectionRecord.id },
@@ -61,7 +61,7 @@ const Scan: React.FC<ScanProps> = ({ navigation }) => {
       const error = new BifoldError(
         'Unable to accept connection',
         'There was a problem while accepting the connection.',
-        1024
+        1032
       )
       throw error
     }

--- a/core/App/screens/Scan.tsx
+++ b/core/App/screens/Scan.tsx
@@ -34,6 +34,7 @@ const Scan: React.FC<ScanProps> = ({ navigation }) => {
       const error = new BifoldError(
         'Unable to accept connection',
         'There was a problem while accepting the connection redirection',
+        (err as Error).message,
         1030
       )
       throw error
@@ -45,23 +46,21 @@ const Scan: React.FC<ScanProps> = ({ navigation }) => {
       const connectionRecord = await agent?.connections.receiveInvitationFromUrl(url, {
         autoAcceptConnection: true,
       })
+
       if (!connectionRecord?.id) {
-        throw new BifoldError(
-          'Unable to accept connection',
-          'There was a problem while accepting the connection.',
-          1031
-        )
+        throw new Error('Connection does not have an ID')
       }
 
       navigation.getParent()?.navigate(Stacks.ConnectionStack, {
         screen: Screens.Connection,
         params: { connectionId: connectionRecord.id },
       })
-    } catch (err) {
+    } catch (err: unknown) {
       const error = new BifoldError(
         'Unable to accept connection',
         'There was a problem while accepting the connection.',
-        1032
+        (err as Error).message,
+        1031
       )
       throw error
     }

--- a/core/App/types/error.ts
+++ b/core/App/types/error.ts
@@ -9,10 +9,13 @@ export class QrCodeScanError extends Error {
 export class BifoldError extends Error {
   public title: string
   public code: number
+  public description: string
 
-  public constructor(title: string, message: string, code: number) {
+  public constructor(title: string, description: string, message: string, code: number) {
     super(message)
+
     this.title = title
+    this.description = description
     this.code = code
 
     // Set the prototype explicitly.

--- a/core/__tests__/components/__snapshots__/ErrorModal.test.tsx.snap
+++ b/core/__tests__/components/__snapshots__/ErrorModal.test.tsx.snap
@@ -110,26 +110,6 @@ exports[`ErrorModal Component Dismiss on demand 1`] = `
         >
           Error.Problem
         </Text>
-        <Text
-          style={
-            Array [
-              Object {
-                "color": "#FFFFFF",
-                "flexShrink": 1,
-                "fontSize": 18,
-                "fontWeight": "normal",
-                "marginVertical": 16,
-              },
-              Object {
-                "marginBottom": 24,
-                "marginTop": 0,
-              },
-            ]
-          }
-          testID="com.ariesbifold:id/ErrorCode"
-        >
-          Global.ErrorCode 1024
-        </Text>
         <View
           accessibilityLabel="Global.Okay"
           accessibilityState={
@@ -289,26 +269,6 @@ exports[`ErrorModal Component Renders correctly 1`] = `
           testID="com.ariesbifold:id/BodyText"
         >
           Error.Problem
-        </Text>
-        <Text
-          style={
-            Array [
-              Object {
-                "color": "#FFFFFF",
-                "flexShrink": 1,
-                "fontSize": 18,
-                "fontWeight": "normal",
-                "marginVertical": 16,
-              },
-              Object {
-                "marginBottom": 24,
-                "marginTop": 0,
-              },
-            ]
-          }
-          testID="com.ariesbifold:id/ErrorCode"
-        >
-          Global.ErrorCode 1024
         </Text>
         <View
           accessibilityLabel="Global.Okay"

--- a/core/__tests__/components/__snapshots__/InfoBox.test.tsx.snap
+++ b/core/__tests__/components/__snapshots__/InfoBox.test.tsx.snap
@@ -89,29 +89,70 @@ exports[`ErrorModal Component Renders correctly as Error 1`] = `
         }
       }
       testID="com.ariesbifold:id/BodyText"
+    />
+    <RNGestureHandlerButton
+      collapsable={false}
+      onGestureEvent={[Function]}
+      onGestureHandlerEvent={[Function]}
+      onGestureHandlerStateChange={[Function]}
+      onHandlerStateChange={[Function]}
+      rippleColor={0}
+      testID="com.ariesbifold:id/ShowDetails"
     >
-      The quick brown fox jumped over the lazy dog.
-    </Text>
-    <Text
-      style={
-        Array [
+      <View
+        accessibilityLabel="Global.ShowDetails"
+        accessible={true}
+        collapsable={false}
+        nativeID="animatedComponent"
+        style={
           Object {
-            "color": "#FFFFFF",
-            "flexShrink": 1,
-            "fontSize": 18,
-            "fontWeight": "normal",
-            "marginVertical": 16,
-          },
-          Object {
-            "marginBottom": 24,
-            "marginTop": 0,
-          },
-        ]
-      }
-      testID="com.ariesbifold:id/ErrorCode"
-    >
-      Global.ErrorCode 1024
-    </Text>
+            "marginVertical": 14,
+            "opacity": 1,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 20,
+                "fontWeight": "normal",
+              }
+            }
+          >
+            Global.ShowDetails
+             
+          </Text>
+          <Text
+            allowFontScaling={false}
+            style={
+              Array [
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 30,
+                },
+                undefined,
+                Object {
+                  "fontFamily": "Material Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+        </View>
+      </View>
+    </RNGestureHandlerButton>
     <View
       accessibilityLabel="Global.Okay"
       accessibilityState={
@@ -249,29 +290,70 @@ exports[`ErrorModal Component Renders correctly as Info 1`] = `
         }
       }
       testID="com.ariesbifold:id/BodyText"
+    />
+    <RNGestureHandlerButton
+      collapsable={false}
+      onGestureEvent={[Function]}
+      onGestureHandlerEvent={[Function]}
+      onGestureHandlerStateChange={[Function]}
+      onHandlerStateChange={[Function]}
+      rippleColor={0}
+      testID="com.ariesbifold:id/ShowDetails"
     >
-      The quick brown fox jumped over the lazy dog.
-    </Text>
-    <Text
-      style={
-        Array [
+      <View
+        accessibilityLabel="Global.ShowDetails"
+        accessible={true}
+        collapsable={false}
+        nativeID="animatedComponent"
+        style={
           Object {
-            "color": "#FFFFFF",
-            "flexShrink": 1,
-            "fontSize": 18,
-            "fontWeight": "normal",
-            "marginVertical": 16,
-          },
-          Object {
-            "marginBottom": 24,
-            "marginTop": 0,
-          },
-        ]
-      }
-      testID="com.ariesbifold:id/ErrorCode"
-    >
-      Global.ErrorCode 1024
-    </Text>
+            "marginVertical": 14,
+            "opacity": 1,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 20,
+                "fontWeight": "normal",
+              }
+            }
+          >
+            Global.ShowDetails
+             
+          </Text>
+          <Text
+            allowFontScaling={false}
+            style={
+              Array [
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 30,
+                },
+                undefined,
+                Object {
+                  "fontFamily": "Material Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+        </View>
+      </View>
+    </RNGestureHandlerButton>
     <View
       accessibilityLabel="Global.Okay"
       accessibilityState={
@@ -409,29 +491,70 @@ exports[`ErrorModal Component Renders correctly as Success 1`] = `
         }
       }
       testID="com.ariesbifold:id/BodyText"
+    />
+    <RNGestureHandlerButton
+      collapsable={false}
+      onGestureEvent={[Function]}
+      onGestureHandlerEvent={[Function]}
+      onGestureHandlerStateChange={[Function]}
+      onHandlerStateChange={[Function]}
+      rippleColor={0}
+      testID="com.ariesbifold:id/ShowDetails"
     >
-      The quick brown fox jumped over the lazy dog.
-    </Text>
-    <Text
-      style={
-        Array [
+      <View
+        accessibilityLabel="Global.ShowDetails"
+        accessible={true}
+        collapsable={false}
+        nativeID="animatedComponent"
+        style={
           Object {
-            "color": "#FFFFFF",
-            "flexShrink": 1,
-            "fontSize": 18,
-            "fontWeight": "normal",
-            "marginVertical": 16,
-          },
-          Object {
-            "marginBottom": 24,
-            "marginTop": 0,
-          },
-        ]
-      }
-      testID="com.ariesbifold:id/ErrorCode"
-    >
-      Global.ErrorCode 1024
-    </Text>
+            "marginVertical": 14,
+            "opacity": 1,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 20,
+                "fontWeight": "normal",
+              }
+            }
+          >
+            Global.ShowDetails
+             
+          </Text>
+          <Text
+            allowFontScaling={false}
+            style={
+              Array [
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 30,
+                },
+                undefined,
+                Object {
+                  "fontFamily": "Material Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+        </View>
+      </View>
+    </RNGestureHandlerButton>
     <View
       accessibilityLabel="Global.Okay"
       accessibilityState={
@@ -569,29 +692,70 @@ exports[`ErrorModal Component Renders correctly as Warning 1`] = `
         }
       }
       testID="com.ariesbifold:id/BodyText"
+    />
+    <RNGestureHandlerButton
+      collapsable={false}
+      onGestureEvent={[Function]}
+      onGestureHandlerEvent={[Function]}
+      onGestureHandlerStateChange={[Function]}
+      onHandlerStateChange={[Function]}
+      rippleColor={0}
+      testID="com.ariesbifold:id/ShowDetails"
     >
-      The quick brown fox jumped over the lazy dog.
-    </Text>
-    <Text
-      style={
-        Array [
+      <View
+        accessibilityLabel="Global.ShowDetails"
+        accessible={true}
+        collapsable={false}
+        nativeID="animatedComponent"
+        style={
           Object {
-            "color": "#FFFFFF",
-            "flexShrink": 1,
-            "fontSize": 18,
-            "fontWeight": "normal",
-            "marginVertical": 16,
-          },
-          Object {
-            "marginBottom": 24,
-            "marginTop": 0,
-          },
-        ]
-      }
-      testID="com.ariesbifold:id/ErrorCode"
-    >
-      Global.ErrorCode 1024
-    </Text>
+            "marginVertical": 14,
+            "opacity": 1,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 20,
+                "fontWeight": "normal",
+              }
+            }
+          >
+            Global.ShowDetails
+             
+          </Text>
+          <Text
+            allowFontScaling={false}
+            style={
+              Array [
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 30,
+                },
+                undefined,
+                Object {
+                  "fontFamily": "Material Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+        </View>
+      </View>
+    </RNGestureHandlerButton>
     <View
       accessibilityLabel="Global.Okay"
       accessibilityState={


### PR DESCRIPTION
# Summary of Changes

Allow `BifoldError` to show a technical message to help debugging as desired by the user.

# Related Issues

n/a

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
