### PR TITLE
fix: update credential card title

### DIFF
--- a/core/App/components/misc/CredentialCard.tsx
+++ b/core/App/components/misc/CredentialCard.tsx
@@ -8,7 +8,7 @@ import Icon from 'react-native-vector-icons/MaterialIcons'
 import { dateFormatOptions } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 import { GenericFn } from '../../types/fn'
-import { parsedSchema } from '../../utils/helpers'
+import { parsedCredDefName, parsedSchema } from '../../utils/helpers'
 import { testIdWithKey } from '../../utils/testable'
 
 import AvatarView from './AvatarView'
@@ -51,7 +51,7 @@ const CredentialCard: React.FC<CredentialCardProps> = ({
     >
       <View style={styles.row} testID={testIdWithKey('CredentialCard')}>
         <AvatarView
-          name={parsedSchema(credential).name}
+          name={parsedCredDefName(credential)}
           style={
             revoked
               ? { borderColor: ListItems.revoked.borderColor, backgroundColor: ColorPallet.brand.primaryBackground }
@@ -60,7 +60,7 @@ const CredentialCard: React.FC<CredentialCardProps> = ({
         />
         <View style={styles.details}>
           <Text style={ListItems.credentialTitle} testID={testIdWithKey('CredentialName')}>
-            {parsedSchema(credential).name}
+            {parsedCredDefName(credential)}
           </Text>
           <Text style={ListItems.credentialDetails} testID={testIdWithKey('CredentialVersion')}>
             {t('CredentialDetails.Version')}: {parsedSchema(credential).version}

--- a/core/App/utils/cred-def.ts
+++ b/core/App/utils/cred-def.ts
@@ -1,0 +1,31 @@
+import { CredentialMetadataKeys, CredentialExchangeRecord as CredentialRecord } from '@aries-framework/core'
+
+import { parsedSchema } from './schema'
+
+function parseCredDefName(credDefId?: string): string {
+  let name = 'Credential'
+  if (credDefId) {
+    const credDefRegex = /[^:]+/g
+    const credDefIdParts = credDefId.match(credDefRegex)
+    if (credDefIdParts?.length === 5) {
+      name = `${credDefIdParts?.[4].replace(/_|-/g, ' ')}`
+        .split(' ')
+        .map((credIdPart) => credIdPart.charAt(0).toUpperCase() + credIdPart.substring(1))
+        .join(' ')
+    }
+  }
+  return name
+}
+
+function credentialDefinition(credential: CredentialRecord): string | undefined {
+  return credential.metadata.get(CredentialMetadataKeys.IndyCredential)?.credentialDefinitionId
+}
+
+export function parsedCredDefName(credential: CredentialRecord): string {
+  let credDefName = parseCredDefName(credentialDefinition(credential))
+  // if credDef name is `default` or `credential` use schema name instead
+  if (credDefName.toLocaleLowerCase() === 'default' || credDefName.toLowerCase() === 'credential') {
+    credDefName = parsedSchema(credential).name
+  }
+  return credDefName
+}

--- a/core/App/utils/helpers.ts
+++ b/core/App/utils/helpers.ts
@@ -1,6 +1,5 @@
 import {
   ConnectionRecord,
-  CredentialMetadataKeys,
   CredentialExchangeRecord as CredentialRecord,
   ProofRecord,
   RequestedAttribute,
@@ -12,58 +11,8 @@ import { parseUrl } from 'query-string'
 
 import { Attribute, Predicate } from '../types/record'
 
-export function parseCredDefName(credDefId?: string): string {
-  let name = 'Credential'
-  if (credDefId) {
-    const credDefRegex = /[^:]+/g
-    const credDefIdParts = credDefId.match(credDefRegex)
-    if (credDefIdParts?.length === 5) {
-      name = `${credDefIdParts?.[4].replace(/_|-/g, ' ')}`
-        .split(' ')
-        .map((credIdPart) => credIdPart.charAt(0).toUpperCase() + credIdPart.substring(1))
-        .join(' ')
-    }
-  }
-  return name
-}
-
-export function credentialDefinition(credential: CredentialRecord): string | undefined {
-  return credential.metadata.get(CredentialMetadataKeys.IndyCredential)?.credentialDefinitionId
-}
-
-export function parsedCredDefName(credential: CredentialRecord): string {
-  let credDefName = parseCredDefName(credentialDefinition(credential))
-  // if credDef name is `default` use schema name instead
-  if (credDefName === 'default' || credDefName === 'Default') {
-    credDefName = parsedSchema(credential).name
-  }
-  return credDefName
-}
-
-export function parseSchema(schemaId?: string): { name: string; version: string } {
-  let name = 'Credential'
-  let version = ''
-  if (schemaId) {
-    const schemaIdRegex = /(.*?):([0-9]):([a-zA-Z .\-_0-9]+):([a-z0-9._-]+)$/
-    const schemaIdParts = schemaId.match(schemaIdRegex)
-    if (schemaIdParts?.length === 5) {
-      name = `${schemaIdParts?.[3].replace(/_|-/g, ' ')}`
-        .split(' ')
-        .map((schemaIdPart) => schemaIdPart.charAt(0).toUpperCase() + schemaIdPart.substring(1))
-        .join(' ')
-      version = schemaIdParts?.[4]
-    }
-  }
-  return { name, version }
-}
-
-export function credentialSchema(credential: CredentialRecord): string | undefined {
-  return credential.metadata.get(CredentialMetadataKeys.IndyCredential)?.schemaId
-}
-
-export function parsedSchema(credential: CredentialRecord): { name: string; version: string } {
-  return parseSchema(credentialSchema(credential))
-}
+export { parsedCredDefName } from './cred-def'
+export { parsedSchema } from './schema'
 
 /**
  * Adapted from https://stackoverflow.com/questions/3426404/create-a-hexadecimal-colour-based-on-a-string-with-javascript

--- a/core/App/utils/helpers.ts
+++ b/core/App/utils/helpers.ts
@@ -12,6 +12,21 @@ import { parseUrl } from 'query-string'
 
 import { Attribute, Predicate } from '../types/record'
 
+export function parseCredDefName(credDefId?: string): string {
+  let name = 'Credential'
+  if (credDefId) {
+    const credDefRegex = /[^:]+/g
+    const credDefIdParts = credDefId.match(credDefRegex)
+    if (credDefIdParts?.length === 5) {
+      name = `${credDefIdParts?.[4].replace(/_|-/g, ' ')}`
+        .split(' ')
+        .map((credIdPart) => credIdPart.charAt(0).toUpperCase() + credIdPart.substring(1))
+        .join(' ')
+    }
+  }
+  return name
+}
+
 export function parseSchema(schemaId?: string): { name: string; version: string } {
   let name = 'Credential'
   let version = ''
@@ -27,6 +42,14 @@ export function parseSchema(schemaId?: string): { name: string; version: string 
     }
   }
   return { name, version }
+}
+
+export function credentialDefenition(credential: CredentialRecord): string | undefined {
+  return credential.metadata.get(CredentialMetadataKeys.IndyCredential)?.credentialDefinitionId
+}
+
+export function parsedCredDefName(credential: CredentialRecord): string {
+  return parseCredDefName(credentialDefenition(credential))
 }
 
 export function credentialSchema(credential: CredentialRecord): string | undefined {

--- a/core/App/utils/helpers.ts
+++ b/core/App/utils/helpers.ts
@@ -27,6 +27,19 @@ export function parseCredDefName(credDefId?: string): string {
   return name
 }
 
+export function credentialDefinition(credential: CredentialRecord): string | undefined {
+  return credential.metadata.get(CredentialMetadataKeys.IndyCredential)?.credentialDefinitionId
+}
+
+export function parsedCredDefName(credential: CredentialRecord): string {
+  let credDefName = parseCredDefName(credentialDefinition(credential))
+  // if credDef name is `default` use schema name instead
+  if (credDefName === 'default' || credDefName === 'Default') {
+    credDefName = parsedSchema(credential).name
+  }
+  return credDefName
+}
+
 export function parseSchema(schemaId?: string): { name: string; version: string } {
   let name = 'Credential'
   let version = ''
@@ -42,19 +55,6 @@ export function parseSchema(schemaId?: string): { name: string; version: string 
     }
   }
   return { name, version }
-}
-
-export function credentialDefinition(credential: CredentialRecord): string | undefined {
-  return credential.metadata.get(CredentialMetadataKeys.IndyCredential)?.credentialDefinitionId
-}
-
-export function parsedCredDefName(credential: CredentialRecord): string {
-  let credDefName = parseCredDefName(credentialDefinition(credential))
-  // if credDef name is `default` use schema name instead
-  if (credDefName === 'default' || credDefName === 'Default') {
-    credDefName = parsedSchema(credential).name
-  }
-  return credDefName
 }
 
 export function credentialSchema(credential: CredentialRecord): string | undefined {

--- a/core/App/utils/helpers.ts
+++ b/core/App/utils/helpers.ts
@@ -44,12 +44,17 @@ export function parseSchema(schemaId?: string): { name: string; version: string 
   return { name, version }
 }
 
-export function credentialDefenition(credential: CredentialRecord): string | undefined {
+export function credentialDefinition(credential: CredentialRecord): string | undefined {
   return credential.metadata.get(CredentialMetadataKeys.IndyCredential)?.credentialDefinitionId
 }
 
 export function parsedCredDefName(credential: CredentialRecord): string {
-  return parseCredDefName(credentialDefenition(credential))
+  let credDefName = parseCredDefName(credentialDefinition(credential))
+  // if credDef name is `default` use schema name instead
+  if (credDefName === 'default' || credDefName === 'Default') {
+    credDefName = parsedSchema(credential).name
+  }
+  return credDefName
 }
 
 export function credentialSchema(credential: CredentialRecord): string | undefined {

--- a/core/App/utils/schema.ts
+++ b/core/App/utils/schema.ts
@@ -1,0 +1,26 @@
+import { CredentialMetadataKeys, CredentialExchangeRecord as CredentialRecord } from '@aries-framework/core'
+
+function parseSchema(schemaId?: string): { name: string; version: string } {
+  let name = 'Credential'
+  let version = ''
+  if (schemaId) {
+    const schemaIdRegex = /(.*?):([0-9]):([a-zA-Z .\-_0-9]+):([a-z0-9._-]+)$/
+    const schemaIdParts = schemaId.match(schemaIdRegex)
+    if (schemaIdParts?.length === 5) {
+      name = `${schemaIdParts?.[3].replace(/_|-/g, ' ')}`
+        .split(' ')
+        .map((schemaIdPart) => schemaIdPart.charAt(0).toUpperCase() + schemaIdPart.substring(1))
+        .join(' ')
+      version = schemaIdParts?.[4]
+    }
+  }
+  return { name, version }
+}
+
+function credentialSchema(credential: CredentialRecord): string | undefined {
+  return credential.metadata.get(CredentialMetadataKeys.IndyCredential)?.schemaId
+}
+
+export function parsedSchema(credential: CredentialRecord): { name: string; version: string } {
+  return parseSchema(credentialSchema(credential))
+}


### PR DESCRIPTION
# Summary of Changes

Changed the credential card title to use the credential definition name instead of the schema name. If the credential definition name is `default` or `Default` then the credential card title will revert to using the schema name instead.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
