### PR TITLE
feat: add camera disclosure notification

### DIFF
--- a/core/App/constants.ts
+++ b/core/App/constants.ts
@@ -6,6 +6,7 @@ export const testIdPrefix = 'com.ariesbifold:id/'
 
 export enum LocalStorageKeys {
   Onboarding = 'OnboardingState',
+  Privacy = 'PrivacyState',
   // FIXME: Once hooks are updated this should no longer be necessary
   RevokedCredentials = 'RevokedCredentials',
   RevokedCredentialsMessageDismissed = 'RevokedCredentialsMessageDismissed',

--- a/core/App/contexts/reducers/store.ts
+++ b/core/App/contexts/reducers/store.ts
@@ -1,7 +1,12 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 
 import { LocalStorageKeys } from '../../constants'
-import { Onboarding as OnboardingState, Credential as CredentialState, State } from '../../types/state'
+import {
+  Privacy as PrivacyState,
+  Onboarding as OnboardingState,
+  Credential as CredentialState,
+  State,
+} from '../../types/state'
 
 enum OnboardingDispatchAction {
   ONBOARDING_UPDATED = 'onboarding/onboardingStateLoaded',
@@ -27,17 +32,24 @@ enum LoadingDispatchAction {
   LOADING_DISABLED = 'loading/loadingDisabled',
 }
 
+enum PrivacyDispatchAction {
+  DID_SHOW_CAMERA_DISCLOSURE = 'privacy/didShowCameraDisclosure',
+  PRIVACY_UPDATED = 'privacy/privacyStateLoaded',
+}
+
 export type DispatchAction =
   | OnboardingDispatchAction
   | ErrorDispatchAction
   | CredentialDispatchAction
   | LoadingDispatchAction
+  | PrivacyDispatchAction
 
 export const DispatchAction = {
   ...OnboardingDispatchAction,
   ...ErrorDispatchAction,
   ...CredentialDispatchAction,
   ...LoadingDispatchAction,
+  ...PrivacyDispatchAction,
 }
 
 export interface ReducerAction {
@@ -47,6 +59,23 @@ export interface ReducerAction {
 
 const reducer = (state: State, action: ReducerAction): State => {
   switch (action.type) {
+    case PrivacyDispatchAction.DID_SHOW_CAMERA_DISCLOSURE: {
+      const newState = {
+        ...state,
+        ...{ privacy: { didShowCameraDisclosure: true } },
+      }
+
+      AsyncStorage.setItem(LocalStorageKeys.Privacy, JSON.stringify(newState.privacy))
+
+      return newState
+    }
+    case PrivacyDispatchAction.PRIVACY_UPDATED: {
+      const privacy: PrivacyState = (action?.payload || []).pop()
+      return {
+        ...state,
+        privacy,
+      }
+    }
     case OnboardingDispatchAction.ONBOARDING_UPDATED: {
       const onboarding: OnboardingState = (action?.payload || []).pop()
       return {

--- a/core/App/contexts/store.tsx
+++ b/core/App/contexts/store.tsx
@@ -18,6 +18,9 @@ const initialState: State = {
     revoked: new Set(),
     revokedMessageDismissed: new Set(),
   },
+  privacy: {
+    didShowCameraDisclosure: false,
+  },
   error: null,
   loading: false,
 }

--- a/core/App/index.ts
+++ b/core/App/index.ts
@@ -36,6 +36,7 @@ export type { StoreProviderProps } from './contexts/store'
 export type { Theme } from './theme'
 export type { ConfigurationContext } from './contexts/configuration'
 export type { Onboarding as OnboardingState } from './types/state'
+export type { Privacy as PrivacyState } from './types/state'
 export type { GenericFn } from './types/fn'
 export type { AuthenticateStackParams } from './types/navigators'
 export type { OnboardingStyleSheet }

--- a/core/App/localization/en/index.ts
+++ b/core/App/localization/en/index.ts
@@ -67,6 +67,10 @@ const translation = {
     "IAgree": "I Agree",
     "Attestation": "I have read, understand and accept the terms and conditions.",
   },
+  "PrivacyPolicy": {
+    "Title": "Privacy Policy",
+    "CameraDisclosure": "The camera is used to scan QR Codes for immediate on-device processing. No information about the images is stored, used for analytics, or shared.",
+  },
   "PinCreate": {
     "UserAuthenticationPIN": "User authentication PIN",
     "PINTooShort": "PIN too short",

--- a/core/App/screens/CameraDisclosure.tsx
+++ b/core/App/screens/CameraDisclosure.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+
+import InfoBox, { InfoBoxType } from '../components/misc/InfoBox'
+import { useTheme } from '../contexts/theme'
+import { GenericFn } from '../types/fn'
+
+interface CameraDisclosureProps {
+  didDismissCameraDisclosure: GenericFn
+}
+
+const CameraDisclosure: React.FC<CameraDisclosureProps> = ({ didDismissCameraDisclosure }) => {
+  const { t } = useTranslation()
+  const { ColorPallet } = useTheme()
+
+  const styles = StyleSheet.create({
+    container: {
+      flexGrow: 1,
+      backgroundColor: ColorPallet.brand.primary,
+      paddingHorizontal: 25,
+    },
+  })
+
+  return (
+    <SafeAreaView style={[styles.container]}>
+      <InfoBox
+        notificationType={InfoBoxType.Info}
+        title={t('PrivacyPolicy.Title')}
+        description={t('PrivacyPolicy.CameraDisclosure')}
+        onCallToActionLabel={t('Global.Okay')}
+        onCallToActionPressed={() => didDismissCameraDisclosure()}
+      />
+    </SafeAreaView>
+  )
+}
+
+export default CameraDisclosure

--- a/core/App/screens/Scan.tsx
+++ b/core/App/screens/Scan.tsx
@@ -2,8 +2,9 @@ import type { BarCodeReadEvent } from 'react-native-camera'
 
 import { Agent } from '@aries-framework/core'
 import { useAgent } from '@aries-framework/react-hooks'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import { StackScreenProps } from '@react-navigation/stack'
-import React, { useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import QRScanner from '../components/misc/QRScanner'
@@ -11,12 +12,17 @@ import { BifoldError, QrCodeScanError } from '../types/error'
 import { ConnectStackParams, Screens, Stacks } from '../types/navigators'
 import { isRedirection } from '../utils/helpers'
 
+import CameraDisclosure from './CameraDisclosure'
+
 type ScanProps = StackScreenProps<ConnectStackParams>
+
+const DidShowCameraDisclosureLocalStorageKey = 'DidShowCameraDisclosure'
 
 const Scan: React.FC<ScanProps> = ({ navigation }) => {
   const { agent } = useAgent()
   const { t } = useTranslation()
   const [qrCodeScanError, setQrCodeScanError] = useState<QrCodeScanError | null>(null)
+  const [didShowCameraDisclosure, setDidShowCameraDisclosure] = useState<boolean | null>()
 
   const handleRedirection = async (url: string, agent?: Agent): Promise<void> => {
     try {
@@ -35,6 +41,26 @@ const Scan: React.FC<ScanProps> = ({ navigation }) => {
       throw error
     }
   }
+
+  useMemo(async () => {
+    const data = await AsyncStorage.getItem(DidShowCameraDisclosureLocalStorageKey)
+    const record = data !== null ? JSON.parse(data) : null
+
+    setDidShowCameraDisclosure(record !== null ? record.didShowCameraDisclosure : false)
+  }, [])
+
+  useEffect(() => {
+    const saveDidShowCameraDisclosure = async () => {
+      await AsyncStorage.setItem(
+        DidShowCameraDisclosureLocalStorageKey,
+        JSON.stringify({ didShowCameraDisclosure: didShowCameraDisclosure })
+      )
+    }
+
+    saveDidShowCameraDisclosure().catch((err: unknown) => {
+      // console.log('Problem', err)
+    })
+  }, [didShowCameraDisclosure])
 
   const handleInvitation = async (url: string): Promise<void> => {
     try {
@@ -74,7 +100,17 @@ const Scan: React.FC<ScanProps> = ({ navigation }) => {
     }
   }
 
-  return <QRScanner handleCodeScan={handleCodeScan} error={qrCodeScanError} enableCameraOnError={true} />
+  const didDismissCameraDisclosure = () => {
+    setDidShowCameraDisclosure(true)
+  }
+
+  return (
+    <>
+      {(!didShowCameraDisclosure && <CameraDisclosure didDismissCameraDisclosure={didDismissCameraDisclosure} />) || (
+        <QRScanner handleCodeScan={handleCodeScan} error={qrCodeScanError} enableCameraOnError={true} />
+      )}
+    </>
+  )
 }
 
 export default Scan

--- a/core/App/screens/Splash.tsx
+++ b/core/App/screens/Splash.tsx
@@ -10,7 +10,7 @@ import { DispatchAction } from '../contexts/reducers/store'
 import { useStore } from '../contexts/store'
 import { useTheme } from '../contexts/theme'
 import { AuthenticateStackParams, Screens } from '../types/navigators'
-import { Onboarding as StoreOnboardingState } from '../types/state'
+import { Onboarding as StoreOnboardingState, Privacy as PrivacyState } from '../types/state'
 
 const onboardingComplete = (state: StoreOnboardingState): boolean => {
   return state.didCompleteTutorial && state.didAgreeToTerms && state.didCreatePIN
@@ -48,7 +48,16 @@ const Splash: React.FC = () => {
   useMemo(() => {
     async function init() {
       try {
-        // await AsyncStorage.removeItem(LocalStorageKeys.Onboarding)
+        const privacyData = await AsyncStorage.getItem(LocalStorageKeys.Privacy)
+        if (privacyData) {
+          const dataAsJSON = JSON.parse(privacyData) as PrivacyState
+
+          dispatch({
+            type: DispatchAction.PRIVACY_UPDATED,
+            payload: [dataAsJSON],
+          })
+        }
+
         const data = await AsyncStorage.getItem(LocalStorageKeys.Onboarding)
         if (data) {
           const onboardingState = JSON.parse(data) as StoreOnboardingState

--- a/core/App/types/state.ts
+++ b/core/App/types/state.ts
@@ -14,9 +14,14 @@ export interface Credential {
   revokedMessageDismissed: Set<CredentialRecord['id']>
 }
 
+export interface Privacy {
+  didShowCameraDisclosure: boolean
+}
+
 export interface State {
   onboarding: Onboarding
   credential: Credential
+  privacy: Privacy
   error: BifoldError | null
   loading: boolean
 }

--- a/core/__tests__/screens/CameraDisclosure.test.tsx
+++ b/core/__tests__/screens/CameraDisclosure.test.tsx
@@ -1,0 +1,31 @@
+import { render, fireEvent } from '@testing-library/react-native'
+import React from 'react'
+
+import CameraDisclosure from '../../App/screens/CameraDisclosure'
+import { testIdWithKey } from '../../App/utils/testable'
+
+jest.mock('@react-navigation/core', () => {
+  return require('../../__mocks__/custom/@react-navigation/core')
+})
+jest.mock('@react-navigation/native', () => {
+  return require('../../__mocks__/custom/@react-navigation/native')
+})
+
+describe('CameraDisclosure Screen', () => {
+  it('Renders correctly', () => {
+    const cb = jest.fn()
+    const tree = render(<CameraDisclosure didDismissCameraDisclosure={cb} />)
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('Okay button triggers callback', () => {
+    const cb = jest.fn()
+    const { getByTestId } = render(<CameraDisclosure didDismissCameraDisclosure={cb} />)
+
+    const okayButton = getByTestId(testIdWithKey('Okay'))
+    fireEvent(okayButton, 'press')
+
+    expect(cb).toBeCalledTimes(1)
+  })
+})

--- a/core/__tests__/screens/__snapshots__/CameraDisclosure.test.tsx.snap
+++ b/core/__tests__/screens/__snapshots__/CameraDisclosure.test.tsx.snap
@@ -1,0 +1,153 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CameraDisclosure Screen Renders correctly 1`] = `
+<RNCSafeAreaView
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#42803E",
+        "flexGrow": 1,
+        "paddingHorizontal": 25,
+      },
+    ]
+  }
+>
+  <View
+    style={
+      Object {
+        "backgroundColor": "#313132",
+        "borderColor": "#0099FF",
+        "borderRadius": 5,
+        "borderWidth": 1,
+        "minWidth": 700,
+        "padding": 10,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flexDirection": "row",
+          "paddingHorizontal": 5,
+          "paddingTop": 5,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignSelf": "center",
+              "marginRight": 10,
+            },
+          ]
+        }
+      >
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": "#0099FF",
+                "fontSize": 30,
+              },
+              undefined,
+              Object {
+                "fontFamily": "Material Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+      <Text
+        style={
+          Object {
+            "alignSelf": "center",
+            "color": "#FFFFFF",
+            "flexShrink": 1,
+            "fontSize": 18,
+            "fontWeight": "bold",
+          }
+        }
+        testID="com.ariesbifold:id/HeaderText"
+      >
+        PrivacyPolicy.Title
+      </Text>
+    </View>
+    <View
+      style={
+        Object {
+          "flexDirection": "column",
+          "marginLeft": 40,
+          "paddingBottom": 5,
+          "paddingHorizontal": 5,
+        }
+      }
+    >
+      <Text
+        style={
+          Object {
+            "color": "#FFFFFF",
+            "flexShrink": 1,
+            "fontSize": 18,
+            "fontWeight": "normal",
+            "marginVertical": 16,
+          }
+        }
+        testID="com.ariesbifold:id/BodyText"
+      >
+        PrivacyPolicy.CameraDisclosure
+      </Text>
+      <View
+        accessibilityLabel="Global.Okay"
+        accessibilityState={
+          Object {
+            "disabled": false,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        nativeID="animatedComponent"
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "backgroundColor": "#42803E",
+            "borderRadius": 4,
+            "opacity": 1,
+            "padding": 16,
+          }
+        }
+        testID="com.ariesbifold:id/Okay"
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 18,
+                "fontWeight": "bold",
+                "textAlign": "center",
+              },
+              false,
+            ]
+          }
+        >
+          Global.Okay
+        </Text>
+      </View>
+    </View>
+  </View>
+</RNCSafeAreaView>
+`;


### PR DESCRIPTION
# Summary of Changes

As per Google's policy we need to disclose why the camera is bing used and what happens to any data captured by it. This adds a screen that is displayed prior to the camera being activated. Once the user dismisses the screen, it will not show again. Following this screen the OS can do any permission requests.


# Related Issues

n/a

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
