### PR TITLE
fix: OOB proof stuck on sending screen

### DIFF
--- a/core/App/screens/ProofRequestAccept.tsx
+++ b/core/App/screens/ProofRequestAccept.tsx
@@ -79,7 +79,7 @@ const ProofRequestAccept: React.FC<ProofRequestAcceptProps> = ({ visible, proofI
 
     if (
       proof.state === ProofState.Done ||
-      (proofDeliveryStatus === ProofState.PresentationSent && typeof proof.connectionId === 'undefined')
+      (proof.state === ProofState.PresentationSent && typeof proof.connectionId === 'undefined')
     ) {
       timer && clearTimeout(timer)
       setProofDeliveryStatus(proof.state)


### PR DESCRIPTION
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>

# Summary of Changes

Fixed the issue where the user would get stuck at the presentation loading screen when doing a connectionless presentation

# Related Issues

Resolves: #405 

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
