### PR TITLE
fix: connectionless proof request render error

### DIFF
--- a/core/App/screens/ProofRequest.tsx
+++ b/core/App/screens/ProofRequest.tsx
@@ -256,7 +256,7 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
             }}
           >
             {loading ? <RecordLoading /> : null}
-            {proofConnectionLabel && <ConnectionAlert connectionID={proofConnectionLabel} />}
+            {proofConnectionLabel ? <ConnectionAlert connectionID={proofConnectionLabel} /> : null}
             <View style={styles.footerButton}>
               <Button
                 title={t('Global.Share')}


### PR DESCRIPTION
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>

# Summary of Changes

Fixed render error when receiving a connection less proof request. When `proofConnectionLabel` is undefined then the code tries to render it as a string without a `<Text>` component. I forced `proofConnectionLabel` to be treated as a boolean which fixes the following error:
![image](https://user-images.githubusercontent.com/36937407/185715702-4b462990-e607-430e-997c-b9c9193f6b09.png)


# Related Issues

Please reference here any issue #'s that are relevant to this PR, or simply enter "N/A" if this PR does not relate to any existing issues.

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
