### PR TITLE
fix: change how salt is stored

### DIFF
--- a/core/App/constants.ts
+++ b/core/App/constants.ts
@@ -14,8 +14,13 @@ export enum LocalStorageKeys {
 }
 
 //Keys for items saved in keychain/async storage
-export const KEYCHAIN_SERVICE_KEY = 'secret.wallet.key'
-export const KEYCHAIN_SERVICE_SALT = 'secret.wallet.salt'
+export enum KeychainServices {
+  Salt = 'secret.wallet.salt',
+  Key = 'secret.wallet.key',
+}
+
+// export const KEYCHAIN_SERVICE_KEY = 'secret.wallet.key'
+// export const KEYCHAIN_SERVICE_SALT = 'secret.wallet.salt'
 export const KEYCHAIN_SERVICE_ID = 'walletid'
 export const KEYCHAIN_SERVICE_PIN_KEY = 'secret.pin.key'
 export const KEYCHAIN_SERVICE_RAND_KEY = 'secret.rand.key'

--- a/core/App/constants.ts
+++ b/core/App/constants.ts
@@ -18,7 +18,7 @@ export enum KeychainServices {
   Key = 'secret.wallet.key',
 }
 
-export const KEYCHAIN_SERVICE_ID = 'walletid'
+export const walletId = 'walletId'
 
 export const dateFormatOptions: { year: 'numeric'; month: 'short'; day: 'numeric' } = {
   year: 'numeric',

--- a/core/App/constants.ts
+++ b/core/App/constants.ts
@@ -13,20 +13,12 @@ export enum LocalStorageKeys {
   Preferences = 'PreferencesState',
 }
 
-//Keys for items saved in keychain/async storage
 export enum KeychainServices {
   Salt = 'secret.wallet.salt',
   Key = 'secret.wallet.key',
 }
 
-// export const KEYCHAIN_SERVICE_KEY = 'secret.wallet.key'
-// export const KEYCHAIN_SERVICE_SALT = 'secret.wallet.salt'
 export const KEYCHAIN_SERVICE_ID = 'walletid'
-export const KEYCHAIN_SERVICE_PIN_KEY = 'secret.pin.key'
-export const KEYCHAIN_SERVICE_RAND_KEY = 'secret.rand.key'
-export const STORAGE_KEY_SALT = 'savedsalt'
-export const STORAGE_FIRSTLOGIN = 'firstlogin'
-export const STORAGE_AUTHLEVEL = 'authlevel'
 
 export const dateFormatOptions: { year: 'numeric'; month: 'short'; day: 'numeric' } = {
   year: 'numeric',

--- a/core/App/contexts/auth.tsx
+++ b/core/App/contexts/auth.tsx
@@ -37,7 +37,7 @@ export const AuthProvider: React.FC = ({ children }) => {
 
     const hash = await hashPIN(pin, secret?.salt)
 
-    return hash === secret.walletKey
+    return hash === secret.key
   }
 
   const getWalletCredentials = async (): Promise<WalletSecret | undefined> => {
@@ -46,11 +46,10 @@ export const AuthProvider: React.FC = ({ children }) => {
     }
 
     const secret = await loadWalletSecret()
-    if (!secret || !secret.walletKey) {
+    if (!secret || !secret.key) {
       return
     }
 
-    delete secret.salt
     setWalletSecret(secret)
 
     return secret

--- a/core/App/navigators/RootStack.tsx
+++ b/core/App/navigators/RootStack.tsx
@@ -83,7 +83,7 @@ const RootStack: React.FC<RootStackProps> = (props: RootStackProps) => {
     try {
       const credentials = await getWalletCredentials()
 
-      if (!credentials?.walletId || !credentials.walletKey) {
+      if (!credentials?.id || !credentials.key) {
         Alert.alert('Error', 'Cannot find wallet id/secret!')
         Toast.hide()
 
@@ -95,7 +95,7 @@ const RootStack: React.FC<RootStackProps> = (props: RootStackProps) => {
           label: 'Aries Bifold',
           mediatorConnectionsInvite: Config.MEDIATOR_URL,
           mediatorPickupStrategy: MediatorPickupStrategy.Implicit,
-          walletConfig: { id: credentials.walletId, key: credentials.walletKey },
+          walletConfig: { id: credentials.id, key: credentials.key },
           autoAcceptConnections: true,
           autoAcceptCredentials: AutoAcceptCredential.ContentApproved,
           logger: new ConsoleLogger(LogLevel.trace),

--- a/core/App/screens/PinEnter.tsx
+++ b/core/App/screens/PinEnter.tsx
@@ -37,7 +37,7 @@ const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated }) => {
 
     const loadWalletCredentials = async () => {
       const creds = await getWalletCredentials()
-      if (creds && creds.walletKey) {
+      if (creds && creds.key) {
         setAuthenticated(true)
       }
     }

--- a/core/App/services/keychain.ts
+++ b/core/App/services/keychain.ts
@@ -1,15 +1,24 @@
 import { Platform } from 'react-native'
-import Keychain, { resetGenericPassword, getSupportedBiometryType } from 'react-native-keychain'
+import Keychain, { getSupportedBiometryType } from 'react-native-keychain'
 import uuid from 'react-native-uuid'
 
-import { KEYCHAIN_SERVICE_ID, KEYCHAIN_SERVICE_KEY } from '../constants'
+import { KEYCHAIN_SERVICE_ID, KeychainServices } from '../constants'
 import { WalletSecret } from '../types/security'
 import { hashPIN } from '../utils/crypto'
 
-const service = KEYCHAIN_SERVICE_KEY
-const pinUserNameKey = 'WalletFauxPINUserName'
+const keyFauxUserName = 'WalletFauxPINUserName'
+const saltFauxUserName = 'WalletFauxSaltUserName'
 
-export const optionsForKeychainAccess = (useBiometrics = false): Keychain.Options => {
+export interface WalletSalt {
+  id: string
+  salt: string
+}
+
+export interface WalletKey {
+  key: string
+}
+
+export const optionsForKeychainAccess = (service: KeychainServices, useBiometrics = false): Keychain.Options => {
   const opts: Keychain.Options = {
     accessible: Keychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
     service,
@@ -31,29 +40,57 @@ export const secretForPIN = async (pin: string): Promise<WalletSecret> => {
   const mySalt = uuid.v4().toString()
   const myKey = await hashPIN(pin, mySalt)
   const secret: WalletSecret = {
-    walletId: KEYCHAIN_SERVICE_ID,
-    walletKey: myKey,
+    id: KEYCHAIN_SERVICE_ID,
+    key: myKey,
     salt: mySalt,
   }
 
   return secret
 }
 
-export const storeWalletSecret = async (secret: WalletSecret, useBiometrics = false): Promise<boolean> => {
-  const opts = optionsForKeychainAccess(useBiometrics)
+export const storeWalletKey = async (secret: WalletKey, useBiometrics = false): Promise<boolean> => {
+  const opts = optionsForKeychainAccess(KeychainServices.Key, useBiometrics)
   const secretAsString = JSON.stringify(secret)
-  const result = await Keychain.setGenericPassword(pinUserNameKey, secretAsString, opts)
+  const result = await Keychain.setGenericPassword(keyFauxUserName, secretAsString, opts)
 
-  if (typeof result === 'boolean') {
-    return false
-  }
-
-  return true
+  return typeof result === 'boolean' ? false : true
 }
 
-export const loadWalletSecret = async (title?: string, description?: string): Promise<WalletSecret | undefined> => {
+export const storeWalletSalt = async (secret: WalletSalt): Promise<boolean> => {
+  const opts = optionsForKeychainAccess(KeychainServices.Salt)
+  const secretAsString = JSON.stringify(secret)
+  const result = await Keychain.setGenericPassword(saltFauxUserName, secretAsString, opts)
+
+  return typeof result === 'boolean' ? false : true
+}
+
+export const storeWalletSecret = async (secret: WalletSecret, useBiometrics = false): Promise<boolean> => {
+  let keyResult = false
+  if (secret.key) {
+    keyResult = await storeWalletKey({ key: secret.key }, useBiometrics)
+  }
+
+  const saltResult = await storeWalletSalt({ id: secret.id, salt: secret.salt })
+
+  return keyResult && saltResult
+}
+
+export const loadWalletSalt = async (): Promise<WalletSalt | undefined> => {
+  const opts: Keychain.Options = {
+    service: KeychainServices.Salt,
+  }
+  const result = await Keychain.getGenericPassword(opts)
+
+  if (!result) {
+    return
+  }
+
+  return JSON.parse(result.password) as WalletSalt
+}
+
+export const loadWalletKey = async (title?: string, description?: string): Promise<WalletKey | undefined> => {
   let opts: Keychain.Options = {
-    service,
+    service: KeychainServices.Key,
   }
 
   if (title && description) {
@@ -72,7 +109,14 @@ export const loadWalletSecret = async (title?: string, description?: string): Pr
     return
   }
 
-  return JSON.parse(result.password) as WalletSecret
+  return JSON.parse(result.password) as WalletKey
+}
+
+export const loadWalletSecret = async (title?: string, description?: string): Promise<WalletSecret | undefined> => {
+  const salt = await loadWalletSalt()
+  const key = await loadWalletKey(title, description)
+
+  return { ...salt, ...key } as WalletSecret
 }
 
 export const convertToUseBiometrics = async (): Promise<boolean> => {
@@ -83,7 +127,6 @@ export const convertToUseBiometrics = async (): Promise<boolean> => {
     return false
   }
 
-  await resetGenericPassword({ service })
   await storeWalletSecret(secret, useBiometrics)
 
   return true

--- a/core/App/services/keychain.ts
+++ b/core/App/services/keychain.ts
@@ -2,7 +2,7 @@ import { Platform } from 'react-native'
 import Keychain, { getSupportedBiometryType } from 'react-native-keychain'
 import uuid from 'react-native-uuid'
 
-import { KEYCHAIN_SERVICE_ID, KeychainServices } from '../constants'
+import { walletId, KeychainServices } from '../constants'
 import { WalletSecret } from '../types/security'
 import { hashPIN } from '../utils/crypto'
 
@@ -40,7 +40,7 @@ export const secretForPIN = async (pin: string): Promise<WalletSecret> => {
   const mySalt = uuid.v4().toString()
   const myKey = await hashPIN(pin, mySalt)
   const secret: WalletSecret = {
-    id: KEYCHAIN_SERVICE_ID,
+    id: walletId,
     key: myKey,
     salt: mySalt,
   }

--- a/core/App/types/security.ts
+++ b/core/App/types/security.ts
@@ -1,7 +1,7 @@
 export interface WalletSecret {
-  walletId: string
-  walletKey: string
-  salt?: string
+  id: string
+  key?: string
+  salt: string
 }
 
 export enum AuthLevel {


### PR DESCRIPTION
# Summary of Changes

To facilitate wallet recovery we need the salt stored outside of any biometry requirement. This will allow the user to recover using the 6-digit wallet PIN if needed.

# Related Issues

Please reference here any issue #'s that are relevant to this PR, or simply enter "N/A" if this PR does not relate to any existing issues.

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
