### PR TITLE
fix: partially undo #429

### DIFF
--- a/core/App/services/keychain.ts
+++ b/core/App/services/keychain.ts
@@ -31,13 +31,7 @@ export const optionsForKeychainAccess = (service: KeychainServices, useBiometric
 
   if (Platform.OS === 'android') {
     opts.securityLevel = Keychain.SECURITY_LEVEL.ANY
-    opts.storage = Keychain.STORAGE_TYPE.AES //AES implies not protected by biometrics unlock
-    if (useBiometrics) {
-      if (!DeviceInfo.isEmulatorSync()) {
-        opts.securityLevel = Keychain.SECURITY_LEVEL.SECURE_HARDWARE
-      }
-      opts.storage = Keychain.STORAGE_TYPE.RSA // RSA implies protected by biometrics unlock
-    }
+    opts.storage = Keychain.STORAGE_TYPE.RSA
   }
 
   return opts


### PR DESCRIPTION
Signed-off-by: Clécio Varjão <1348549+cvarjao@users.noreply.github.com>

# Summary of Changes

Partially undo #429. It looks like the react native keychain library we are using doesn't work with AES encryption. Might need to be upgrade.

# Related Issues

Please reference here any issue #'s that are relevant to this PR, or simply enter "N/A" if this PR does not relate to any existing issues.

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
