### PR TITLE
made back home button always display  on proof req

### DIFF
--- a/core/App/screens/ProofRequestAccept.tsx
+++ b/core/App/screens/ProofRequestAccept.tsx
@@ -147,15 +147,16 @@ const ProofRequestAccept: React.FC<ProofRequestAcceptProps> = ({ visible, proofI
           )}
 
         <View style={[styles.controlsContainer]}>
-          {proofDeliveryStatus === ProofState.PresentationSent && typeof proof.connectionId !== 'undefined' && (
-            <Button
-              title={t('Loading.BackToHome')}
-              accessibilityLabel={t('Loading.BackToHome')}
-              testID={testIdWithKey('BackToHome')}
-              onPress={onBackToHomeTouched}
-              buttonType={ButtonType.Secondary}
-            />
-          )}
+          {(proofDeliveryStatus !== ProofState.PresentationSent || typeof proof.connectionId !== 'undefined') &&
+            proofDeliveryStatus !== ProofState.Done && (
+              <Button
+                title={t('Loading.BackToHome')}
+                accessibilityLabel={t('Loading.BackToHome')}
+                testID={testIdWithKey('BackToHome')}
+                onPress={onBackToHomeTouched}
+                buttonType={ButtonType.Secondary}
+              />
+            )}
 
           {((proofDeliveryStatus === ProofState.PresentationSent && typeof proof.connectionId === 'undefined') ||
             proofDeliveryStatus === ProofState.Done) && (


### PR DESCRIPTION
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>

# Summary of Changes

Made sure the "Back to Home" button is always accessible when sending a proof request. Tested on connection based and connectionless proof requests.
Proof Request screen:
![image](https://user-images.githubusercontent.com/36937407/189770544-ad7cf57c-988a-4462-bd40-f287984b1aa7.png)

Sent Screen:
![image](https://user-images.githubusercontent.com/36937407/189770603-4a5952ec-56c7-42da-800a-a564648d4fe1.png)


# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
