### PR TITLE
fix: stuck proof when no ack received

### DIFF
--- a/core/App/screens/ProofRequestAccept.tsx
+++ b/core/App/screens/ProofRequestAccept.tsx
@@ -14,8 +14,6 @@ import { Screens, TabStacks } from '../types/navigators'
 import { statusBarStyleForColor, StatusBarStyles } from '../utils/luminance'
 import { testIdWithKey } from '../utils/testable'
 
-const connectionTimerDelay = 5000 // in ms
-
 export interface ProofRequestAcceptProps {
   visible: boolean
   proofId: string
@@ -23,10 +21,7 @@ export interface ProofRequestAcceptProps {
 
 const ProofRequestAccept: React.FC<ProofRequestAcceptProps> = ({ visible, proofId }) => {
   const { t } = useTranslation()
-  const [shouldShowDelayMessage, setShouldShowDelayMessage] = useState<boolean>(false)
   const [proofDeliveryStatus, setProofDeliveryStatus] = useState<ProofState>(ProofState.RequestReceived)
-  const [, setTimerDidFire] = useState<boolean>(false)
-  const [timer, setTimer] = useState<NodeJS.Timeout>()
   const proof = useProofById(proofId)
   const navigation = useNavigation()
   const { ColorPallet, TextTheme } = useTheme()
@@ -68,36 +63,15 @@ const ProofRequestAccept: React.FC<ProofRequestAcceptProps> = ({ visible, proofI
     navigation.getParent()?.navigate(TabStacks.HomeStack, { screen: Screens.Home })
   }
 
-  const onDoneTouched = () => {
-    navigation.getParent()?.navigate(TabStacks.CredentialStack, { screen: Screens.Credentials })
-  }
-
   useEffect(() => {
     if (proof.state === proofDeliveryStatus) {
       return
     }
 
-    if (
-      proof.state === ProofState.Done ||
-      (proof.state === ProofState.PresentationSent && typeof proof.connectionId === 'undefined')
-    ) {
-      timer && clearTimeout(timer)
+    if (proof.state === ProofState.Done || proof.state === ProofState.PresentationSent) {
       setProofDeliveryStatus(proof.state)
     }
   }, [proof])
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setShouldShowDelayMessage(true)
-      setTimerDidFire(true)
-    }, connectionTimerDelay)
-
-    setTimer(timer)
-
-    return () => {
-      timer && clearTimeout(timer)
-    }
-  }, [visible])
 
   return (
     <Modal visible={visible} transparent={true} animationType={'none'}>
@@ -130,43 +104,18 @@ const ProofRequestAccept: React.FC<ProofRequestAcceptProps> = ({ visible, proofI
         </View>
 
         <View style={[styles.image, { minHeight: 250, alignItems: 'center', justifyContent: 'flex-end' }]}>
-          {(proofDeliveryStatus === ProofState.RequestReceived ||
-            (proofDeliveryStatus === ProofState.PresentationSent && typeof proof.connectionId !== 'undefined')) && (
-            <SendingProof />
-          )}
-          {((proofDeliveryStatus === ProofState.PresentationSent && typeof proof.connectionId === 'undefined') ||
-            proofDeliveryStatus === ProofState.Done) && <SentProof />}
+          {proofDeliveryStatus === ProofState.RequestReceived && <SendingProof />}
+          {proofDeliveryStatus === ProofState.PresentationSent && <SentProof />}
         </View>
 
-        {shouldShowDelayMessage &&
-          proofDeliveryStatus === ProofState.PresentationSent &&
-          typeof proof.connectionId !== 'undefined' && (
-            <Text style={[TextTheme.normal, styles.delayMessageText]} testID={testIdWithKey('TakingTooLong')}>
-              {t('Connection.TakingTooLong')}
-            </Text>
-          )}
-
         <View style={[styles.controlsContainer]}>
-          {proofDeliveryStatus === ProofState.PresentationSent && typeof proof.connectionId !== 'undefined' && (
-            <Button
-              title={t('Loading.BackToHome')}
-              accessibilityLabel={t('Loading.BackToHome')}
-              testID={testIdWithKey('BackToHome')}
-              onPress={onBackToHomeTouched}
-              buttonType={ButtonType.Secondary}
-            />
-          )}
-
-          {((proofDeliveryStatus === ProofState.PresentationSent && typeof proof.connectionId === 'undefined') ||
-            proofDeliveryStatus === ProofState.Done) && (
-            <Button
-              title={t('Global.Done')}
-              accessibilityLabel={t('Global.Done')}
-              testID={testIdWithKey('Done')}
-              onPress={onDoneTouched}
-              buttonType={ButtonType.Primary}
-            />
-          )}
+          <Button
+            title={t('Loading.BackToHome')}
+            accessibilityLabel={t('Loading.BackToHome')}
+            testID={testIdWithKey('BackToHome')}
+            onPress={onBackToHomeTouched}
+            buttonType={ButtonType.Secondary}
+          />
         </View>
       </SafeAreaView>
     </Modal>


### PR DESCRIPTION
# Summary of Changes

As per [RFC0037](https://github.com/hyperledger/aries-rfcs/blob/main/features/0037-present-proof/README.md) its not clear if an ACK should be send when a proof is recieved. This can lead to a state where the wallet does not know if the present proof workflow is complete or not. This fixes the issue.

# Related Issues

n/a

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
