### PR TITLE
Fixed navigation error on UseBiometrics screen

### DIFF
--- a/core/App/screens/Splash.tsx
+++ b/core/App/screens/Splash.tsx
@@ -10,7 +10,7 @@ import {
 import { agentDependencies } from '@aries-framework/react-native'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { useNavigation } from '@react-navigation/core'
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet } from 'react-native'
 import { Config } from 'react-native-config'
@@ -124,7 +124,7 @@ const Splash: React.FC = () => {
   }, [store.authentication.didAuthenticate])
 
   useEffect(() => {
-    if (!store.authentication.didAuthenticate) {
+    if (!store.authentication.didAuthenticate || !store.onboarding.didConsiderBiometry) {
       return
     }
 
@@ -179,7 +179,7 @@ const Splash: React.FC = () => {
     }
 
     initAgent()
-  }, [store.authentication.didAuthenticate])
+  }, [store.authentication.didAuthenticate, store.onboarding.didConsiderBiometry])
 
   return (
     <SafeAreaView style={styles.container}>


### PR DESCRIPTION
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>

# Summary of Changes

Previously on the UseBiometrics page, during on-boarding, the agent initialisation would start as soon as the user visited the page. This made the buttons unresponsive for a few seconds while the agent was loading. In addition it would try to navigate to the tabstack as soon as the agent was initialised. Since the tabstack is not available on the biometrics screen, if the user stayed on the biometrics screen for the 10-ish seconds that it takes for the agent to initialise, then the navigation to the tabstack would fail, and the user would be stuck on the splash screen once they pressed the `Continue` button.

This change resolves the issue by making the agent initialisation happen after the user presses continue on the biometrics screen.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
