### PR TITLE
feat: disable app biometrics when phone biometrics is disabled

### DIFF
--- a/core/App/contexts/auth.tsx
+++ b/core/App/contexts/auth.tsx
@@ -19,6 +19,7 @@ export interface AuthContext {
   checkPIN: (pin: string) => Promise<boolean>
   getWalletCredentials: () => Promise<WalletSecret | undefined>
   removeSavedWalletSecret: () => void
+  disableBiometrics: () => Promise<void>
   setPIN: (pin: string) => Promise<void>
   commitPIN: (useBiometry: boolean) => Promise<boolean>
   isBiometricsActive: () => Promise<boolean>
@@ -92,12 +93,17 @@ export const AuthProvider: React.FC = ({ children }) => {
     setWalletSecret(undefined)
   }
 
+  const disableBiometrics = async () => {
+    await wipeWalletKey(true)
+  }
+
   return (
     <AuthContext.Provider
       value={{
         checkPIN,
         getWalletCredentials,
         removeSavedWalletSecret,
+        disableBiometrics,
         commitPIN,
         setPIN,
         isBiometricsActive,

--- a/core/App/localization/en/index.ts
+++ b/core/App/localization/en/index.ts
@@ -102,7 +102,9 @@ const translation = {
     "EnableBiometrics": "You have to enable biometrics to be able to load the wallet.",
     "BiometricsNotProvided": "Biometrics not provided, you may use PIN to load the wallet.",
     "LoggedOut": "You're logged out",
-    "LoggedOutDescription": "To protect your information, you're logged out of your wallet if you have not used it for 5 minutes."
+    "LoggedOutDescription": "To protect your information, you're logged out of your wallet if you have not used it for 5 minutes.",
+    "BiometricsChanged": "Biometrics unlock has been disabled because your device biometrics changed.",
+    "BiometricsChangedEnterPIN": "Please enter your wallet PIN."
   },
   "Biometry": {
     "Toggle": "Toggle Biometrics",

--- a/core/App/localization/fr/index.ts
+++ b/core/App/localization/fr/index.ts
@@ -94,7 +94,9 @@ const translation = {
         "EnableBiometrics": "Vous devez activer la biométrie pour pouvoir charger le portefeuille.",
         "BiometricsNotProvided": "Biométrie non fournie, vous pouvez utiliser le NIP pour vous connecter au portefeuille.",
         "LoggedOut": "You're logged out",
-        "LoggedOutDescription": "To protect your information, you're logged out of your wallet if you have not used it for 5 minutes."
+        "LoggedOutDescription": "To protect your information, you're logged out of your wallet if you have not used it for 5 minutes.",
+        "BiometricsChanged": "Biometrics unlock has been disabled because your device biometrics changed.",
+        "BiometricsChangedEnterPIN": "Please enter your wallet PIN."
     },
     "Biometry": {
         "Toggle": "Toggle Biometrics",

--- a/core/App/screens/PinEnter.tsx
+++ b/core/App/screens/PinEnter.tsx
@@ -22,11 +22,12 @@ interface PinEnterProps {
 
 const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated }) => {
   const { t } = useTranslation()
-  const { checkPIN, getWalletCredentials } = useAuth()
+  const { checkPIN, getWalletCredentials, isBiometricsActive, disableBiometrics } = useAuth()
   const [, dispatch] = useStore()
   const [pin, setPin] = useState<string>('')
   const [continueEnabled, setContinueEnabled] = useState(true)
   const [modalVisible, setModalVisible] = useState<boolean>(false)
+  const [biometricsEnrollmentChange, setBiometricsEnrollmentChange] = useState<boolean>(false)
   const { ColorPallet, TextTheme, Assets } = useTheme()
   const [state] = useContext(StoreContext)
 
@@ -44,6 +45,18 @@ const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated }) => {
     if (!state.preferences.useBiometry) {
       return
     }
+
+    isBiometricsActive().then((res) => {
+      if (!res) {
+        // biometry state has changed, display message and disable biometry
+        setBiometricsEnrollmentChange(true)
+        disableBiometrics()
+        dispatch({
+          type: DispatchAction.USE_BIOMETRY,
+          payload: [false],
+        })
+      }
+    })
 
     const loadWalletCredentials = async () => {
       const creds = await getWalletCredentials()
@@ -114,7 +127,18 @@ const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated }) => {
             marginBottom: 20,
           }}
         />
-        <Text style={[TextTheme.normal, { alignSelf: 'center', marginBottom: 16 }]}>{t('PinEnter.EnterPIN')}</Text>
+        {biometricsEnrollmentChange ? (
+          <>
+            <Text style={[TextTheme.normal, { alignSelf: 'center', textAlign: 'center' }]}>
+              {t('PinEnter.BiometricsChanged')}
+            </Text>
+            <Text style={[TextTheme.normal, { alignSelf: 'center', marginBottom: 16 }]}>
+              {t('PinEnter.BiometricsChangedEnterPIN')}
+            </Text>
+          </>
+        ) : (
+          <Text style={[TextTheme.normal, { alignSelf: 'center', marginBottom: 16 }]}>{t('PinEnter.EnterPIN')}</Text>
+        )}
         <PinInput
           onPinChanged={setPin}
           testID={testIdWithKey('EnterPIN')}


### PR DESCRIPTION
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>

# Summary of Changes

If user enables biometrics during onboarding and then disables biometrics on the phone after app has been initialized, then the next time the user opens the app, they will be notified that biometrics has been disabled on the app and they will be prompted to enter their PIN.
![biometricsChanged](https://user-images.githubusercontent.com/36937407/193895755-add2b28c-1127-489b-8ef4-99b4ed7a5402.png)


# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
