### PR TITLE
fixed biometrics hang if user closed app while onboarding

### DIFF
--- a/core/App/contexts/auth.tsx
+++ b/core/App/contexts/auth.tsx
@@ -1,7 +1,8 @@
 import { agentDependencies } from '@aries-framework/react-native'
-import { DispatchAction } from '../contexts/reducers/store'
 import React, { createContext, useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+
+import { DispatchAction } from '../contexts/reducers/store'
 import { useStore } from '../contexts/store'
 import {
   secretForPIN,

--- a/core/App/contexts/auth.tsx
+++ b/core/App/contexts/auth.tsx
@@ -1,9 +1,8 @@
-import { Agent, AgentConfig } from '@aries-framework/core'
-import { IndyWallet } from '@aries-framework/core/build/wallet/IndyWallet'
 import { agentDependencies } from '@aries-framework/react-native'
+import { DispatchAction } from '../contexts/reducers/store'
 import React, { createContext, useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-
+import { useStore } from '../contexts/store'
 import {
   secretForPIN,
   storeWalletSecret,
@@ -28,6 +27,7 @@ export const AuthContext = createContext<AuthContext>(null as unknown as AuthCon
 
 export const AuthProvider: React.FC = ({ children }) => {
   const [walletSecret, setWalletSecret] = useState<WalletSecret>()
+  const [, dispatch] = useStore()
   const { t } = useTranslation()
 
   const setPIN = async (pin: string): Promise<void> => {
@@ -54,6 +54,10 @@ export const AuthProvider: React.FC = ({ children }) => {
     if (!secret) {
       return false
     }
+    // set did authenticate to true if we can get wallet credentials
+    dispatch({
+      type: DispatchAction.DID_AUTHENTICATE,
+    })
     if (useBiometry) {
       await storeWalletSecret(secret, useBiometry)
     } else {


### PR DESCRIPTION
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>

# Summary of Changes

Previously if the user closed the app at the biometrics screen, then opened it again, they would get stuck on the splash screen after clicking continue. This was due to `store.authentication.didAuthenticate` being reset after the app gets reopened. Since `didAuthenticate` gets reset to false the agent is never initialized on the splash screen.

I changed the commitPIN functionality to set the user as authenticated if it is able to load the wallet secret. That way the user can close the app between the create PIN screen and the biometrics screen and still be considered authenticated by the app 

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [ ] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [ ] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [ ] Updated documentation as needed for changed code and new or modified features;
- [ ] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
