### PR TITLE
feat: added biometrics button unlock to PinEnter

### DIFF
--- a/core/App/localization/en/index.ts
+++ b/core/App/localization/en/index.ts
@@ -101,7 +101,10 @@ const translation = {
     "Hide": "Hide",
   },
   "PinEnter": {
-    "EnterPIN": "Enter PIN",
+    "EnterPIN": "Enter your wallet PIN",
+    "Unlock":"Unlock",
+    "Or":"Or",
+    "BiometricsUnlock": "Unlock with biometrics",
     "IncorrectPIN": "Incorrect PIN",
     "RepeatPIN": "Please try your PIN again.",
     "EnableBiometrics": "You have to enable biometrics to be able to load the wallet.",

--- a/core/App/localization/fr/index.ts
+++ b/core/App/localization/fr/index.ts
@@ -30,7 +30,7 @@ const translation = {
         "ShowDetails": "Afficher les détails",
         "TryAgain": "Try Again",
         "Biometrics": "Biometrics",
-        "On" : "On",
+        "On": "On",
         "Off": "Off",
     },
     "Language": {
@@ -94,6 +94,9 @@ const translation = {
     },
     "PinEnter": {
         "EnterPIN": "Veuillez saisir votre NIP",
+        "Unlock": "Unlock",
+        "Or": "Or",
+        "BiometricsUnlock": "Unlock with biometrics",
         "IncorrectPIN": "NIP erroné",
         "RepeatPIN": "Please try your PIN again.",
         "EnableBiometrics": "Vous devez activer la biométrie pour pouvoir charger le portefeuille.",

--- a/core/App/localization/pt-br/index.ts
+++ b/core/App/localization/pt-br/index.ts
@@ -101,6 +101,9 @@ const translation = {
   },
   "PinEnter": {
     "EnterPIN": "Digitar PIN",
+    "Unlock":"Unlock",
+    "Or":"Or",
+    "BiometricsUnlock": "Unlock with biometrics",
     "IncorrectPIN": "PIN incorreto",
     "EnableBiometrics": "Você deve habilitar a biometria para poder carregar a carteira.",
     "BiometricsNotProvided": "Biometria não informada, você deve usar o PIN para carregar a carteira."

--- a/core/App/screens/PinEnter.tsx
+++ b/core/App/screens/PinEnter.tsx
@@ -85,6 +85,24 @@ const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated }) => {
     return penalty
   }
 
+  const loadWalletCredentials = async () => {
+    const creds = await getWalletCredentials()
+    if (creds && creds.key) {
+      //remove lockout notification
+      dispatch({
+        type: DispatchAction.LOCKOUT_UPDATED,
+        payload: [{ displayNotification: false }],
+      })
+
+      // reset login attempts if login is successful
+      dispatch({
+        type: DispatchAction.ATTEMPT_UPDATED,
+        payload: [{ loginAttempts: 0 }],
+      })
+      setAuthenticated()
+    }
+  }
+
   useEffect(() => {
     if (!state.preferences.useBiometry) {
       return
@@ -101,24 +119,6 @@ const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated }) => {
         })
       }
     })
-
-    const loadWalletCredentials = async () => {
-      const creds = await getWalletCredentials()
-      if (creds && creds.key) {
-        //remove lockout notification
-        dispatch({
-          type: DispatchAction.LOCKOUT_UPDATED,
-          payload: [{ displayNotification: false }],
-        })
-
-        // reset login attempts if login is successful
-        dispatch({
-          type: DispatchAction.ATTEMPT_UPDATED,
-          payload: [{ loginAttempts: 0 }],
-        })
-        setAuthenticated()
-      }
-    }
 
     loadWalletCredentials().catch((error: unknown) => {
       // TODO:(jl) Handle error
@@ -234,19 +234,35 @@ const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated }) => {
           />
         )}
       </View>
-      <View style={{ marginTop: 'auto', margin: 20 }}>
+      <View style={{ marginTop: 'auto', margin: 20, marginBottom: 10 }}>
         <Button
-          title={t('Global.Enter')}
+          title={t('PinEnter.Unlock')}
           buttonType={ButtonType.Primary}
           testID={testIdWithKey('Enter')}
           disabled={!continueEnabled}
-          accessibilityLabel={t('Global.Enter')}
+          accessibilityLabel={t('PinEnter.Unlock')}
           onPress={() => {
             Keyboard.dismiss()
             onPinInputCompleted(pin)
           }}
         />
       </View>
+
+      {state.preferences.useBiometry && (
+        <>
+          <Text style={[TextTheme.normal, { alignSelf: 'center' }]}>{t('PinEnter.Or')}</Text>
+          <View style={{ margin: 20, marginTop: 10 }}>
+            <Button
+              title={t('PinEnter.BiometricsUnlock')}
+              buttonType={ButtonType.Secondary}
+              testID={testIdWithKey('Enter')}
+              disabled={!continueEnabled}
+              accessibilityLabel={t('PinEnter.BiometricsUnlock')}
+              onPress={loadWalletCredentials}
+            />
+          </View>
+        </>
+      )}
 
       {modalVisible && (
         <PopupModal


### PR DESCRIPTION
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>

# Summary of Changes

Added biometrics button on PinEnter screen to re-prompt the user if they decline biometrics
![bioButton1](https://user-images.githubusercontent.com/36937407/197018450-16c831b0-5ee8-4081-9b3c-be2ca6c7c0d7.png)

![bioButton2](https://user-images.githubusercontent.com/36937407/197018478-0e6002aa-9534-4318-a415-2f88fb5d1d14.png)

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
