### PR TITLE
feat: app commons provider with logger service implementation

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,5 +1,6 @@
 import {
   AgentProvider,
+  AppCommonsProvider,
   AuthProvider,
   ConfigurationProvider,
   NetworkProvider,
@@ -38,20 +39,22 @@ const App = () => {
       <AgentProvider>
         <ThemeProvider value={theme}>
           <ConfigurationProvider value={defaultConfiguration}>
-            <AuthProvider>
-              <NetworkProvider>
-                <StatusBar
-                  hidden={false}
-                  barStyle="light-content"
-                  backgroundColor={theme.ColorPallet.brand.primary}
-                  translucent={false}
-                />
-                <NetInfo />
-                <ErrorModal />
-                <RootStack />
-                <Toast topOffset={15} config={toastConfig} />
-              </NetworkProvider>
-            </AuthProvider>
+            <AppCommonsProvider>
+              <AuthProvider>
+                <NetworkProvider>
+                  <StatusBar
+                    hidden={false}
+                    barStyle="light-content"
+                    backgroundColor={theme.ColorPallet.brand.primary}
+                    translucent={false}
+                  />
+                  <NetInfo />
+                  <ErrorModal />
+                  <RootStack />
+                  <Toast topOffset={15} config={toastConfig} />
+                </NetworkProvider>
+              </AuthProvider>
+            </AppCommonsProvider>
           </ConfigurationProvider>
         </ThemeProvider>
       </AgentProvider>

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,6 +1,6 @@
 import {
   AgentProvider,
-  AppCommonsProvider,
+  CommonUtilProvider,
   AuthProvider,
   ConfigurationProvider,
   NetworkProvider,
@@ -39,7 +39,7 @@ const App = () => {
       <AgentProvider>
         <ThemeProvider value={theme}>
           <ConfigurationProvider value={defaultConfiguration}>
-            <AppCommonsProvider>
+            <CommonUtilProvider>
               <AuthProvider>
                 <NetworkProvider>
                   <StatusBar
@@ -54,7 +54,7 @@ const App = () => {
                   <Toast topOffset={15} config={toastConfig} />
                 </NetworkProvider>
               </AuthProvider>
-            </AppCommonsProvider>
+            </CommonUtilProvider>
           </ConfigurationProvider>
         </ThemeProvider>
       </AgentProvider>

--- a/core/App/contexts/commons.tsx
+++ b/core/App/contexts/commons.tsx
@@ -8,7 +8,7 @@ export interface AppCommonsContext {
 
 export const AppCommons = createContext<AppCommonsContext>(null as unknown as AppCommonsContext)
 
-export const AppCommonsProvider: React.FC = ({ children }) => {
+export const CommonUtilProvider: React.FC = ({ children }) => {
   const logger = new AppConsoleLogger(LogLevel.test)
   const log = async (messaage: string, logLevel: Exclude<LogLevel, LogLevel.off>) => {
     logger.log(logLevel, messaage)
@@ -29,7 +29,7 @@ export const AppCommonsProvider: React.FC = ({ children }) => {
 export const useCommons = () => {
   const commonsContext = useContext(AppCommons)
   if (!commonsContext) {
-    throw new Error('commonsContext must be used within a AppCommonsProvider')
+    throw new Error('commonsContext must be used within a CommonUtilProvider')
   }
   return commonsContext
 }

--- a/core/App/contexts/commons.tsx
+++ b/core/App/contexts/commons.tsx
@@ -1,0 +1,40 @@
+import React, { createContext, useContext, useState } from 'react'
+
+import { AppConsoleLogger, LogLevel } from '../services/logger'
+
+export interface AppCommonsContext {
+  log: (message: string, logLevel: Exclude<LogLevel, LogLevel.off>) => void
+}
+
+export const AppCommons = createContext<AppCommonsContext>(null as unknown as AppCommonsContext)
+
+export const AppCommonsProvider: React.FC = ({ children }) => {
+  const logger = new AppConsoleLogger(LogLevel.test)
+  const log = async (messaage: string, logLevel: Exclude<LogLevel, LogLevel.off>) => {
+    logger.log(logLevel, messaage)
+    //TODO: do some more logic like collecting errors for later logging and investigation
+  }
+
+  return (
+    <AppCommons.Provider
+      value={{
+        log: log,
+      }}
+    >
+      {children}
+    </AppCommons.Provider>
+  )
+}
+
+export const useCommons = () => {
+  const commonsContext = useContext(AppCommons)
+  if (!commonsContext) {
+    throw new Error('commonsContext must be used within a AppCommonsProvider')
+  }
+  return commonsContext
+}
+
+export const appLog = (messaage: string, logLevel: Exclude<LogLevel, LogLevel.off>) => {
+  const { log } = useCommons()
+  log(messaage, logLevel)
+}

--- a/core/App/contexts/commons.tsx
+++ b/core/App/contexts/commons.tsx
@@ -33,8 +33,3 @@ export const useCommons = () => {
   }
   return commonsContext
 }
-
-export const appLog = (messaage: string, logLevel: Exclude<LogLevel, LogLevel.off>) => {
-  const { log } = useCommons()
-  log(messaage, logLevel)
-}

--- a/core/App/contexts/commons.tsx
+++ b/core/App/contexts/commons.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState } from 'react'
+import React, { createContext, useContext } from 'react'
 
 import { AppConsoleLogger, LogLevel } from '../services/logger'
 

--- a/core/App/index.ts
+++ b/core/App/index.ts
@@ -20,7 +20,7 @@ import toastConfig from './components/toast/ToastConfig'
 import HomeContentView from './components/views/HomeContentView'
 import * as contexts from './contexts'
 import { AuthProvider } from './contexts/auth'
-import { AppCommonsProvider, appLog } from './contexts/commons'
+import { CommonUtilProvider, appLog } from './contexts/commons'
 import { NetworkProvider } from './contexts/network'
 import { defaultConfiguration } from './defaultConfiguration'
 import RootStack from './navigators/RootStack'
@@ -67,7 +67,7 @@ export {
   LoadingIndicator,
   indyLedgers,
   Agent,
-  AppCommonsProvider,
+  CommonUtilProvider,
   AgentProvider,
   AuthProvider,
   NetworkProvider,

--- a/core/App/index.ts
+++ b/core/App/index.ts
@@ -20,6 +20,7 @@ import toastConfig from './components/toast/ToastConfig'
 import HomeContentView from './components/views/HomeContentView'
 import * as contexts from './contexts'
 import { AuthProvider } from './contexts/auth'
+import { AppCommonsProvider, appLog } from './contexts/commons'
 import { NetworkProvider } from './contexts/network'
 import { defaultConfiguration } from './defaultConfiguration'
 import RootStack from './navigators/RootStack'
@@ -66,6 +67,7 @@ export {
   LoadingIndicator,
   indyLedgers,
   Agent,
+  AppCommonsProvider,
   AgentProvider,
   AuthProvider,
   NetworkProvider,
@@ -92,4 +94,5 @@ export {
   types,
   components,
   contexts,
+  appLog,
 }

--- a/core/App/index.ts
+++ b/core/App/index.ts
@@ -20,7 +20,7 @@ import toastConfig from './components/toast/ToastConfig'
 import HomeContentView from './components/views/HomeContentView'
 import * as contexts from './contexts'
 import { AuthProvider } from './contexts/auth'
-import { CommonUtilProvider, appLog } from './contexts/commons'
+import { CommonUtilProvider } from './contexts/commons'
 import { NetworkProvider } from './contexts/network'
 import { defaultConfiguration } from './defaultConfiguration'
 import RootStack from './navigators/RootStack'
@@ -94,5 +94,4 @@ export {
   types,
   components,
   contexts,
-  appLog,
 }

--- a/core/App/index.ts
+++ b/core/App/index.ts
@@ -94,4 +94,5 @@ export {
   types,
   components,
   contexts,
+  appLog,
 }

--- a/core/App/index.ts
+++ b/core/App/index.ts
@@ -94,5 +94,4 @@ export {
   types,
   components,
   contexts,
-  appLog,
 }

--- a/core/App/services/logger.ts
+++ b/core/App/services/logger.ts
@@ -71,9 +71,12 @@ export class AppConsoleLogger {
 
     // Log, with or without data
     if (data) {
-      console[consoleLevel](`${prefix}: ${message}`, JSON.stringify(data, replaceError, 2))
+      console[consoleLevel](
+        `${prefix}: ${new Date().toISOString()} - ${message}`,
+        JSON.stringify(data, replaceError, 2)
+      )
     } else {
-      console[consoleLevel](`${prefix}: ${message}`)
+      console[consoleLevel](`${prefix}:  ${new Date().toISOString()} - ${message}`)
     }
   }
 


### PR DESCRIPTION
# Summary of Changes

This is a "Commons" provider meant to provide a shell for all globally common properties and methods needs to be accessed by the app modules that are not Auth/Aget ..etc something like a logger service and more to come on future refactoring

I also added and export function for logger service just to make it much easier to log directly without having to import the commons context... something like
`appLog(....)`
