### PR TITLE
fix: allow persistent storage to be extended 

### DIFF
--- a/core/App/contexts/configuration.tsx
+++ b/core/App/contexts/configuration.tsx
@@ -1,4 +1,4 @@
-import { CredentialExchangeRecord, CredentialMetadataKeys, IndyPoolConfig } from '@aries-framework/core'
+import { IndyPoolConfig } from '@aries-framework/core'
 import { createContext, useContext } from 'react'
 
 import { RecordProps } from '../components/record/Record'
@@ -14,6 +14,7 @@ export interface ConfigurationContext {
   useBiometry: React.FC
   record: React.FC<RecordProps>
   indyLedgers: IndyPoolConfig[]
+  useStore: any
 }
 
 export const ConfigurationContext = createContext<ConfigurationContext>(null as unknown as ConfigurationContext)

--- a/core/App/contexts/reducers/store.ts
+++ b/core/App/contexts/reducers/store.ts
@@ -78,7 +78,7 @@ export interface ReducerAction {
   payload?: Array<any>
 }
 
-const reducer = (state: State, action: ReducerAction): State => {
+export const reducer = (state: State, action: ReducerAction): State => {
   switch (action.type) {
     case PreferencesDispatchAction.USE_BIOMETRY: {
       const choice = (action?.payload ?? []).pop() ?? false

--- a/core/App/defaultConfiguration.ts
+++ b/core/App/defaultConfiguration.ts
@@ -3,6 +3,7 @@ import defaultIndyLedgers from '../configs/ledgers/indy'
 import Record from './components/record/Record'
 import HomeContentView from './components/views/HomeContentView'
 import { ConfigurationContext } from './contexts/configuration'
+import { useStore } from './contexts/store'
 import OnboardingPages from './screens/OnboardingPages'
 import Splash from './screens/Splash'
 import Terms from './screens/Terms'
@@ -18,4 +19,5 @@ export const defaultConfiguration: ConfigurationContext = {
   useBiometry: UseBiometry,
   record: Record,
   indyLedgers: defaultIndyLedgers,
+  useStore,
 }

--- a/core/App/index.ts
+++ b/core/App/index.ts
@@ -33,7 +33,8 @@ export { LocalStorageKeys } from './constants'
 export { initLanguages, initStoredLanguage, translationResources } from './localization'
 export { ConfigurationProvider, useConfiguration } from './contexts/configuration'
 export { StoreProvider, StoreContext, useStore } from './contexts/store'
-export { DispatchAction } from './contexts/reducers/store'
+export { default as Store, DispatchAction, reducer } from './contexts/reducers/store'
+
 export { ThemeProvider, useTheme } from './contexts/theme'
 export { ColorPallet } from './theme'
 export { theme } from './theme'
@@ -55,6 +56,8 @@ export type { GenericFn } from './types/fn'
 export type { AuthenticateStackParams } from './types/navigators'
 export type { OnboardingStyleSheet }
 export type { WalletSecret } from './types/security'
+export type { State as DefaultState } from './types/state'
+export type { ReducerAction } from './contexts/reducers/store'
 
 export {
   LoadingIndicator,

--- a/core/App/screens/PinEnter.tsx
+++ b/core/App/screens/PinEnter.tsx
@@ -1,5 +1,5 @@
 import { useNavigation } from '@react-navigation/core'
-import React, { useEffect, useState, useContext } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Platform, StatusBar, Keyboard, StyleSheet, Text, Image, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
@@ -12,7 +12,7 @@ import PopupModal from '../components/modals/PopupModal'
 import { attemptLockoutBaseRules, attemptLockoutThresholdRules } from '../constants'
 import { useAuth } from '../contexts/auth'
 import { DispatchAction } from '../contexts/reducers/store'
-import { StoreContext, useStore } from '../contexts/store'
+import { useStore } from '../contexts/store'
 import { useTheme } from '../contexts/theme'
 import { Screens } from '../types/navigators'
 import { hashPIN } from '../utils/crypto'
@@ -32,7 +32,7 @@ export enum PinEntryUsage {
 const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated, pinEntryUsage = PinEntryUsage.WalletUnlock }) => {
   const { t } = useTranslation()
   const { checkPIN, getWalletCredentials, isBiometricsActive, disableBiometrics } = useAuth()
-  const [, dispatch] = useStore()
+  const [store, dispatch] = useStore()
   const [pin, setPin] = useState<string>('')
   const [continueEnabled, setContinueEnabled] = useState(true)
   const [displayLockoutWarning, setDisplayLockoutWarning] = useState(false)
@@ -40,7 +40,6 @@ const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated, pinEntryUsage = P
   const [alertModalVisible, setAlertModalVisible] = useState<boolean>(false)
   const [biometricsEnrollmentChange, setBiometricsEnrollmentChange] = useState<boolean>(false)
   const { ColorPallet, TextTheme, Assets } = useTheme()
-  const [state] = useContext(StoreContext)
 
   const style = StyleSheet.create({
     container: {
@@ -60,8 +59,8 @@ const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated, pinEntryUsage = P
       type: DispatchAction.ATTEMPT_UPDATED,
       payload: [
         {
-          loginAttempts: state.loginAttempt.loginAttempts,
-          lockoutDate: state.loginAttempt.lockoutDate,
+          loginAttempts: store.loginAttempt.loginAttempts,
+          lockoutDate: store.loginAttempt.lockoutDate,
           servedPenalty: false,
         },
       ],
@@ -73,7 +72,7 @@ const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated, pinEntryUsage = P
     dispatch({
       type: DispatchAction.ATTEMPT_UPDATED,
       payload: [
-        { loginAttempts: state.loginAttempt.loginAttempts, lockoutDate: Date.now() + penalty, servedPenalty: false },
+        { loginAttempts: store.loginAttempt.loginAttempts, lockoutDate: Date.now() + penalty, servedPenalty: false },
       ],
     })
     navigation.navigate(Screens.AttemptLockout as never)
@@ -115,7 +114,7 @@ const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated, pinEntryUsage = P
   }
 
   useEffect(() => {
-    if (!state.preferences.useBiometry) {
+    if (!store.preferences.useBiometry) {
       return
     }
 
@@ -138,9 +137,9 @@ const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated, pinEntryUsage = P
 
   useEffect(() => {
     // check number of login attempts and determine if app should apply lockout
-    const attempts = state.loginAttempt.loginAttempts
+    const attempts = store.loginAttempt.loginAttempts
     const penalty = getLockoutPenalty(attempts)
-    if (penalty && !state.loginAttempt.servedPenalty) {
+    if (penalty && !store.loginAttempt.servedPenalty) {
       // only apply lockout if user has not served their penalty
       attemptLockout(penalty)
     }
@@ -148,20 +147,20 @@ const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated, pinEntryUsage = P
     // display warning if we are one away from a lockout
     const displayWarning = !!getLockoutPenalty(attempts + 1)
     setDisplayLockoutWarning(displayWarning)
-  }, [state.loginAttempt.loginAttempts])
+  }, [store.loginAttempt.loginAttempts])
 
   const unlockWalletWithPIN = async (pin: string) => {
     try {
       setContinueEnabled(false)
       const result = await checkPIN(pin)
 
-      if (state.loginAttempt.servedPenalty) {
+      if (store.loginAttempt.servedPenalty) {
         // once the user starts entering their PIN, unMark them as having served their lockout penalty
         unMarkServedPenalty()
       }
 
       if (!result) {
-        const newAttempt = state.loginAttempt.loginAttempts + 1
+        const newAttempt = store.loginAttempt.loginAttempts + 1
         if (!getLockoutPenalty(newAttempt)) {
           // skip displaying modals if we are going to lockout
           setAlertModalVisible(true)
@@ -282,7 +281,7 @@ const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated, pinEntryUsage = P
           autoFocus={true}
         />
         {alertModalVisible && <AlertModal title={t('PinEnter.IncorrectPIN')} message="" submit={clearAlertModal} />}
-        {state.lockout.displayNotification && (
+        {store.lockout.displayNotification && (
           <PopupModal
             notificationType={InfoBoxType.Info}
             title={t('PinEnter.LoggedOut')}
@@ -315,7 +314,7 @@ const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated, pinEntryUsage = P
         />
       </View>
 
-      {state.preferences.useBiometry && pinEntryUsage === PinEntryUsage.WalletUnlock && (
+      {store.preferences.useBiometry && pinEntryUsage === PinEntryUsage.WalletUnlock && (
         <>
           <Text style={[TextTheme.normal, { alignSelf: 'center' }]}>{t('PinEnter.Or')}</Text>
           <View style={{ margin: 20, marginTop: 10 }}>

--- a/core/App/screens/PinEnter.tsx
+++ b/core/App/screens/PinEnter.tsx
@@ -11,8 +11,9 @@ import AlertModal from '../components/modals/AlertModal'
 import PopupModal from '../components/modals/PopupModal'
 import { attemptLockoutBaseRules, attemptLockoutThresholdRules } from '../constants'
 import { useAuth } from '../contexts/auth'
+import { useConfiguration } from '../contexts/configuration'
 import { DispatchAction } from '../contexts/reducers/store'
-import { useStore } from '../contexts/store'
+// import { useStore } from '../contexts/store'
 import { useTheme } from '../contexts/theme'
 import { Screens } from '../types/navigators'
 import { hashPIN } from '../utils/crypto'
@@ -32,6 +33,7 @@ export enum PinEntryUsage {
 const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated, pinEntryUsage = PinEntryUsage.WalletUnlock }) => {
   const { t } = useTranslation()
   const { checkPIN, getWalletCredentials, isBiometricsActive, disableBiometrics } = useAuth()
+  const { useStore } = useConfiguration()
   const [store, dispatch] = useStore()
   const [pin, setPin] = useState<string>('')
   const [continueEnabled, setContinueEnabled] = useState(true)


### PR DESCRIPTION
# Summary of Changes

Allow persistent storage to be extended by adding to to the config `useConfiguration()` overrides.

# Related Issues

Please reference here any issue #'s that are relevant to this PR, or simply enter "N/A" if this PR does not relate to any existing issues.

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
