### PR TITLE
fix: update accessibility interactions on PIN create screen

### DIFF
--- a/core/App/components/buttons/Button.tsx
+++ b/core/App/components/buttons/Button.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef, useState } from 'react'
 import { Text, TouchableOpacity } from 'react-native'
 
 import { useTheme } from '../../contexts/theme'
@@ -18,44 +18,42 @@ export interface ButtonProps {
   disabled?: boolean
 }
 
-export const Button: React.FC<ButtonProps> = ({
-  title,
-  buttonType,
-  accessibilityLabel,
-  testID,
-  onPress,
-  disabled = false,
-}) => {
-  const accessible = accessibilityLabel && accessibilityLabel !== '' ? true : false
-  const { Buttons, heavyOpacity } = useTheme()
-  const buttonStyles = {
-    [ButtonType.Primary]: { color: Buttons.primary, text: Buttons.primaryText },
-    [ButtonType.Secondary]: { color: Buttons.secondary, text: Buttons.secondaryText },
-    [ButtonType.Critical]: { color: Buttons.critical, text: Buttons.primaryText },
-  }
-  return (
-    <TouchableOpacity
-      onPress={onPress}
-      accessible={accessible}
-      accessibilityLabel={accessibilityLabel}
-      testID={testID}
-      style={[
-        buttonStyles[buttonType].color,
-        disabled && (buttonType === ButtonType.Primary ? Buttons.primaryDisabled : Buttons.secondaryDisabled),
-      ]}
-      disabled={disabled}
-      activeOpacity={heavyOpacity}
-    >
-      <Text
+export const Button: React.FC<ButtonProps & React.RefAttributes<HTMLInputElement | undefined>> = forwardRef(
+  ({ title, buttonType, accessibilityLabel, testID, onPress, disabled = false }, ref: any) => {
+    const accessible = accessibilityLabel && accessibilityLabel !== '' ? true : false
+    const { Buttons, heavyOpacity } = useTheme()
+    const buttonStyles = {
+      [ButtonType.Primary]: { color: Buttons.primary, text: Buttons.primaryText },
+      [ButtonType.Secondary]: { color: Buttons.secondary, text: Buttons.secondaryText },
+      [ButtonType.Critical]: { color: Buttons.critical, text: Buttons.primaryText },
+    }
+
+    return (
+      <TouchableOpacity
+        onPress={onPress}
+        accessible={accessible}
+        accessibilityLabel={accessibilityLabel}
+        testID={testID}
         style={[
-          buttonStyles[buttonType].text,
-          disabled && (buttonType === ButtonType.Primary ? Buttons.primaryTextDisabled : Buttons.secondaryTextDisabled),
+          buttonStyles[buttonType].color,
+          disabled && (buttonType === ButtonType.Primary ? Buttons.primaryDisabled : Buttons.secondaryDisabled),
         ]}
+        disabled={disabled}
+        activeOpacity={heavyOpacity}
+        ref={ref}
       >
-        {title}
-      </Text>
-    </TouchableOpacity>
-  )
-}
+        <Text
+          style={[
+            buttonStyles[buttonType].text,
+            disabled &&
+              (buttonType === ButtonType.Primary ? Buttons.primaryTextDisabled : Buttons.secondaryTextDisabled),
+          ]}
+        >
+          {title}
+        </Text>
+      </TouchableOpacity>
+    )
+  }
+)
 
 export default Button

--- a/core/App/components/inputs/PinInput.tsx
+++ b/core/App/components/inputs/PinInput.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react'
+import React, { useState, forwardRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Keyboard, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import { CodeField, useClearByFocusCell } from 'react-native-confirmation-code-field'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
@@ -16,97 +16,97 @@ interface PinInputProps {
   autoFocus?: boolean
 }
 
-const PinInput: React.FC<PinInputProps> = ({ label, onPinChanged, testID, accessibilityLabel, autoFocus = false }) => {
-  // const accessible = accessibilityLabel && accessibilityLabel !== '' ? true : false
-  const [pin, setPin] = useState('')
-  const [showPin, setShowPin] = useState(false)
-  const [props, getCellOnLayoutHandler] = useClearByFocusCell({
-    value: pin,
-    setValue: setPin,
-  })
-  const { t } = useTranslation()
-  const { TextTheme, PinInputTheme } = useTheme()
-  const style = StyleSheet.create({
-    codeField: {
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-    },
-    codeFieldRoot: {
-      marginBottom: 24,
-    },
-    cell: {
-      width: 40,
-      height: 48,
-      backgroundColor: PinInputTheme.cell.backgroundColor,
-      borderWidth: 2,
-      borderRadius: 5,
-      borderColor: PinInputTheme.cell.borderColor,
-      marginRight: 8,
-    },
-    focusedCell: {
-      borderColor: PinInputTheme.focussedCell.borderColor,
-    },
-    cellText: {
-      ...TextTheme.headingThree,
-      color: PinInputTheme.cellText.color,
-      textAlign: 'center',
-      textAlignVertical: 'center',
-      lineHeight: 42,
-    },
-  })
+const PinInput: React.FC<PinInputProps & React.RefAttributes<HTMLInputElement>> = forwardRef(
+  ({ label, onPinChanged, testID, accessibilityLabel, autoFocus = false }, ref: any) => {
+    // const accessible = accessibilityLabel && accessibilityLabel !== '' ? true : false
+    const [pin, setPin] = useState('')
+    const [showPin, setShowPin] = useState(false)
+    const [props, getCellOnLayoutHandler] = useClearByFocusCell({
+      value: pin,
+      setValue: setPin,
+    })
+    const { t } = useTranslation()
+    const { TextTheme, PinInputTheme } = useTheme()
+    const style = StyleSheet.create({
+      codeField: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+      },
+      codeFieldRoot: {
+        marginBottom: 24,
+      },
+      cell: {
+        width: 40,
+        height: 48,
+        backgroundColor: PinInputTheme.cell.backgroundColor,
+        borderWidth: 2,
+        borderRadius: 5,
+        borderColor: PinInputTheme.cell.borderColor,
+        marginRight: 8,
+      },
+      focusedCell: {
+        borderColor: PinInputTheme.focussedCell.borderColor,
+      },
+      cellText: {
+        ...TextTheme.headingThree,
+        color: PinInputTheme.cellText.color,
+        textAlign: 'center',
+        textAlignVertical: 'center',
+        lineHeight: 42,
+      },
+    })
 
-  return (
-    <View>
-      {label && <Text style={[TextTheme.label, { marginBottom: 8 }]}>{label}</Text>}
-      <View style={[style.codeField]}>
-        <CodeField
-          {...props}
-          testID={testID}
-          accessibilityLabel={accessibilityLabel}
-          accessible
-          value={pin}
-          onChangeText={(value: string) => {
-            onPinChanged && onPinChanged(value)
-            setPin(value)
-            if (value.length === minPINLength) {
-              Keyboard.dismiss()
-            }
-          }}
-          cellCount={minPINLength}
-          keyboardType="numeric"
-          textContentType="password"
-          rootStyle={style.codeFieldRoot}
-          renderCell={({ index, symbol, isFocused }) => {
-            let child = ''
-            if (symbol) {
-              child = showPin ? symbol : '•'
-            }
-            return (
-              <View
-                key={index}
-                style={[style.cell, isFocused && style.focusedCell]}
-                onLayout={getCellOnLayoutHandler(index)}
-              >
-                <Text style={[style.cellText]} maxFontSizeMultiplier={1}>
-                  {child}
-                </Text>
-              </View>
-            )
-          }}
-          autoFocus={autoFocus}
-        />
-        <TouchableOpacity
-          accessibilityLabel={showPin ? t('PinCreate.Hide') : t('PinCreate.Show')}
-          testID={showPin ? testIdWithKey('Hide') : testIdWithKey('Show')}
-          onPress={() => setShowPin(!showPin)}
-          style={[{ marginRight: 8, marginBottom: 32 }]}
-        >
-          <Icon color={PinInputTheme.icon.color} name={showPin ? 'visibility-off' : 'visibility'} size={30}></Icon>
-        </TouchableOpacity>
+    return (
+      <View>
+        {label && <Text style={[TextTheme.label, { marginBottom: 8 }]}>{label}</Text>}
+        <View style={[style.codeField]}>
+          <CodeField
+            {...props}
+            testID={testID}
+            accessibilityLabel={accessibilityLabel}
+            accessible
+            value={pin}
+            onChangeText={(value: string) => {
+              onPinChanged && onPinChanged(value)
+              setPin(value)
+            }}
+            cellCount={minPINLength}
+            keyboardType="numeric"
+            textContentType="password"
+            rootStyle={style.codeFieldRoot}
+            renderCell={({ index, symbol, isFocused }) => {
+              let child = ''
+              if (symbol) {
+                child = showPin ? symbol : '•'
+              }
+              return (
+                <View
+                  key={index}
+                  style={[style.cell, isFocused && style.focusedCell]}
+                  onLayout={getCellOnLayoutHandler(index)}
+                >
+                  <Text style={[style.cellText]} maxFontSizeMultiplier={1}>
+                    {child}
+                  </Text>
+                </View>
+              )
+            }}
+            autoFocus={autoFocus}
+            ref={ref}
+          />
+          <TouchableOpacity
+            accessibilityLabel={showPin ? t('PinCreate.Hide') : t('PinCreate.Show')}
+            testID={showPin ? testIdWithKey('Hide') : testIdWithKey('Show')}
+            onPress={() => setShowPin(!showPin)}
+            style={[{ marginRight: 8, marginBottom: 32 }]}
+          >
+            <Icon color={PinInputTheme.icon.color} name={showPin ? 'visibility-off' : 'visibility'} size={30}></Icon>
+          </TouchableOpacity>
+        </View>
       </View>
-    </View>
-  )
-}
+    )
+  }
+)
 
 export default PinInput

--- a/core/App/components/inputs/PinInput.tsx
+++ b/core/App/components/inputs/PinInput.tsx
@@ -16,7 +16,9 @@ interface PinInputProps {
   autoFocus?: boolean
 }
 
-const PinInput: React.FC<PinInputProps & React.RefAttributes<HTMLInputElement>> = forwardRef(
+// TODO:(jl) Would be great if someone can figure out the proper type for
+// ref below.
+const PinInput: React.FC<PinInputProps & React.RefAttributes<HTMLInputElement | undefined>> = forwardRef(
   ({ label, onPinChanged, testID, accessibilityLabel, autoFocus = false }, ref: any) => {
     // const accessible = accessibilityLabel && accessibilityLabel !== '' ? true : false
     const [pin, setPin] = useState('')
@@ -27,6 +29,7 @@ const PinInput: React.FC<PinInputProps & React.RefAttributes<HTMLInputElement>> 
     })
     const { t } = useTranslation()
     const { TextTheme, PinInputTheme } = useTheme()
+
     const style = StyleSheet.create({
       codeField: {
         flexDirection: 'row',

--- a/core/App/screens/PinCreate.tsx
+++ b/core/App/screens/PinCreate.tsx
@@ -1,8 +1,8 @@
 import { useNavigation } from '@react-navigation/core'
 import { StackNavigationProp } from '@react-navigation/stack'
-import React, { useState } from 'react'
+import React, { useState, createRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Platform, Keyboard, StyleSheet, Text, StatusBar, View } from 'react-native'
+import { Keyboard, StyleSheet, Text, StatusBar, View, TextInput } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import Button, { ButtonType } from '../components/buttons/Button'
@@ -14,7 +14,7 @@ import { DispatchAction } from '../contexts/reducers/store'
 import { useStore } from '../contexts/store'
 import { useTheme } from '../contexts/theme'
 import { AuthenticateStackParams, Screens } from '../types/navigators'
-import { statusBarStyleForColor, StatusBarStyles } from '../utils/luminance'
+import { StatusBarStyles } from '../utils/luminance'
 import { testIdWithKey } from '../utils/testable'
 
 interface PinCreateProps {
@@ -40,8 +40,9 @@ const PinCreate: React.FC<PinCreateProps> = ({ setAuthenticated }) => {
   const navigation = useNavigation<StackNavigationProp<AuthenticateStackParams>>()
   const [, dispatch] = useStore()
   const { t } = useTranslation()
-
+  const pinTwoInputRef = createRef<TextInput>()
   const { ColorPallet, TextTheme } = useTheme()
+
   const style = StyleSheet.create({
     container: {
       height: '100%',
@@ -127,21 +128,30 @@ const PinCreate: React.FC<PinCreateProps> = ({ setAuthenticated }) => {
         </Text>
         <PinInput
           label={t('PinCreate.EnterPINTitle')}
-          onPinChanged={setPin}
+          onPinChanged={(p: string) => {
+            setPin(p)
+
+            if (p.length === minPINLength && pinTwoInputRef.current) {
+              pinTwoInputRef.current.focus()
+            }
+          }}
           testID={testIdWithKey('EnterPIN')}
           accessibilityLabel={t('PinCreate.EnterPIN')}
-          autoFocus={true}
+          autoFocus={false}
         />
         <PinInput
           label={t('PinCreate.ReenterPIN')}
           onPinChanged={(p: string) => {
             setPinTwo(p)
+
             if (p.length === minPINLength) {
               Keyboard.dismiss()
             }
           }}
           testID={testIdWithKey('ReenterPIN')}
           accessibilityLabel={t('PinCreate.ReenterPIN')}
+          autoFocus={false}
+          ref={pinTwoInputRef}
         />
         {modalState.visible && (
           <AlertModal

--- a/core/App/screens/PinCreate.tsx
+++ b/core/App/screens/PinCreate.tsx
@@ -130,6 +130,8 @@ const PinCreate: React.FC<PinCreateProps> = ({ setAuthenticated }) => {
     }
   }
 
+  // const r: ?React.ElementRef<typeof View>
+
   return (
     <SafeAreaView>
       <StatusBar barStyle={StatusBarStyles.Light} />
@@ -144,6 +146,8 @@ const PinCreate: React.FC<PinCreateProps> = ({ setAuthenticated }) => {
 
             if (p.length === minPINLength) {
               if (pinTwoInputRef && pinTwoInputRef.current) {
+                // NOTE:(jl) `findNodeHandle` will be deprecated in React 18.
+                // https://reactnative.dev/docs/new-architecture-library-intro#preparing-your-javascript-codebase-for-the-new-react-native-renderer-fabric
                 pinTwoInputRef.current.focus()
                 const reactTag = findNodeHandle(pinTwoInputRef.current)
                 if (reactTag) {
@@ -164,6 +168,8 @@ const PinCreate: React.FC<PinCreateProps> = ({ setAuthenticated }) => {
             if (p.length === minPINLength) {
               Keyboard.dismiss()
               if (createPinButtonRef && createPinButtonRef.current) {
+                // NOTE:(jl) `findNodeHandle` will be deprecated in React 18.
+                // https://reactnative.dev/docs/new-architecture-library-intro#preparing-your-javascript-codebase-for-the-new-react-native-renderer-fabric
                 const reactTag = findNodeHandle(createPinButtonRef.current)
                 if (reactTag) {
                   AccessibilityInfo.setAccessibilityFocus(reactTag)

--- a/core/App/screens/PinCreate.tsx
+++ b/core/App/screens/PinCreate.tsx
@@ -1,8 +1,18 @@
 import { useNavigation } from '@react-navigation/core'
 import { StackNavigationProp } from '@react-navigation/stack'
-import React, { useState, createRef } from 'react'
+import React, { useState, useRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Keyboard, StyleSheet, Text, StatusBar, View, TextInput } from 'react-native'
+import {
+  AccessibilityInfo,
+  Keyboard,
+  StyleSheet,
+  Text,
+  StatusBar,
+  View,
+  TextInput,
+  TouchableOpacity,
+  findNodeHandle,
+} from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import Button, { ButtonType } from '../components/buttons/Button'
@@ -40,8 +50,9 @@ const PinCreate: React.FC<PinCreateProps> = ({ setAuthenticated }) => {
   const navigation = useNavigation<StackNavigationProp<AuthenticateStackParams>>()
   const [, dispatch] = useStore()
   const { t } = useTranslation()
-  const pinTwoInputRef = createRef<TextInput>()
   const { ColorPallet, TextTheme } = useTheme()
+  const pinTwoInputRef = useRef<TextInput>()
+  const createPinButtonRef = useRef<TouchableOpacity>()
 
   const style = StyleSheet.create({
     container: {
@@ -131,8 +142,14 @@ const PinCreate: React.FC<PinCreateProps> = ({ setAuthenticated }) => {
           onPinChanged={(p: string) => {
             setPin(p)
 
-            if (p.length === minPINLength && pinTwoInputRef.current) {
-              pinTwoInputRef.current.focus()
+            if (p.length === minPINLength) {
+              if (pinTwoInputRef && pinTwoInputRef.current) {
+                pinTwoInputRef.current.focus()
+                const reactTag = findNodeHandle(pinTwoInputRef.current)
+                if (reactTag) {
+                  AccessibilityInfo.setAccessibilityFocus(reactTag)
+                }
+              }
             }
           }}
           testID={testIdWithKey('EnterPIN')}
@@ -146,6 +163,12 @@ const PinCreate: React.FC<PinCreateProps> = ({ setAuthenticated }) => {
 
             if (p.length === minPINLength) {
               Keyboard.dismiss()
+              if (createPinButtonRef && createPinButtonRef.current) {
+                const reactTag = findNodeHandle(createPinButtonRef.current)
+                if (reactTag) {
+                  AccessibilityInfo.setAccessibilityFocus(reactTag)
+                }
+              }
             }
           }}
           testID={testIdWithKey('ReenterPIN')}
@@ -169,9 +192,9 @@ const PinCreate: React.FC<PinCreateProps> = ({ setAuthenticated }) => {
           buttonType={ButtonType.Primary}
           disabled={!continueEnabled}
           onPress={async () => {
-            Keyboard.dismiss()
             await confirmEntry(pin, pinTwo)
           }}
+          ref={createPinButtonRef}
         />
       </View>
     </SafeAreaView>

--- a/core/App/screens/PinCreate.tsx
+++ b/core/App/screens/PinCreate.tsx
@@ -146,9 +146,9 @@ const PinCreate: React.FC<PinCreateProps> = ({ setAuthenticated }) => {
 
             if (p.length === minPINLength) {
               if (pinTwoInputRef && pinTwoInputRef.current) {
+                pinTwoInputRef.current.focus()
                 // NOTE:(jl) `findNodeHandle` will be deprecated in React 18.
                 // https://reactnative.dev/docs/new-architecture-library-intro#preparing-your-javascript-codebase-for-the-new-react-native-renderer-fabric
-                pinTwoInputRef.current.focus()
                 const reactTag = findNodeHandle(pinTwoInputRef.current)
                 if (reactTag) {
                   AccessibilityInfo.setAccessibilityFocus(reactTag)

--- a/core/App/screens/PinEnter.tsx
+++ b/core/App/screens/PinEnter.tsx
@@ -18,6 +18,7 @@ import { Screens } from '../types/navigators'
 import { hashPIN } from '../utils/crypto'
 import { statusBarStyleForColor, StatusBarStyles } from '../utils/luminance'
 import { testIdWithKey } from '../utils/testable'
+import { minPINLength } from '../constants'
 
 interface PinEnterProps {
   setAuthenticated: (status: boolean) => void
@@ -269,7 +270,13 @@ const PinEnter: React.FC<PinEnterProps> = ({ setAuthenticated, pinEntryUsage = P
           <Text style={[TextTheme.normal, { alignSelf: 'center', marginBottom: 16 }]}>{t('PinEnter.EnterPIN')}</Text>
         )}
         <PinInput
-          onPinChanged={setPin}
+          onPinChanged={(p: string) => {
+            setPin(p)
+
+            if (p.length === minPINLength) {
+              Keyboard.dismiss()
+            }
+          }}
           testID={testIdWithKey('EnterPIN')}
           accessibilityLabel={t('PinEnter.EnterPIN')}
           autoFocus={true}

--- a/core/App/screens/PinEnter.tsx
+++ b/core/App/screens/PinEnter.tsx
@@ -1,7 +1,7 @@
 import { useNavigation } from '@react-navigation/core'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Platform, StatusBar, Keyboard, StyleSheet, Text, Image, View } from 'react-native'
+import { StatusBar, Keyboard, StyleSheet, Text, Image, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import { Button, ButtonType } from '../components/buttons/Button'
@@ -9,16 +9,15 @@ import PinInput from '../components/inputs/PinInput'
 import { InfoBoxType } from '../components/misc/InfoBox'
 import AlertModal from '../components/modals/AlertModal'
 import PopupModal from '../components/modals/PopupModal'
-import { attemptLockoutBaseRules, attemptLockoutThresholdRules } from '../constants'
+import { minPINLength, attemptLockoutBaseRules, attemptLockoutThresholdRules } from '../constants'
 import { useAuth } from '../contexts/auth'
 import { DispatchAction } from '../contexts/reducers/store'
 import { useStore } from '../contexts/store'
 import { useTheme } from '../contexts/theme'
 import { Screens } from '../types/navigators'
 import { hashPIN } from '../utils/crypto'
-import { statusBarStyleForColor, StatusBarStyles } from '../utils/luminance'
+import { StatusBarStyles } from '../utils/luminance'
 import { testIdWithKey } from '../utils/testable'
-import { minPINLength } from '../constants'
 
 interface PinEnterProps {
   setAuthenticated: (status: boolean) => void

--- a/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
+++ b/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`displays a credential offer screen accepting a credential 1`] = `
               }
             }
           >
-            <Button
+            <ForwardRef
               accessibilityLabel="Global.Accept"
               buttonType={1}
               disabled={false}
@@ -54,7 +54,7 @@ exports[`displays a credential offer screen accepting a credential 1`] = `
               }
             }
           >
-            <Button
+            <ForwardRef
               accessibilityLabel="Global.Decline"
               buttonType={2}
               disabled={false}
@@ -1232,7 +1232,7 @@ exports[`displays a credential offer screen declining a credential 1`] = `
               }
             }
           >
-            <Button
+            <ForwardRef
               accessibilityLabel="Global.Accept"
               buttonType={1}
               disabled={false}
@@ -1248,7 +1248,7 @@ exports[`displays a credential offer screen declining a credential 1`] = `
               }
             }
           >
-            <Button
+            <ForwardRef
               accessibilityLabel="Global.Decline"
               buttonType={2}
               disabled={false}
@@ -2426,7 +2426,7 @@ exports[`displays a credential offer screen renders correctly 1`] = `
               }
             }
           >
-            <Button
+            <ForwardRef
               accessibilityLabel="Global.Accept"
               buttonType={1}
               disabled={false}
@@ -2442,7 +2442,7 @@ exports[`displays a credential offer screen renders correctly 1`] = `
               }
             }
           >
-            <Button
+            <ForwardRef
               accessibilityLabel="Global.Decline"
               buttonType={2}
               disabled={false}


### PR DESCRIPTION
# Summary of Changes

- When creating a PIN, after the first line is entered automatically bring focust to the first character of the 2nd line;
- Improve the order of the screen reader on the PIN create screen.


# Related Issues

Please reference here any issue #'s that are relevant to this PR, or simply enter "N/A" if this PR does not relate to any existing issues.

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
