### PR TITLE
chore: adds testIDs to back button in settings stack

### DIFF
--- a/core/App/navigators/SettingStack.tsx
+++ b/core/App/navigators/SettingStack.tsx
@@ -1,6 +1,7 @@
 import { createStackNavigator } from '@react-navigation/stack'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
+import { testIdWithKey } from 'utils/testable'
 
 import { useConfiguration } from '../contexts/configuration'
 import { useTheme } from '../contexts/theme'
@@ -26,13 +27,41 @@ const SettingStack: React.FC = () => {
 
   return (
     <Stack.Navigator screenOptions={{ ...defaultStackOptions }}>
-      <Stack.Screen name={Screens.Settings} component={Settings} options={{ title: t('Screens.Settings') }} />
-      <Stack.Screen name={Screens.Language} component={Language} options={{ title: t('Screens.Language') }} />
-      <Stack.Screen name={Screens.UseBiometry} component={UseBiometry} options={{ title: t('Screens.Biometry') }} />
-      <Stack.Screen name={Screens.RecreatePIN} component={PINRecreate} options={{ title: t('Screens.ChangePIN') }} />
-      <Stack.Screen name={Screens.CreatePIN} component={PINCreate} options={{ title: t('Screens.ChangePIN') }} />
-      <Stack.Screen name={Screens.Terms} component={terms} options={{ title: t('Screens.Terms') }} />
-      <Stack.Screen name={Screens.Developer} component={developer} options={{ title: t('Screens.Developer') }} />
+      <Stack.Screen
+        name={Screens.Settings}
+        component={Settings}
+        options={{ title: t('Screens.Settings'), headerBackTestID: testIdWithKey('Back') }}
+      />
+      <Stack.Screen
+        name={Screens.Language}
+        component={Language}
+        options={{ title: t('Screens.Language'), headerBackTestID: testIdWithKey('Back') }}
+      />
+      <Stack.Screen
+        name={Screens.UseBiometry}
+        component={UseBiometry}
+        options={{ title: t('Screens.Biometry'), headerBackTestID: testIdWithKey('Back') }}
+      />
+      <Stack.Screen
+        name={Screens.RecreatePIN}
+        component={PINRecreate}
+        options={{ title: t('Screens.ChangePIN'), headerBackTestID: testIdWithKey('Back') }}
+      />
+      <Stack.Screen
+        name={Screens.CreatePIN}
+        component={PINCreate}
+        options={{ title: t('Screens.ChangePIN'), headerBackTestID: testIdWithKey('Back') }}
+      />
+      <Stack.Screen
+        name={Screens.Terms}
+        component={terms}
+        options={{ title: t('Screens.Terms'), headerBackTestID: testIdWithKey('Back') }}
+      />
+      <Stack.Screen
+        name={Screens.Developer}
+        component={developer}
+        options={{ title: t('Screens.Developer'), headerBackTestID: testIdWithKey('Back') }}
+      />
       <Stack.Screen name={Screens.Onboarding} options={{ title: t('Screens.Onboarding') }}>
         {(props) => (
           <Onboarding

--- a/core/App/navigators/SettingStack.tsx
+++ b/core/App/navigators/SettingStack.tsx
@@ -1,7 +1,6 @@
 import { createStackNavigator } from '@react-navigation/stack'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { testIdWithKey } from 'utils/testable'
 
 import { useConfiguration } from '../contexts/configuration'
 import { useTheme } from '../contexts/theme'
@@ -13,6 +12,7 @@ import PINRecreate from '../screens/PINRecreate'
 import Settings from '../screens/Settings'
 import UseBiometry from '../screens/UseBiometry'
 import { Screens, SettingStackParams } from '../types/navigators'
+import { testIdWithKey } from '../utils/testable'
 
 import { createDefaultStackOptions } from './defaultStackOptions'
 


### PR DESCRIPTION
Signed-off-by: Akiff Manji <akiff.manji@gmail.com>

# Summary of Changes

Back buttons in settings stack were missing testIDs.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [ ] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [ ] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [ ] Updated documentation as needed for changed code and new or modified features;
- [ ] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
