### PR TITLE
fix: disable back button when updating biometry

### DIFF
--- a/core/App/contexts/reducers/store.ts
+++ b/core/App/contexts/reducers/store.ts
@@ -38,6 +38,7 @@ enum PrivacyDispatchAction {
 enum PreferencesDispatchAction {
   ENABLE_DEVELOPER_MODE = 'preferences/enableDeveloperMode',
   USE_BIOMETRY = 'preferences/useBiometry',
+  BIOMETRY_PREFERENCES_UPDATED = 'preferences/biometryPreferencesUpdated',
   PREFERENCES_UPDATED = 'preferences/preferencesStateLoaded',
 }
 
@@ -108,6 +109,14 @@ export const reducer = <S extends State>(state: S, action: ReducerAction<Dispatc
       AsyncStorage.setItem(LocalStorageKeys.Preferences, JSON.stringify(preferences))
 
       return newState
+    }
+    case PreferencesDispatchAction.BIOMETRY_PREFERENCES_UPDATED: {
+      const updatePending = (action?.payload ?? []).pop() ?? false
+      const preferences = { ...state.preferences, biometryPreferencesUpdated: updatePending }
+      return {
+        ...state,
+        preferences,
+      }
     }
     case PreferencesDispatchAction.PREFERENCES_UPDATED: {
       const preferences: PreferencesState = (action?.payload || []).pop()

--- a/core/App/contexts/store.tsx
+++ b/core/App/contexts/store.tsx
@@ -33,6 +33,7 @@ export const defaultState: State = {
   },
   preferences: {
     developerModeEnabled: false,
+    biometryPreferencesUpdated: false,
     useBiometry: false,
   },
   deepLink: {

--- a/core/App/navigators/SettingStack.tsx
+++ b/core/App/navigators/SettingStack.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { useConfiguration } from '../contexts/configuration'
+import { useStore } from '../contexts/store'
 import { useTheme } from '../contexts/theme'
 import Language from '../screens/Language'
 import Onboarding from '../screens/Onboarding'
@@ -19,6 +20,7 @@ import { createDefaultStackOptions } from './defaultStackOptions'
 const SettingStack: React.FC = () => {
   const Stack = createStackNavigator<SettingStackParams>()
   const theme = useTheme()
+  const [store] = useStore()
   const { t } = useTranslation()
   const { pages, terms, developer } = useConfiguration()
   const defaultStackOptions = createDefaultStackOptions(theme)
@@ -40,7 +42,11 @@ const SettingStack: React.FC = () => {
       <Stack.Screen
         name={Screens.UseBiometry}
         component={UseBiometry}
-        options={{ title: t('Screens.Biometry'), headerBackTestID: testIdWithKey('Back') }}
+        options={{
+          title: t('Screens.Biometry'),
+          headerLeft: store.preferences.biometryPreferencesUpdated ? () => null : undefined,
+          headerBackTestID: testIdWithKey('Back'),
+        }}
       />
       <Stack.Screen
         name={Screens.RecreatePIN}

--- a/core/App/screens/UseBiometry.tsx
+++ b/core/App/screens/UseBiometry.tsx
@@ -90,7 +90,10 @@ const UseBiometry: React.FC = () => {
     // to first authenticate before this action is accepted
     if (screenUsage === UseBiometryUsage.ToggleOnOff) {
       setCanSeeCheckPIN(true)
-
+      dispatch({
+        type: DispatchAction.BIOMETRY_PREFERENCES_UPDATED,
+        payload: [true],
+      })
       return
     }
 
@@ -101,6 +104,10 @@ const UseBiometry: React.FC = () => {
     // If successfully authenticated the toggle may proceed.
     if (status) {
       setBiometryEnabled((previousState) => !previousState)
+      dispatch({
+        type: DispatchAction.BIOMETRY_PREFERENCES_UPDATED,
+        payload: [false],
+      })
     }
 
     setCanSeeCheckPIN(false)

--- a/core/App/types/state.ts
+++ b/core/App/types/state.ts
@@ -9,6 +9,7 @@ export interface Onboarding {
 
 export interface Preferences {
   useBiometry: boolean
+  biometryPreferencesUpdated: boolean
   developerModeEnabled: boolean
 }
 


### PR DESCRIPTION
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>

# Summary of Changes

Previously when updating the biometrics preferences through the settings screen, the user could sometimes click the back button before they were prompted to enter their pin. These changes disable the back button on the navigator after the user has updated their biometrics preferences, and re-enables the back button after the user has supplied their PIN.
## Before updating:
![image](https://user-images.githubusercontent.com/36937407/207126171-3666b9dc-3a77-450d-ba4d-05747a982f02.png)

## After updating:
![image](https://user-images.githubusercontent.com/36937407/207126329-fd645a43-e579-437f-afa1-3cad8a094cb5.png)

## After PIN:
![image](https://user-images.githubusercontent.com/36937407/207126453-bfd84fca-a28f-4058-a7ed-3a06e65f0e4f.png)


# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
