### PR TITLE
fix: text colour generator for default OCA bundle

### DIFF
--- a/core/App/components/misc/CredentialCard.tsx
+++ b/core/App/components/misc/CredentialCard.tsx
@@ -160,18 +160,18 @@ const CredentialCard: React.FC<CredentialCardProps> = ({ credential, style = {},
         return
       }
     }
-    OCABundle.resolve(credential).then(async (_bundle) => {
-      if (_bundle !== undefined) {
-        setBundles({ bundle1: _bundle, bundle2: undefined })
+    OCABundle.resolve(credential).then(async (bundle) => {
+      if (bundle !== undefined) {
+        setBundles({ bundle1: bundle, bundle2: undefined })
       } else {
-        await OCABundle.resolveDefaultBundle(credential).then((_defaultBundle) => {
-          setBundles({ bundle1: undefined, bundle2: _defaultBundle })
+        await OCABundle.resolveDefaultBundle(credential).then((defaultBundle) => {
+          setBundles({ bundle1: undefined, bundle2: defaultBundle })
         })
       }
     })
   }, [])
 
-  const renderCredentialCardHeader2 = () => {
+  const renderCredentialCardHeader = () => {
     return (
       <View style={[styles.outerHeaderContainer]}>
         <View testID={testIdWithKey('CredentialCardHeader')} style={[styles.innerHeaderContainer]}>
@@ -192,7 +192,9 @@ const CredentialCard: React.FC<CredentialCardProps> = ({ credential, style = {},
               style={[
                 TextTheme.label,
                 {
-                  color: overlay?.header?.color ?? credentialTextColor(overlay?.header?.backgroundColor),
+                  color:
+                    overlay?.header?.color ??
+                    credentialTextColor(overlay?.header?.backgroundColor || overlay?.backgroundColor),
                   paddingHorizontal: 0.5 * paddingHorizontal,
                   flex: !overlay?.header?.imageSource ? 4 : 3,
                   textAlignVertical: 'center',
@@ -210,7 +212,9 @@ const CredentialCard: React.FC<CredentialCardProps> = ({ credential, style = {},
             style={[
               TextTheme.label,
               {
-                color: overlay?.header?.color ?? credentialTextColor(overlay?.header?.backgroundColor),
+                color:
+                  overlay?.header?.color ??
+                  credentialTextColor(overlay?.header?.backgroundColor || overlay?.backgroundColor),
                 textAlign: 'right',
                 paddingHorizontal: 0.5 * paddingHorizontal,
                 flex: 4,
@@ -248,7 +252,9 @@ const CredentialCard: React.FC<CredentialCardProps> = ({ credential, style = {},
             style={[
               TextTheme.caption,
               {
-                color: overlay?.footer?.color ?? credentialTextColor(overlay?.footer?.backgroundColor),
+                color:
+                  overlay?.footer?.color ??
+                  credentialTextColor(overlay?.footer?.backgroundColor || overlay?.backgroundColor),
               },
             ]}
             testID={testIdWithKey('CredentialIssued')}
@@ -264,7 +270,7 @@ const CredentialCard: React.FC<CredentialCardProps> = ({ credential, style = {},
   const renderCredentialCard = (revoked = false) => {
     return (
       <>
-        {renderCredentialCardHeader2()}
+        {renderCredentialCardHeader()}
         {renderCredentialCardBody()}
         {renderCredentialCardFooter(revoked)}
       </>

--- a/core/__tests__/screens/__snapshots__/CommonDecline.test.tsx.snap
+++ b/core/__tests__/screens/__snapshots__/CommonDecline.test.tsx.snap
@@ -191,7 +191,7 @@ exports[`common decline screen decline offer renders correctly 1`] = `
                           "fontWeight": "bold",
                         },
                         Object {
-                          "color": "#FFFFFF",
+                          "color": "#313132",
                           "flex": 4,
                           "paddingHorizontal": 5,
                           "textAlignVertical": "center",
@@ -214,7 +214,7 @@ exports[`common decline screen decline offer renders correctly 1`] = `
                           "fontWeight": "bold",
                         },
                         Object {
-                          "color": "#FFFFFF",
+                          "color": "#313132",
                           "flex": 4,
                           "paddingHorizontal": 5,
                           "textAlign": "right",
@@ -259,7 +259,7 @@ exports[`common decline screen decline offer renders correctly 1`] = `
                         "fontWeight": "normal",
                       },
                       Object {
-                        "color": "#FFFFFF",
+                        "color": "#313132",
                       },
                     ]
                   }

--- a/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
+++ b/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
@@ -328,7 +328,7 @@ exports[`displays a credential offer screen accepting a credential 1`] = `
                             "fontWeight": "bold",
                           },
                           Object {
-                            "color": "#FFFFFF",
+                            "color": "#313132",
                             "flex": 4,
                             "paddingHorizontal": 5,
                             "textAlignVertical": "center",
@@ -351,7 +351,7 @@ exports[`displays a credential offer screen accepting a credential 1`] = `
                             "fontWeight": "bold",
                           },
                           Object {
-                            "color": "#FFFFFF",
+                            "color": "#313132",
                             "flex": 4,
                             "paddingHorizontal": 5,
                             "textAlign": "right",
@@ -396,7 +396,7 @@ exports[`displays a credential offer screen accepting a credential 1`] = `
                           "fontWeight": "normal",
                         },
                         Object {
-                          "color": "#FFFFFF",
+                          "color": "#313132",
                         },
                       ]
                     }
@@ -1552,7 +1552,7 @@ exports[`displays a credential offer screen declining a credential 1`] = `
                             "fontWeight": "bold",
                           },
                           Object {
-                            "color": "#FFFFFF",
+                            "color": "#313132",
                             "flex": 4,
                             "paddingHorizontal": 5,
                             "textAlignVertical": "center",
@@ -1575,7 +1575,7 @@ exports[`displays a credential offer screen declining a credential 1`] = `
                             "fontWeight": "bold",
                           },
                           Object {
-                            "color": "#FFFFFF",
+                            "color": "#313132",
                             "flex": 4,
                             "paddingHorizontal": 5,
                             "textAlign": "right",
@@ -1620,7 +1620,7 @@ exports[`displays a credential offer screen declining a credential 1`] = `
                           "fontWeight": "normal",
                         },
                         Object {
-                          "color": "#FFFFFF",
+                          "color": "#313132",
                         },
                       ]
                     }
@@ -2776,7 +2776,7 @@ exports[`displays a credential offer screen renders correctly 1`] = `
                             "fontWeight": "bold",
                           },
                           Object {
-                            "color": "#FFFFFF",
+                            "color": "#313132",
                             "flex": 4,
                             "paddingHorizontal": 5,
                             "textAlignVertical": "center",
@@ -2799,7 +2799,7 @@ exports[`displays a credential offer screen renders correctly 1`] = `
                             "fontWeight": "bold",
                           },
                           Object {
-                            "color": "#FFFFFF",
+                            "color": "#313132",
                             "flex": 4,
                             "paddingHorizontal": 5,
                             "textAlign": "right",
@@ -2844,7 +2844,7 @@ exports[`displays a credential offer screen renders correctly 1`] = `
                           "fontWeight": "normal",
                         },
                         Object {
-                          "color": "#FFFFFF",
+                          "color": "#313132",
                         },
                       ]
                     }


### PR DESCRIPTION
Signed-off-by: Akiff Manji <akiff.manji@gmail.com>

# Summary of Changes

Recent change #476 added structure for default OCA bundle that does not conform to previous credential branding properties, therefore default text colour generator was receiving an `undefined` background colour for context. This PR fixes the issue.

## Fix:
![Screenshot_1670878305](https://user-images.githubusercontent.com/5605464/207153580-60036a52-4a65-466e-98f8-4a014d922259.png)

# Related Issues

#476

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [ ] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [ ] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [ ] Updated documentation as needed for changed code and new or modified features;
- [ ] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
