### PR TITLE
feat: scroll ability to home screen for large text mode

### DIFF
--- a/core/App/screens/Home.tsx
+++ b/core/App/screens/Home.tsx
@@ -3,6 +3,7 @@ import { StackScreenProps } from '@react-navigation/stack'
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FlatList, StyleSheet, View, Text, Dimensions, TouchableOpacity } from 'react-native'
+import { ScrollView } from 'react-native-gesture-handler'
 
 import NotificationListItem, { NotificationType } from '../components/listItems/NotificationListItem'
 import NoNewUpdates from '../components/misc/NoNewUpdates'
@@ -98,7 +99,7 @@ const Home: React.FC<HomeProps> = ({ navigation }) => {
 
   return (
     <>
-      <View>
+      <ScrollView>
         <View style={styles.rowContainer}>
           <Text style={[HomeTheme.notificationsHeader, styles.header]}>
             {t('Home.Notifications')}
@@ -160,7 +161,7 @@ const Home: React.FC<HomeProps> = ({ navigation }) => {
           )}
         />
         <HomeContentView />
-      </View>
+      </ScrollView>
     </>
   )
 }

--- a/core/__tests__/screens/__snapshots__/Home.test.tsx.snap
+++ b/core/__tests__/screens/__snapshots__/Home.test.tsx.snap
@@ -1,172 +1,178 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`displays a home screen renders correctly 1`] = `
-<View>
-  <View
-    style={
-      Object {
-        "alignItems": "center",
-        "flexDirection": "row",
-        "justifyContent": "space-between",
-        "paddingHorizontal": 25,
-      }
-    }
-  >
-    <Text
+<RCTScrollView
+  collapsable={false}
+  onGestureHandlerEvent={[Function]}
+  onGestureHandlerStateChange={[Function]}
+>
+  <View>
+    <View
       style={
-        Array [
-          Object {
-            "color": "#FFFFFF",
-            "fontSize": 26,
-            "fontWeight": "bold",
-          },
-          Object {
-            "marginBottom": 20,
-            "marginTop": 25,
-          },
-        ]
+        Object {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+          "paddingHorizontal": 25,
+        }
       }
     >
-      Home.Notifications
-      
-    </Text>
-  </View>
-  <RCTScrollView
-    ListEmptyComponent={[Function]}
-    data={Array []}
-    decelerationRate="fast"
-    getItem={[Function]}
-    getItemCount={[Function]}
-    horizontal={true}
-    keyExtractor={[Function]}
-    onContentSizeChange={[Function]}
-    onLayout={[Function]}
-    onMomentumScrollBegin={[Function]}
-    onMomentumScrollEnd={[Function]}
-    onScroll={[Function]}
-    onScrollBeginDrag={[Function]}
-    onScrollEndDrag={[Function]}
-    removeClippedSubviews={false}
-    renderItem={[Function]}
-    scrollEnabled={false}
-    scrollEventThrottle={50}
-    showsHorizontalScrollIndicator={false}
-    snapToOffsets={
-      Array [
-        0,
-      ]
-    }
-    stickyHeaderIndices={Array []}
-    viewabilityConfigCallbackPairs={Array []}
-  >
-    <View>
-      <View
+      <Text
         style={
-          Object {
-            "marginHorizontal": 25,
-            "width": 700,
-          }
+          Array [
+            Object {
+              "color": "#FFFFFF",
+              "fontSize": 26,
+              "fontWeight": "bold",
+            },
+            Object {
+              "marginBottom": 20,
+              "marginTop": 25,
+            },
+          ]
         }
       >
+        Home.Notifications
+        
+      </Text>
+    </View>
+    <RCTScrollView
+      ListEmptyComponent={[Function]}
+      data={Array []}
+      decelerationRate="fast"
+      getItem={[Function]}
+      getItemCount={[Function]}
+      horizontal={true}
+      keyExtractor={[Function]}
+      onContentSizeChange={[Function]}
+      onLayout={[Function]}
+      onMomentumScrollBegin={[Function]}
+      onMomentumScrollEnd={[Function]}
+      onScroll={[Function]}
+      onScrollBeginDrag={[Function]}
+      onScrollEndDrag={[Function]}
+      removeClippedSubviews={false}
+      renderItem={[Function]}
+      scrollEnabled={false}
+      scrollEventThrottle={50}
+      showsHorizontalScrollIndicator={false}
+      snapToOffsets={
+        Array [
+          0,
+        ]
+      }
+      stickyHeaderIndices={Array []}
+      viewabilityConfigCallbackPairs={Array []}
+    >
+      <View>
         <View
           style={
             Object {
-              "backgroundColor": "#313132",
-              "borderColor": "#0099FF",
-              "borderRadius": 5,
-              "borderWidth": 1,
-              "padding": 10,
+              "marginHorizontal": 25,
+              "width": 700,
             }
           }
         >
           <View
             style={
               Object {
-                "alignItems": "center",
-                "flexDirection": "row",
+                "backgroundColor": "#313132",
+                "borderColor": "#0099FF",
+                "borderRadius": 5,
+                "borderWidth": 1,
+                "padding": 10,
               }
             }
           >
             <View
               style={
                 Object {
-                  "alignSelf": "center",
-                  "marginRight": 10,
+                  "alignItems": "center",
+                  "flexDirection": "row",
                 }
               }
             >
+              <View
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "marginRight": 10,
+                  }
+                }
+              >
+                <Text
+                  allowFontScaling={false}
+                  style={
+                    Array [
+                      Object {
+                        "color": "#0099FF",
+                        "fontSize": 30,
+                      },
+                      undefined,
+                      Object {
+                        "fontFamily": "Material Icons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  
+                </Text>
+              </View>
               <Text
-                allowFontScaling={false}
                 style={
                   Array [
                     Object {
-                      "color": "#0099FF",
-                      "fontSize": 30,
-                    },
-                    undefined,
-                    Object {
-                      "fontFamily": "Material Icons",
-                      "fontStyle": "normal",
+                      "color": "#FFFFFF",
+                      "fontSize": 18,
                       "fontWeight": "normal",
                     },
-                    Object {},
+                    Object {
+                      "flexShrink": 1,
+                    },
                   ]
                 }
+                testID="com.ariesbifold:id/NoNewUpdates"
               >
-                
+                Home.NoNewUpdates
               </Text>
             </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "justifyContent": "center",
+                  "marginHorizontal": 25,
+                  "marginTop": 35,
+                },
+              ]
+            }
+          >
             <Text
               style={
                 Array [
                   Object {
                     "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "normal",
+                    "fontSize": 38,
+                    "fontWeight": "bold",
                   },
                   Object {
-                    "flexShrink": 1,
+                    "marginBottom": 20,
+                    "marginTop": 25,
                   },
                 ]
               }
-              testID="com.ariesbifold:id/NoNewUpdates"
             >
-              Home.NoNewUpdates
+              Home.Welcome
             </Text>
           </View>
         </View>
-        <View
-          style={
-            Array [
-              Object {
-                "alignItems": "center",
-                "justifyContent": "center",
-                "marginHorizontal": 25,
-                "marginTop": 35,
-              },
-            ]
-          }
-        >
-          <Text
-            style={
-              Array [
-                Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 38,
-                  "fontWeight": "bold",
-                },
-                Object {
-                  "marginBottom": 20,
-                  "marginTop": 25,
-                },
-              ]
-            }
-          >
-            Home.Welcome
-          </Text>
-        </View>
       </View>
-    </View>
-  </RCTScrollView>
-</View>
+    </RCTScrollView>
+  </View>
+</RCTScrollView>
 `;


### PR DESCRIPTION
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>

# Summary of Changes

Before in large text mode, some of the home content would overflow and become inaccessible. This change adds a scroll view to the home screen so that if any content overflows, then the user can scroll down to access it

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
