### PR TITLE
fix: made credential list update upon revocation notice

### DIFF
--- a/core/App/components/misc/CredentialCard.tsx
+++ b/core/App/components/misc/CredentialCard.tsx
@@ -89,7 +89,7 @@ const CredentialCard: React.FC<CredentialCardProps> = ({ credential, style = {},
   const metaLayer = bundles?.bundle1?.getMetaOverlay(i18n.language) ?? bundles?.bundle2?.getMetaOverlay(i18n.language)
   const overlay = bundles?.bundle1?.getCardLayoutOverlay() ?? bundles?.bundle2?.getCardLayoutOverlay()
 
-  const [isRevoked] = useState<boolean>(credential.revocationNotification !== undefined)
+  const [isRevoked, setIsRevoked] = useState<boolean>(false)
   const bundleLoaded = bundles?.bundle1 !== undefined || bundles?.bundle2 !== undefined
 
   const credentialTextColor = (hex?: string) => {
@@ -169,6 +169,10 @@ const CredentialCard: React.FC<CredentialCardProps> = ({ credential, style = {},
     })
   }, [])
 
+  useEffect(() => {
+    setIsRevoked(credential.revocationNotification !== undefined)
+  }, [credential.revocationNotification])
+
   const renderCredentialCardHeader = () => {
     return (
       <View style={[styles.outerHeaderContainer]}>
@@ -242,7 +246,7 @@ const CredentialCard: React.FC<CredentialCardProps> = ({ credential, style = {},
               style={[TextTheme.label, { color: ColorPallet.semantic.error }]}
               testID={testIdWithKey('CredentialRevoked')}
             >
-              Revoked
+              {t('CredentialDetails.Revoked')}
             </Text>
           </View>
         ) : (


### PR DESCRIPTION
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>

# Summary of Changes

Previously the credential list screen was not updating when a credential was revoked. The user would receive a notification on the home page but there would be no visible difference in the list screen until the user restarted the app.

# Related Issues

Resolves: #563

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
