### PR TITLE
fix: stop delay message from showing immediately

### DIFF
--- a/core/App/screens/CredentialOfferAccept.tsx
+++ b/core/App/screens/CredentialOfferAccept.tsx
@@ -85,7 +85,7 @@ const CredentialOfferAccept: React.FC<CredentialOfferAcceptProps> = ({ visible, 
   }, [credential])
 
   useEffect(() => {
-    if ((timerDidFire || credentialDeliveryStatus !== DeliveryStatus.Pending) && !visible) {
+    if (timerDidFire || credentialDeliveryStatus !== DeliveryStatus.Pending || !visible) {
       return
     }
 


### PR DESCRIPTION
# Summary of Changes

Fixed logic that was causing the delay message ('This is taking longer than usual') to appear without any delay.

See the new behavior here: 
![bifold_taking_longer](https://user-images.githubusercontent.com/32586431/213577055-f390093c-2ad0-409c-944f-74f95e824463.gif)

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
