### PR TITLE
fix: Added unmount on blur to tabstack

### DIFF
--- a/core/App/navigators/TabStack.tsx
+++ b/core/App/navigators/TabStack.tsx
@@ -26,6 +26,7 @@ const TabStack: React.FC = () => {
     <SafeAreaView style={{ flex: 1, backgroundColor: ColorPallet.brand.primary }}>
       <Tab.Navigator
         screenOptions={{
+          unmountOnBlur: true,
           tabBarStyle: {
             ...TabTheme.tabBarStyle,
           },


### PR DESCRIPTION
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>

# Summary of Changes

Previously when in the credential details screen, navigating away  and then back to the credential list screen using the tab stack at the bottom of the page would navigate the user to the credential details screen instead of the credentials list screen. The same was also true for the home screen and notifications list screen.

The home screen and credential list screen buttons should always take a user to the home and credential list screens. 

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
