### PR TITLE
fix: enable dismissing keyboard by pressing outside of it

### DIFF
--- a/core/App/screens/PINEnter.tsx
+++ b/core/App/screens/PINEnter.tsx
@@ -1,7 +1,7 @@
 import { useNavigation } from '@react-navigation/core'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StatusBar, Keyboard, StyleSheet, Text, Image, View } from 'react-native'
+import { StatusBar, Keyboard, StyleSheet, Text, Image, View, TouchableWithoutFeedback, ScrollView } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import ButtonLoading from '../components/animated/ButtonLoading'
@@ -28,6 +28,18 @@ interface PINEnterProps {
 export enum PINEntryUsage {
   PINCheck,
   WalletUnlock,
+}
+
+const DismissKeyboardView: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  return (
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+      <SafeAreaView>
+        <ScrollView keyboardShouldPersistTaps={'handled'} contentContainerStyle={{ height: '100%' }}>
+          {children}
+        </ScrollView>
+      </SafeAreaView>
+    </TouchableWithoutFeedback>
+  )
 }
 
 const PINEnter: React.FC<PINEnterProps> = ({ setAuthenticated, usage = PINEntryUsage.WalletUnlock }) => {
@@ -244,7 +256,7 @@ const PINEnter: React.FC<PINEnterProps> = ({ setAuthenticated, usage = PINEntryU
   }
 
   return (
-    <SafeAreaView>
+    <DismissKeyboardView>
       <StatusBar barStyle={StatusBarStyles.Light} />
       <View style={[style.container]}>
         <Image
@@ -348,7 +360,7 @@ const PINEnter: React.FC<PINEnterProps> = ({ setAuthenticated, usage = PINEntryU
           onCallToActionPressed={clearAlertModal}
         />
       )}
-    </SafeAreaView>
+    </DismissKeyboardView>
   )
 }
 

--- a/core/__tests__/screens/__snapshots__/PINEnter.test.tsx.snap
+++ b/core/__tests__/screens/__snapshots__/PINEnter.test.tsx.snap
@@ -1,322 +1,401 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`displays a PIN create screen PIN create renders correctly 1`] = `
-<RNCSafeAreaView>
-  <View
-    style={
-      Array [
-        Object {
-          "backgroundColor": "#000000",
-          "height": "100%",
-          "padding": 20,
-        },
-      ]
+<RNCSafeAreaView
+  accessible={false}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+>
+  <RCTScrollView
+    contentContainerStyle={
+      Object {
+        "height": "100%",
+      }
     }
+    keyboardShouldPersistTaps="handled"
   >
-    <Image
-      source={
-        Object {
-          "default": "",
-        }
-      }
-      style={
-        Object {
-          "alignSelf": "center",
-          "height": "33%",
-          "marginBottom": 20,
-          "resizeMode": "contain",
-          "width": "33%",
-        }
-      }
-    />
-    <Text
-      style={
-        Array [
-          Object {
-            "color": "#FFFFFF",
-            "fontSize": 18,
-            "fontWeight": "normal",
-          },
-          Object {
-            "alignSelf": "center",
-            "marginBottom": 16,
-          },
-        ]
-      }
-    >
-      PINEnter.EnterPIN
-    </Text>
     <View>
       <View
         style={
           Array [
             Object {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "justifyContent": "space-between",
+              "backgroundColor": "#000000",
+              "height": "100%",
+              "padding": 20,
             },
           ]
         }
       >
-        <View
+        <Image
+          source={
+            Object {
+              "default": "",
+            }
+          }
+          style={
+            Object {
+              "alignSelf": "center",
+              "height": "33%",
+              "marginBottom": 20,
+              "resizeMode": "contain",
+              "width": "33%",
+            }
+          }
+        />
+        <Text
           style={
             Array [
               Object {
-                "flexDirection": "row",
-                "justifyContent": "space-between",
+                "color": "#FFFFFF",
+                "fontSize": 18,
+                "fontWeight": "normal",
               },
               Object {
-                "marginBottom": 24,
+                "alignSelf": "center",
+                "marginBottom": 16,
               },
             ]
           }
         >
+          PINEnter.EnterPIN
+        </Text>
+        <View>
           <View
-            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "backgroundColor": "#313132",
-                  "borderColor": "#313132",
-                  "borderRadius": 5,
-                  "borderWidth": 2,
-                  "height": 48,
-                  "marginRight": 8,
-                  "width": 40,
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "space-between",
                 },
-                false,
               ]
             }
           >
-            <Text
-              maxFontSizeMultiplier={1}
+            <View
               style={
                 Array [
                   Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 26,
-                    "fontWeight": "bold",
-                    "lineHeight": 42,
-                    "textAlign": "center",
-                    "textAlignVertical": "center",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                  },
+                  Object {
+                    "marginBottom": 24,
                   },
                 ]
               }
             >
-              
-            </Text>
-          </View>
-          <View
-            onLayout={[Function]}
-            style={
-              Array [
-                Object {
-                  "backgroundColor": "#313132",
-                  "borderColor": "#313132",
-                  "borderRadius": 5,
-                  "borderWidth": 2,
-                  "height": 48,
-                  "marginRight": 8,
-                  "width": 40,
-                },
-                false,
-              ]
-            }
-          >
-            <Text
-              maxFontSizeMultiplier={1}
-              style={
-                Array [
+              <View
+                onLayout={[Function]}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "#313132",
+                      "borderColor": "#313132",
+                      "borderRadius": 5,
+                      "borderWidth": 2,
+                      "height": 48,
+                      "marginRight": 8,
+                      "width": 40,
+                    },
+                    false,
+                  ]
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 26,
+                        "fontWeight": "bold",
+                        "lineHeight": 42,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      },
+                    ]
+                  }
+                >
+                  
+                </Text>
+              </View>
+              <View
+                onLayout={[Function]}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "#313132",
+                      "borderColor": "#313132",
+                      "borderRadius": 5,
+                      "borderWidth": 2,
+                      "height": 48,
+                      "marginRight": 8,
+                      "width": 40,
+                    },
+                    false,
+                  ]
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 26,
+                        "fontWeight": "bold",
+                        "lineHeight": 42,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      },
+                    ]
+                  }
+                >
+                  
+                </Text>
+              </View>
+              <View
+                onLayout={[Function]}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "#313132",
+                      "borderColor": "#313132",
+                      "borderRadius": 5,
+                      "borderWidth": 2,
+                      "height": 48,
+                      "marginRight": 8,
+                      "width": 40,
+                    },
+                    false,
+                  ]
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 26,
+                        "fontWeight": "bold",
+                        "lineHeight": 42,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      },
+                    ]
+                  }
+                >
+                  
+                </Text>
+              </View>
+              <View
+                onLayout={[Function]}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "#313132",
+                      "borderColor": "#313132",
+                      "borderRadius": 5,
+                      "borderWidth": 2,
+                      "height": 48,
+                      "marginRight": 8,
+                      "width": 40,
+                    },
+                    false,
+                  ]
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 26,
+                        "fontWeight": "bold",
+                        "lineHeight": 42,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      },
+                    ]
+                  }
+                >
+                  
+                </Text>
+              </View>
+              <View
+                onLayout={[Function]}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "#313132",
+                      "borderColor": "#313132",
+                      "borderRadius": 5,
+                      "borderWidth": 2,
+                      "height": 48,
+                      "marginRight": 8,
+                      "width": 40,
+                    },
+                    false,
+                  ]
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 26,
+                        "fontWeight": "bold",
+                        "lineHeight": 42,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      },
+                    ]
+                  }
+                >
+                  
+                </Text>
+              </View>
+              <View
+                onLayout={[Function]}
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "#313132",
+                      "borderColor": "#313132",
+                      "borderRadius": 5,
+                      "borderWidth": 2,
+                      "height": 48,
+                      "marginRight": 8,
+                      "width": 40,
+                    },
+                    false,
+                  ]
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 26,
+                        "fontWeight": "bold",
+                        "lineHeight": 42,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      },
+                    ]
+                  }
+                >
+                  
+                </Text>
+              </View>
+              <TextInput
+                accessibilityLabel="PINEnter.EnterPIN"
+                accessible={true}
+                autoCapitalize="characters"
+                autoCorrect={false}
+                autoFocus={true}
+                blurOnSubmit={false}
+                caretHidden={true}
+                clearButtonMode="never"
+                disableFullscreenUI={true}
+                keyboardType="numeric"
+                maxLength={6}
+                onBlur={[Function]}
+                onChangeText={[Function]}
+                onFocus={[Function]}
+                onPressOut={[Function]}
+                spellCheck={false}
+                style={
                   Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 26,
-                    "fontWeight": "bold",
-                    "lineHeight": 42,
-                    "textAlign": "center",
-                    "textAlignVertical": "center",
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-          </View>
-          <View
-            onLayout={[Function]}
-            style={
-              Array [
-                Object {
-                  "backgroundColor": "#313132",
-                  "borderColor": "#313132",
-                  "borderRadius": 5,
-                  "borderWidth": 2,
-                  "height": 48,
-                  "marginRight": 8,
-                  "width": 40,
-                },
-                false,
-              ]
-            }
-          >
-            <Text
-              maxFontSizeMultiplier={1}
+                    "bottom": 0,
+                    "fontSize": 1,
+                    "left": 0,
+                    "opacity": 0.01,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+                testID="com.ariesbifold:id/EnterPIN"
+                textContentType="password"
+                underlineColorAndroid="transparent"
+                value=""
+              />
+            </View>
+            <View
+              accessibilityLabel="PINCreate.Show"
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              nativeID="animatedComponent"
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 26,
-                    "fontWeight": "bold",
-                    "lineHeight": 42,
-                    "textAlign": "center",
-                    "textAlignVertical": "center",
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-          </View>
-          <View
-            onLayout={[Function]}
-            style={
-              Array [
                 Object {
-                  "backgroundColor": "#313132",
-                  "borderColor": "#313132",
-                  "borderRadius": 5,
-                  "borderWidth": 2,
-                  "height": 48,
+                  "marginBottom": 32,
                   "marginRight": 8,
-                  "width": 40,
-                },
-                false,
-              ]
-            }
-          >
-            <Text
-              maxFontSizeMultiplier={1}
-              style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 26,
-                    "fontWeight": "bold",
-                    "lineHeight": 42,
-                    "textAlign": "center",
-                    "textAlignVertical": "center",
-                  },
-                ]
+                  "opacity": 1,
+                }
               }
+              testID="com.ariesbifold:id/Show"
             >
-              
-            </Text>
+              <Text
+                allowFontScaling={false}
+                style={
+                  Array [
+                    Object {
+                      "color": "#FFFFFF",
+                      "fontSize": 30,
+                    },
+                    undefined,
+                    Object {
+                      "fontFamily": "Material Icons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                
+              </Text>
+            </View>
           </View>
-          <View
-            onLayout={[Function]}
-            style={
-              Array [
-                Object {
-                  "backgroundColor": "#313132",
-                  "borderColor": "#313132",
-                  "borderRadius": 5,
-                  "borderWidth": 2,
-                  "height": 48,
-                  "marginRight": 8,
-                  "width": 40,
-                },
-                false,
-              ]
-            }
-          >
-            <Text
-              maxFontSizeMultiplier={1}
-              style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 26,
-                    "fontWeight": "bold",
-                    "lineHeight": 42,
-                    "textAlign": "center",
-                    "textAlignVertical": "center",
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-          </View>
-          <View
-            onLayout={[Function]}
-            style={
-              Array [
-                Object {
-                  "backgroundColor": "#313132",
-                  "borderColor": "#313132",
-                  "borderRadius": 5,
-                  "borderWidth": 2,
-                  "height": 48,
-                  "marginRight": 8,
-                  "width": 40,
-                },
-                false,
-              ]
-            }
-          >
-            <Text
-              maxFontSizeMultiplier={1}
-              style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 26,
-                    "fontWeight": "bold",
-                    "lineHeight": 42,
-                    "textAlign": "center",
-                    "textAlignVertical": "center",
-                  },
-                ]
-              }
-            >
-              
-            </Text>
-          </View>
-          <TextInput
-            accessibilityLabel="PINEnter.EnterPIN"
-            accessible={true}
-            autoCapitalize="characters"
-            autoCorrect={false}
-            autoFocus={true}
-            blurOnSubmit={false}
-            caretHidden={true}
-            clearButtonMode="never"
-            disableFullscreenUI={true}
-            keyboardType="numeric"
-            maxLength={6}
-            onBlur={[Function]}
-            onChangeText={[Function]}
-            onFocus={[Function]}
-            onPressOut={[Function]}
-            spellCheck={false}
-            style={
-              Object {
-                "bottom": 0,
-                "fontSize": 1,
-                "left": 0,
-                "opacity": 0.01,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              }
-            }
-            testID="com.ariesbifold:id/EnterPIN"
-            textContentType="password"
-            underlineColorAndroid="transparent"
-            value=""
-          />
         </View>
+      </View>
+      <View
+        style={
+          Object {
+            "margin": 20,
+            "marginBottom": 10,
+            "marginTop": "auto",
+          }
+        }
+      >
         <View
-          accessibilityLabel="PINCreate.Show"
+          accessibilityLabel="PINEnter.Unlock"
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           collapsable={false}
           focusable={true}
@@ -330,100 +409,42 @@ exports[`displays a PIN create screen PIN create renders correctly 1`] = `
           onStartShouldSetResponder={[Function]}
           style={
             Object {
-              "marginBottom": 32,
-              "marginRight": 8,
+              "backgroundColor": "#42803E",
+              "borderRadius": 4,
               "opacity": 1,
+              "padding": 16,
             }
           }
-          testID="com.ariesbifold:id/Show"
+          testID="com.ariesbifold:id/Enter"
         >
-          <Text
-            allowFontScaling={false}
+          <View
             style={
-              Array [
-                Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 30,
-                },
-                undefined,
-                Object {
-                  "fontFamily": "Material Icons",
-                  "fontStyle": "normal",
-                  "fontWeight": "normal",
-                },
-                Object {},
-              ]
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+              }
             }
           >
-            
-          </Text>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                    "textAlign": "center",
+                  },
+                  false,
+                ]
+              }
+            >
+              PINEnter.Unlock
+            </Text>
+          </View>
         </View>
       </View>
     </View>
-  </View>
-  <View
-    style={
-      Object {
-        "margin": 20,
-        "marginBottom": 10,
-        "marginTop": "auto",
-      }
-    }
-  >
-    <View
-      accessibilityLabel="PINEnter.Unlock"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      nativeID="animatedComponent"
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        Object {
-          "backgroundColor": "#42803E",
-          "borderRadius": 4,
-          "opacity": 1,
-          "padding": 16,
-        }
-      }
-      testID="com.ariesbifold:id/Enter"
-    >
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "flexDirection": "row",
-            "justifyContent": "center",
-          }
-        }
-      >
-        <Text
-          style={
-            Array [
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 18,
-                "fontWeight": "bold",
-                "textAlign": "center",
-              },
-              false,
-            ]
-          }
-        >
-          PINEnter.Unlock
-        </Text>
-      </View>
-    </View>
-  </View>
+  </RCTScrollView>
 </RNCSafeAreaView>
 `;

--- a/core/__tests__/screens/__snapshots__/UseBiometry.test.tsx.snap
+++ b/core/__tests__/screens/__snapshots__/UseBiometry.test.tsx.snap
@@ -229,322 +229,399 @@ exports[`UseBiometry Screen Renders correctly when biometry available 1`] = `
     transparent={true}
     visible={false}
   >
-    <RNCSafeAreaView>
-      <View
-        style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": "100%",
-              "padding": 20,
-            },
-          ]
+    <RNCSafeAreaView
+      accessible={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+    >
+      <RCTScrollView
+        contentContainerStyle={
+          Object {
+            "height": "100%",
+          }
         }
+        keyboardShouldPersistTaps="handled"
       >
-        <Image
-          source={
-            Object {
-              "default": "",
-            }
-          }
-          style={
-            Object {
-              "alignSelf": "center",
-              "height": "33%",
-              "marginBottom": 20,
-              "resizeMode": "contain",
-              "width": "33%",
-            }
-          }
-        />
-        <Text
-          style={
-            Array [
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 18,
-                "fontWeight": "normal",
-              },
-              Object {
-                "alignSelf": "center",
-                "marginBottom": 16,
-              },
-            ]
-          }
-        >
-          PINEnter.EnterPIN
-        </Text>
         <View>
           <View
             style={
               Array [
                 Object {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "justifyContent": "space-between",
+                  "backgroundColor": "#000000",
+                  "height": "100%",
+                  "padding": 20,
                 },
               ]
             }
           >
-            <View
+            <Image
+              source={
+                Object {
+                  "default": "",
+                }
+              }
+              style={
+                Object {
+                  "alignSelf": "center",
+                  "height": "33%",
+                  "marginBottom": 20,
+                  "resizeMode": "contain",
+                  "width": "33%",
+                }
+              }
+            />
+            <Text
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "justifyContent": "space-between",
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "normal",
                   },
                   Object {
-                    "marginBottom": 24,
+                    "alignSelf": "center",
+                    "marginBottom": 16,
                   },
                 ]
               }
             >
+              PINEnter.EnterPIN
+            </Text>
+            <View>
               <View
-                onLayout={[Function]}
                 style={
                   Array [
                     Object {
-                      "backgroundColor": "#313132",
-                      "borderColor": "#313132",
-                      "borderRadius": 5,
-                      "borderWidth": 2,
-                      "height": 48,
-                      "marginRight": 8,
-                      "width": 40,
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "justifyContent": "space-between",
                     },
-                    false,
                   ]
                 }
               >
-                <Text
-                  maxFontSizeMultiplier={1}
+                <View
                   style={
                     Array [
                       Object {
-                        "color": "#FFFFFF",
-                        "fontSize": 26,
-                        "fontWeight": "bold",
-                        "lineHeight": 42,
-                        "textAlign": "center",
-                        "textAlignVertical": "center",
+                        "flexDirection": "row",
+                        "justifyContent": "space-between",
+                      },
+                      Object {
+                        "marginBottom": 24,
                       },
                     ]
                   }
                 >
-                  
-                </Text>
-              </View>
-              <View
-                onLayout={[Function]}
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "#313132",
-                      "borderColor": "#313132",
-                      "borderRadius": 5,
-                      "borderWidth": 2,
-                      "height": 48,
-                      "marginRight": 8,
-                      "width": 40,
-                    },
-                    false,
-                  ]
-                }
-              >
-                <Text
-                  maxFontSizeMultiplier={1}
-                  style={
-                    Array [
+                  <View
+                    onLayout={[Function]}
+                    style={
+                      Array [
+                        Object {
+                          "backgroundColor": "#313132",
+                          "borderColor": "#313132",
+                          "borderRadius": 5,
+                          "borderWidth": 2,
+                          "height": 48,
+                          "marginRight": 8,
+                          "width": 40,
+                        },
+                        false,
+                      ]
+                    }
+                  >
+                    <Text
+                      maxFontSizeMultiplier={1}
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 26,
+                            "fontWeight": "bold",
+                            "lineHeight": 42,
+                            "textAlign": "center",
+                            "textAlignVertical": "center",
+                          },
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <View
+                    onLayout={[Function]}
+                    style={
+                      Array [
+                        Object {
+                          "backgroundColor": "#313132",
+                          "borderColor": "#313132",
+                          "borderRadius": 5,
+                          "borderWidth": 2,
+                          "height": 48,
+                          "marginRight": 8,
+                          "width": 40,
+                        },
+                        false,
+                      ]
+                    }
+                  >
+                    <Text
+                      maxFontSizeMultiplier={1}
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 26,
+                            "fontWeight": "bold",
+                            "lineHeight": 42,
+                            "textAlign": "center",
+                            "textAlignVertical": "center",
+                          },
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <View
+                    onLayout={[Function]}
+                    style={
+                      Array [
+                        Object {
+                          "backgroundColor": "#313132",
+                          "borderColor": "#313132",
+                          "borderRadius": 5,
+                          "borderWidth": 2,
+                          "height": 48,
+                          "marginRight": 8,
+                          "width": 40,
+                        },
+                        false,
+                      ]
+                    }
+                  >
+                    <Text
+                      maxFontSizeMultiplier={1}
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 26,
+                            "fontWeight": "bold",
+                            "lineHeight": 42,
+                            "textAlign": "center",
+                            "textAlignVertical": "center",
+                          },
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <View
+                    onLayout={[Function]}
+                    style={
+                      Array [
+                        Object {
+                          "backgroundColor": "#313132",
+                          "borderColor": "#313132",
+                          "borderRadius": 5,
+                          "borderWidth": 2,
+                          "height": 48,
+                          "marginRight": 8,
+                          "width": 40,
+                        },
+                        false,
+                      ]
+                    }
+                  >
+                    <Text
+                      maxFontSizeMultiplier={1}
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 26,
+                            "fontWeight": "bold",
+                            "lineHeight": 42,
+                            "textAlign": "center",
+                            "textAlignVertical": "center",
+                          },
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <View
+                    onLayout={[Function]}
+                    style={
+                      Array [
+                        Object {
+                          "backgroundColor": "#313132",
+                          "borderColor": "#313132",
+                          "borderRadius": 5,
+                          "borderWidth": 2,
+                          "height": 48,
+                          "marginRight": 8,
+                          "width": 40,
+                        },
+                        false,
+                      ]
+                    }
+                  >
+                    <Text
+                      maxFontSizeMultiplier={1}
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 26,
+                            "fontWeight": "bold",
+                            "lineHeight": 42,
+                            "textAlign": "center",
+                            "textAlignVertical": "center",
+                          },
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <View
+                    onLayout={[Function]}
+                    style={
+                      Array [
+                        Object {
+                          "backgroundColor": "#313132",
+                          "borderColor": "#313132",
+                          "borderRadius": 5,
+                          "borderWidth": 2,
+                          "height": 48,
+                          "marginRight": 8,
+                          "width": 40,
+                        },
+                        false,
+                      ]
+                    }
+                  >
+                    <Text
+                      maxFontSizeMultiplier={1}
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 26,
+                            "fontWeight": "bold",
+                            "lineHeight": 42,
+                            "textAlign": "center",
+                            "textAlignVertical": "center",
+                          },
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <TextInput
+                    accessibilityLabel="PINEnter.EnterPIN"
+                    accessible={true}
+                    autoCapitalize="characters"
+                    autoCorrect={false}
+                    autoFocus={true}
+                    blurOnSubmit={false}
+                    caretHidden={true}
+                    clearButtonMode="never"
+                    disableFullscreenUI={true}
+                    keyboardType="numeric"
+                    maxLength={6}
+                    onBlur={[Function]}
+                    onChangeText={[Function]}
+                    onFocus={[Function]}
+                    onPressOut={[Function]}
+                    spellCheck={false}
+                    style={
                       Object {
-                        "color": "#FFFFFF",
-                        "fontSize": 26,
-                        "fontWeight": "bold",
-                        "lineHeight": 42,
-                        "textAlign": "center",
-                        "textAlignVertical": "center",
-                      },
-                    ]
-                  }
-                >
-                  
-                </Text>
-              </View>
-              <View
-                onLayout={[Function]}
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "#313132",
-                      "borderColor": "#313132",
-                      "borderRadius": 5,
-                      "borderWidth": 2,
-                      "height": 48,
-                      "marginRight": 8,
-                      "width": 40,
-                    },
-                    false,
-                  ]
-                }
-              >
-                <Text
-                  maxFontSizeMultiplier={1}
+                        "bottom": 0,
+                        "fontSize": 1,
+                        "left": 0,
+                        "opacity": 0.01,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      }
+                    }
+                    testID="com.ariesbifold:id/EnterPIN"
+                    textContentType="password"
+                    underlineColorAndroid="transparent"
+                    value=""
+                  />
+                </View>
+                <View
+                  accessibilityLabel="PINCreate.Show"
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
                   style={
-                    Array [
-                      Object {
-                        "color": "#FFFFFF",
-                        "fontSize": 26,
-                        "fontWeight": "bold",
-                        "lineHeight": 42,
-                        "textAlign": "center",
-                        "textAlignVertical": "center",
-                      },
-                    ]
-                  }
-                >
-                  
-                </Text>
-              </View>
-              <View
-                onLayout={[Function]}
-                style={
-                  Array [
                     Object {
-                      "backgroundColor": "#313132",
-                      "borderColor": "#313132",
-                      "borderRadius": 5,
-                      "borderWidth": 2,
-                      "height": 48,
+                      "marginBottom": 32,
                       "marginRight": 8,
-                      "width": 40,
-                    },
-                    false,
-                  ]
-                }
-              >
-                <Text
-                  maxFontSizeMultiplier={1}
-                  style={
-                    Array [
-                      Object {
-                        "color": "#FFFFFF",
-                        "fontSize": 26,
-                        "fontWeight": "bold",
-                        "lineHeight": 42,
-                        "textAlign": "center",
-                        "textAlignVertical": "center",
-                      },
-                    ]
+                      "opacity": 1,
+                    }
                   }
+                  testID="com.ariesbifold:id/Show"
                 >
-                  
-                </Text>
+                  <Text
+                    allowFontScaling={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "#FFFFFF",
+                          "fontSize": 30,
+                        },
+                        undefined,
+                        Object {
+                          "fontFamily": "Material Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
-              <View
-                onLayout={[Function]}
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "#313132",
-                      "borderColor": "#313132",
-                      "borderRadius": 5,
-                      "borderWidth": 2,
-                      "height": 48,
-                      "marginRight": 8,
-                      "width": 40,
-                    },
-                    false,
-                  ]
-                }
-              >
-                <Text
-                  maxFontSizeMultiplier={1}
-                  style={
-                    Array [
-                      Object {
-                        "color": "#FFFFFF",
-                        "fontSize": 26,
-                        "fontWeight": "bold",
-                        "lineHeight": 42,
-                        "textAlign": "center",
-                        "textAlignVertical": "center",
-                      },
-                    ]
-                  }
-                >
-                  
-                </Text>
-              </View>
-              <View
-                onLayout={[Function]}
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "#313132",
-                      "borderColor": "#313132",
-                      "borderRadius": 5,
-                      "borderWidth": 2,
-                      "height": 48,
-                      "marginRight": 8,
-                      "width": 40,
-                    },
-                    false,
-                  ]
-                }
-              >
-                <Text
-                  maxFontSizeMultiplier={1}
-                  style={
-                    Array [
-                      Object {
-                        "color": "#FFFFFF",
-                        "fontSize": 26,
-                        "fontWeight": "bold",
-                        "lineHeight": 42,
-                        "textAlign": "center",
-                        "textAlignVertical": "center",
-                      },
-                    ]
-                  }
-                >
-                  
-                </Text>
-              </View>
-              <TextInput
-                accessibilityLabel="PINEnter.EnterPIN"
-                accessible={true}
-                autoCapitalize="characters"
-                autoCorrect={false}
-                autoFocus={true}
-                blurOnSubmit={false}
-                caretHidden={true}
-                clearButtonMode="never"
-                disableFullscreenUI={true}
-                keyboardType="numeric"
-                maxLength={6}
-                onBlur={[Function]}
-                onChangeText={[Function]}
-                onFocus={[Function]}
-                onPressOut={[Function]}
-                spellCheck={false}
-                style={
-                  Object {
-                    "bottom": 0,
-                    "fontSize": 1,
-                    "left": 0,
-                    "opacity": 0.01,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  }
-                }
-                testID="com.ariesbifold:id/EnterPIN"
-                textContentType="password"
-                underlineColorAndroid="transparent"
-                value=""
-              />
             </View>
+          </View>
+          <View
+            style={
+              Object {
+                "margin": 20,
+                "marginBottom": 10,
+                "marginTop": "auto",
+              }
+            }
+          >
             <View
-              accessibilityLabel="PINCreate.Show"
+              accessibilityLabel="PINEnter.Unlock"
+              accessibilityState={
+                Object {
+                  "disabled": false,
+                }
+              }
               accessible={true}
               focusable={true}
               onClick={[Function]}
@@ -556,99 +633,43 @@ exports[`UseBiometry Screen Renders correctly when biometry available 1`] = `
               onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "marginBottom": 32,
-                  "marginRight": 8,
+                  "backgroundColor": "#42803E",
+                  "borderRadius": 4,
                   "opacity": 1,
+                  "padding": 16,
                 }
               }
-              testID="com.ariesbifold:id/Show"
+              testID="com.ariesbifold:id/Enter"
             >
-              <Text
-                allowFontScaling={false}
+              <View
                 style={
-                  Array [
-                    Object {
-                      "color": "#FFFFFF",
-                      "fontSize": 30,
-                    },
-                    undefined,
-                    Object {
-                      "fontFamily": "Material Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    Object {},
-                  ]
+                  Object {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                  }
                 }
               >
-                
-              </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 18,
+                        "fontWeight": "bold",
+                        "textAlign": "center",
+                      },
+                      false,
+                    ]
+                  }
+                >
+                  PINEnter.Unlock
+                </Text>
+              </View>
             </View>
           </View>
         </View>
-      </View>
-      <View
-        style={
-          Object {
-            "margin": 20,
-            "marginBottom": 10,
-            "marginTop": "auto",
-          }
-        }
-      >
-        <View
-          accessibilityLabel="PINEnter.Unlock"
-          accessibilityState={
-            Object {
-              "disabled": false,
-            }
-          }
-          accessible={true}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Object {
-              "backgroundColor": "#42803E",
-              "borderRadius": 4,
-              "opacity": 1,
-              "padding": 16,
-            }
-          }
-          testID="com.ariesbifold:id/Enter"
-        >
-          <View
-            style={
-              Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "center",
-              }
-            }
-          >
-            <Text
-              style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                    "textAlign": "center",
-                  },
-                  false,
-                ]
-              }
-            >
-              PINEnter.Unlock
-            </Text>
-          </View>
-        </View>
-      </View>
+      </RCTScrollView>
     </RNCSafeAreaView>
   </Modal>
 </RNCSafeAreaView>
@@ -868,322 +889,401 @@ exports[`UseBiometry Screen Renders correctly when biometry not available 1`] = 
     transparent={true}
     visible={false}
   >
-    <RNCSafeAreaView>
-      <View
-        style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": "100%",
-              "padding": 20,
-            },
-          ]
+    <RNCSafeAreaView
+      accessible={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+    >
+      <RCTScrollView
+        contentContainerStyle={
+          Object {
+            "height": "100%",
+          }
         }
+        keyboardShouldPersistTaps="handled"
       >
-        <Image
-          source={
-            Object {
-              "default": "",
-            }
-          }
-          style={
-            Object {
-              "alignSelf": "center",
-              "height": "33%",
-              "marginBottom": 20,
-              "resizeMode": "contain",
-              "width": "33%",
-            }
-          }
-        />
-        <Text
-          style={
-            Array [
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 18,
-                "fontWeight": "normal",
-              },
-              Object {
-                "alignSelf": "center",
-                "marginBottom": 16,
-              },
-            ]
-          }
-        >
-          PINEnter.EnterPIN
-        </Text>
         <View>
           <View
             style={
               Array [
                 Object {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "justifyContent": "space-between",
+                  "backgroundColor": "#000000",
+                  "height": "100%",
+                  "padding": 20,
                 },
               ]
             }
           >
-            <View
+            <Image
+              source={
+                Object {
+                  "default": "",
+                }
+              }
+              style={
+                Object {
+                  "alignSelf": "center",
+                  "height": "33%",
+                  "marginBottom": 20,
+                  "resizeMode": "contain",
+                  "width": "33%",
+                }
+              }
+            />
+            <Text
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "justifyContent": "space-between",
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "normal",
                   },
                   Object {
-                    "marginBottom": 24,
+                    "alignSelf": "center",
+                    "marginBottom": 16,
                   },
                 ]
               }
             >
+              PINEnter.EnterPIN
+            </Text>
+            <View>
               <View
-                onLayout={[Function]}
                 style={
                   Array [
                     Object {
-                      "backgroundColor": "#313132",
-                      "borderColor": "#313132",
-                      "borderRadius": 5,
-                      "borderWidth": 2,
-                      "height": 48,
-                      "marginRight": 8,
-                      "width": 40,
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "justifyContent": "space-between",
                     },
-                    false,
                   ]
                 }
               >
-                <Text
-                  maxFontSizeMultiplier={1}
+                <View
                   style={
                     Array [
                       Object {
-                        "color": "#FFFFFF",
-                        "fontSize": 26,
-                        "fontWeight": "bold",
-                        "lineHeight": 42,
-                        "textAlign": "center",
-                        "textAlignVertical": "center",
+                        "flexDirection": "row",
+                        "justifyContent": "space-between",
+                      },
+                      Object {
+                        "marginBottom": 24,
                       },
                     ]
                   }
                 >
-                  
-                </Text>
-              </View>
-              <View
-                onLayout={[Function]}
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "#313132",
-                      "borderColor": "#313132",
-                      "borderRadius": 5,
-                      "borderWidth": 2,
-                      "height": 48,
-                      "marginRight": 8,
-                      "width": 40,
-                    },
-                    false,
-                  ]
-                }
-              >
-                <Text
-                  maxFontSizeMultiplier={1}
-                  style={
-                    Array [
+                  <View
+                    onLayout={[Function]}
+                    style={
+                      Array [
+                        Object {
+                          "backgroundColor": "#313132",
+                          "borderColor": "#313132",
+                          "borderRadius": 5,
+                          "borderWidth": 2,
+                          "height": 48,
+                          "marginRight": 8,
+                          "width": 40,
+                        },
+                        false,
+                      ]
+                    }
+                  >
+                    <Text
+                      maxFontSizeMultiplier={1}
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 26,
+                            "fontWeight": "bold",
+                            "lineHeight": 42,
+                            "textAlign": "center",
+                            "textAlignVertical": "center",
+                          },
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <View
+                    onLayout={[Function]}
+                    style={
+                      Array [
+                        Object {
+                          "backgroundColor": "#313132",
+                          "borderColor": "#313132",
+                          "borderRadius": 5,
+                          "borderWidth": 2,
+                          "height": 48,
+                          "marginRight": 8,
+                          "width": 40,
+                        },
+                        false,
+                      ]
+                    }
+                  >
+                    <Text
+                      maxFontSizeMultiplier={1}
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 26,
+                            "fontWeight": "bold",
+                            "lineHeight": 42,
+                            "textAlign": "center",
+                            "textAlignVertical": "center",
+                          },
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <View
+                    onLayout={[Function]}
+                    style={
+                      Array [
+                        Object {
+                          "backgroundColor": "#313132",
+                          "borderColor": "#313132",
+                          "borderRadius": 5,
+                          "borderWidth": 2,
+                          "height": 48,
+                          "marginRight": 8,
+                          "width": 40,
+                        },
+                        false,
+                      ]
+                    }
+                  >
+                    <Text
+                      maxFontSizeMultiplier={1}
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 26,
+                            "fontWeight": "bold",
+                            "lineHeight": 42,
+                            "textAlign": "center",
+                            "textAlignVertical": "center",
+                          },
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <View
+                    onLayout={[Function]}
+                    style={
+                      Array [
+                        Object {
+                          "backgroundColor": "#313132",
+                          "borderColor": "#313132",
+                          "borderRadius": 5,
+                          "borderWidth": 2,
+                          "height": 48,
+                          "marginRight": 8,
+                          "width": 40,
+                        },
+                        false,
+                      ]
+                    }
+                  >
+                    <Text
+                      maxFontSizeMultiplier={1}
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 26,
+                            "fontWeight": "bold",
+                            "lineHeight": 42,
+                            "textAlign": "center",
+                            "textAlignVertical": "center",
+                          },
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <View
+                    onLayout={[Function]}
+                    style={
+                      Array [
+                        Object {
+                          "backgroundColor": "#313132",
+                          "borderColor": "#313132",
+                          "borderRadius": 5,
+                          "borderWidth": 2,
+                          "height": 48,
+                          "marginRight": 8,
+                          "width": 40,
+                        },
+                        false,
+                      ]
+                    }
+                  >
+                    <Text
+                      maxFontSizeMultiplier={1}
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 26,
+                            "fontWeight": "bold",
+                            "lineHeight": 42,
+                            "textAlign": "center",
+                            "textAlignVertical": "center",
+                          },
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <View
+                    onLayout={[Function]}
+                    style={
+                      Array [
+                        Object {
+                          "backgroundColor": "#313132",
+                          "borderColor": "#313132",
+                          "borderRadius": 5,
+                          "borderWidth": 2,
+                          "height": 48,
+                          "marginRight": 8,
+                          "width": 40,
+                        },
+                        false,
+                      ]
+                    }
+                  >
+                    <Text
+                      maxFontSizeMultiplier={1}
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 26,
+                            "fontWeight": "bold",
+                            "lineHeight": 42,
+                            "textAlign": "center",
+                            "textAlignVertical": "center",
+                          },
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <TextInput
+                    accessibilityLabel="PINEnter.EnterPIN"
+                    accessible={true}
+                    autoCapitalize="characters"
+                    autoCorrect={false}
+                    autoFocus={true}
+                    blurOnSubmit={false}
+                    caretHidden={true}
+                    clearButtonMode="never"
+                    disableFullscreenUI={true}
+                    keyboardType="numeric"
+                    maxLength={6}
+                    onBlur={[Function]}
+                    onChangeText={[Function]}
+                    onFocus={[Function]}
+                    onPressOut={[Function]}
+                    spellCheck={false}
+                    style={
                       Object {
-                        "color": "#FFFFFF",
-                        "fontSize": 26,
-                        "fontWeight": "bold",
-                        "lineHeight": 42,
-                        "textAlign": "center",
-                        "textAlignVertical": "center",
-                      },
-                    ]
-                  }
-                >
-                  
-                </Text>
-              </View>
-              <View
-                onLayout={[Function]}
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "#313132",
-                      "borderColor": "#313132",
-                      "borderRadius": 5,
-                      "borderWidth": 2,
-                      "height": 48,
-                      "marginRight": 8,
-                      "width": 40,
-                    },
-                    false,
-                  ]
-                }
-              >
-                <Text
-                  maxFontSizeMultiplier={1}
+                        "bottom": 0,
+                        "fontSize": 1,
+                        "left": 0,
+                        "opacity": 0.01,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      }
+                    }
+                    testID="com.ariesbifold:id/EnterPIN"
+                    textContentType="password"
+                    underlineColorAndroid="transparent"
+                    value=""
+                  />
+                </View>
+                <View
+                  accessibilityLabel="PINCreate.Show"
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  nativeID="animatedComponent"
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
                   style={
-                    Array [
-                      Object {
-                        "color": "#FFFFFF",
-                        "fontSize": 26,
-                        "fontWeight": "bold",
-                        "lineHeight": 42,
-                        "textAlign": "center",
-                        "textAlignVertical": "center",
-                      },
-                    ]
-                  }
-                >
-                  
-                </Text>
-              </View>
-              <View
-                onLayout={[Function]}
-                style={
-                  Array [
                     Object {
-                      "backgroundColor": "#313132",
-                      "borderColor": "#313132",
-                      "borderRadius": 5,
-                      "borderWidth": 2,
-                      "height": 48,
+                      "marginBottom": 32,
                       "marginRight": 8,
-                      "width": 40,
-                    },
-                    false,
-                  ]
-                }
-              >
-                <Text
-                  maxFontSizeMultiplier={1}
-                  style={
-                    Array [
-                      Object {
-                        "color": "#FFFFFF",
-                        "fontSize": 26,
-                        "fontWeight": "bold",
-                        "lineHeight": 42,
-                        "textAlign": "center",
-                        "textAlignVertical": "center",
-                      },
-                    ]
+                      "opacity": 1,
+                    }
                   }
+                  testID="com.ariesbifold:id/Show"
                 >
-                  
-                </Text>
+                  <Text
+                    allowFontScaling={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "#FFFFFF",
+                          "fontSize": 30,
+                        },
+                        undefined,
+                        Object {
+                          "fontFamily": "Material Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
-              <View
-                onLayout={[Function]}
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "#313132",
-                      "borderColor": "#313132",
-                      "borderRadius": 5,
-                      "borderWidth": 2,
-                      "height": 48,
-                      "marginRight": 8,
-                      "width": 40,
-                    },
-                    false,
-                  ]
-                }
-              >
-                <Text
-                  maxFontSizeMultiplier={1}
-                  style={
-                    Array [
-                      Object {
-                        "color": "#FFFFFF",
-                        "fontSize": 26,
-                        "fontWeight": "bold",
-                        "lineHeight": 42,
-                        "textAlign": "center",
-                        "textAlignVertical": "center",
-                      },
-                    ]
-                  }
-                >
-                  
-                </Text>
-              </View>
-              <View
-                onLayout={[Function]}
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "#313132",
-                      "borderColor": "#313132",
-                      "borderRadius": 5,
-                      "borderWidth": 2,
-                      "height": 48,
-                      "marginRight": 8,
-                      "width": 40,
-                    },
-                    false,
-                  ]
-                }
-              >
-                <Text
-                  maxFontSizeMultiplier={1}
-                  style={
-                    Array [
-                      Object {
-                        "color": "#FFFFFF",
-                        "fontSize": 26,
-                        "fontWeight": "bold",
-                        "lineHeight": 42,
-                        "textAlign": "center",
-                        "textAlignVertical": "center",
-                      },
-                    ]
-                  }
-                >
-                  
-                </Text>
-              </View>
-              <TextInput
-                accessibilityLabel="PINEnter.EnterPIN"
-                accessible={true}
-                autoCapitalize="characters"
-                autoCorrect={false}
-                autoFocus={true}
-                blurOnSubmit={false}
-                caretHidden={true}
-                clearButtonMode="never"
-                disableFullscreenUI={true}
-                keyboardType="numeric"
-                maxLength={6}
-                onBlur={[Function]}
-                onChangeText={[Function]}
-                onFocus={[Function]}
-                onPressOut={[Function]}
-                spellCheck={false}
-                style={
-                  Object {
-                    "bottom": 0,
-                    "fontSize": 1,
-                    "left": 0,
-                    "opacity": 0.01,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  }
-                }
-                testID="com.ariesbifold:id/EnterPIN"
-                textContentType="password"
-                underlineColorAndroid="transparent"
-                value=""
-              />
             </View>
+          </View>
+          <View
+            style={
+              Object {
+                "margin": 20,
+                "marginBottom": 10,
+                "marginTop": "auto",
+              }
+            }
+          >
             <View
-              accessibilityLabel="PINCreate.Show"
+              accessibilityLabel="PINEnter.Unlock"
+              accessibilityState={
+                Object {
+                  "disabled": false,
+                }
+              }
               accessible={true}
               collapsable={false}
               focusable={true}
@@ -1197,101 +1297,43 @@ exports[`UseBiometry Screen Renders correctly when biometry not available 1`] = 
               onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "marginBottom": 32,
-                  "marginRight": 8,
+                  "backgroundColor": "#42803E",
+                  "borderRadius": 4,
                   "opacity": 1,
+                  "padding": 16,
                 }
               }
-              testID="com.ariesbifold:id/Show"
+              testID="com.ariesbifold:id/Enter"
             >
-              <Text
-                allowFontScaling={false}
+              <View
                 style={
-                  Array [
-                    Object {
-                      "color": "#FFFFFF",
-                      "fontSize": 30,
-                    },
-                    undefined,
-                    Object {
-                      "fontFamily": "Material Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    Object {},
-                  ]
+                  Object {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                  }
                 }
               >
-                
-              </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 18,
+                        "fontWeight": "bold",
+                        "textAlign": "center",
+                      },
+                      false,
+                    ]
+                  }
+                >
+                  PINEnter.Unlock
+                </Text>
+              </View>
             </View>
           </View>
         </View>
-      </View>
-      <View
-        style={
-          Object {
-            "margin": 20,
-            "marginBottom": 10,
-            "marginTop": "auto",
-          }
-        }
-      >
-        <View
-          accessibilityLabel="PINEnter.Unlock"
-          accessibilityState={
-            Object {
-              "disabled": false,
-            }
-          }
-          accessible={true}
-          collapsable={false}
-          focusable={true}
-          nativeID="animatedComponent"
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Object {
-              "backgroundColor": "#42803E",
-              "borderRadius": 4,
-              "opacity": 1,
-              "padding": 16,
-            }
-          }
-          testID="com.ariesbifold:id/Enter"
-        >
-          <View
-            style={
-              Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "center",
-              }
-            }
-          >
-            <Text
-              style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                    "textAlign": "center",
-                  },
-                  false,
-                ]
-              }
-            >
-              PINEnter.Unlock
-            </Text>
-          </View>
-        </View>
-      </View>
+      </RCTScrollView>
     </RNCSafeAreaView>
   </Modal>
 </RNCSafeAreaView>
@@ -1565,322 +1607,399 @@ exports[`UseBiometry Screen Toggles use biometrics ok 1`] = `
     transparent={true}
     visible={false}
   >
-    <RNCSafeAreaView>
-      <View
-        style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": "100%",
-              "padding": 20,
-            },
-          ]
+    <RNCSafeAreaView
+      accessible={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+    >
+      <RCTScrollView
+        contentContainerStyle={
+          Object {
+            "height": "100%",
+          }
         }
+        keyboardShouldPersistTaps="handled"
       >
-        <Image
-          source={
-            Object {
-              "default": "",
-            }
-          }
-          style={
-            Object {
-              "alignSelf": "center",
-              "height": "33%",
-              "marginBottom": 20,
-              "resizeMode": "contain",
-              "width": "33%",
-            }
-          }
-        />
-        <Text
-          style={
-            Array [
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 18,
-                "fontWeight": "normal",
-              },
-              Object {
-                "alignSelf": "center",
-                "marginBottom": 16,
-              },
-            ]
-          }
-        >
-          PINEnter.EnterPIN
-        </Text>
         <View>
           <View
             style={
               Array [
                 Object {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "justifyContent": "space-between",
+                  "backgroundColor": "#000000",
+                  "height": "100%",
+                  "padding": 20,
                 },
               ]
             }
           >
-            <View
+            <Image
+              source={
+                Object {
+                  "default": "",
+                }
+              }
+              style={
+                Object {
+                  "alignSelf": "center",
+                  "height": "33%",
+                  "marginBottom": 20,
+                  "resizeMode": "contain",
+                  "width": "33%",
+                }
+              }
+            />
+            <Text
               style={
                 Array [
                   Object {
-                    "flexDirection": "row",
-                    "justifyContent": "space-between",
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "normal",
                   },
                   Object {
-                    "marginBottom": 24,
+                    "alignSelf": "center",
+                    "marginBottom": 16,
                   },
                 ]
               }
             >
+              PINEnter.EnterPIN
+            </Text>
+            <View>
               <View
-                onLayout={[Function]}
                 style={
                   Array [
                     Object {
-                      "backgroundColor": "#313132",
-                      "borderColor": "#313132",
-                      "borderRadius": 5,
-                      "borderWidth": 2,
-                      "height": 48,
-                      "marginRight": 8,
-                      "width": 40,
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "justifyContent": "space-between",
                     },
-                    false,
                   ]
                 }
               >
-                <Text
-                  maxFontSizeMultiplier={1}
+                <View
                   style={
                     Array [
                       Object {
-                        "color": "#FFFFFF",
-                        "fontSize": 26,
-                        "fontWeight": "bold",
-                        "lineHeight": 42,
-                        "textAlign": "center",
-                        "textAlignVertical": "center",
+                        "flexDirection": "row",
+                        "justifyContent": "space-between",
+                      },
+                      Object {
+                        "marginBottom": 24,
                       },
                     ]
                   }
                 >
-                  
-                </Text>
-              </View>
-              <View
-                onLayout={[Function]}
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "#313132",
-                      "borderColor": "#313132",
-                      "borderRadius": 5,
-                      "borderWidth": 2,
-                      "height": 48,
-                      "marginRight": 8,
-                      "width": 40,
-                    },
-                    false,
-                  ]
-                }
-              >
-                <Text
-                  maxFontSizeMultiplier={1}
-                  style={
-                    Array [
+                  <View
+                    onLayout={[Function]}
+                    style={
+                      Array [
+                        Object {
+                          "backgroundColor": "#313132",
+                          "borderColor": "#313132",
+                          "borderRadius": 5,
+                          "borderWidth": 2,
+                          "height": 48,
+                          "marginRight": 8,
+                          "width": 40,
+                        },
+                        false,
+                      ]
+                    }
+                  >
+                    <Text
+                      maxFontSizeMultiplier={1}
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 26,
+                            "fontWeight": "bold",
+                            "lineHeight": 42,
+                            "textAlign": "center",
+                            "textAlignVertical": "center",
+                          },
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <View
+                    onLayout={[Function]}
+                    style={
+                      Array [
+                        Object {
+                          "backgroundColor": "#313132",
+                          "borderColor": "#313132",
+                          "borderRadius": 5,
+                          "borderWidth": 2,
+                          "height": 48,
+                          "marginRight": 8,
+                          "width": 40,
+                        },
+                        false,
+                      ]
+                    }
+                  >
+                    <Text
+                      maxFontSizeMultiplier={1}
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 26,
+                            "fontWeight": "bold",
+                            "lineHeight": 42,
+                            "textAlign": "center",
+                            "textAlignVertical": "center",
+                          },
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <View
+                    onLayout={[Function]}
+                    style={
+                      Array [
+                        Object {
+                          "backgroundColor": "#313132",
+                          "borderColor": "#313132",
+                          "borderRadius": 5,
+                          "borderWidth": 2,
+                          "height": 48,
+                          "marginRight": 8,
+                          "width": 40,
+                        },
+                        false,
+                      ]
+                    }
+                  >
+                    <Text
+                      maxFontSizeMultiplier={1}
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 26,
+                            "fontWeight": "bold",
+                            "lineHeight": 42,
+                            "textAlign": "center",
+                            "textAlignVertical": "center",
+                          },
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <View
+                    onLayout={[Function]}
+                    style={
+                      Array [
+                        Object {
+                          "backgroundColor": "#313132",
+                          "borderColor": "#313132",
+                          "borderRadius": 5,
+                          "borderWidth": 2,
+                          "height": 48,
+                          "marginRight": 8,
+                          "width": 40,
+                        },
+                        false,
+                      ]
+                    }
+                  >
+                    <Text
+                      maxFontSizeMultiplier={1}
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 26,
+                            "fontWeight": "bold",
+                            "lineHeight": 42,
+                            "textAlign": "center",
+                            "textAlignVertical": "center",
+                          },
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <View
+                    onLayout={[Function]}
+                    style={
+                      Array [
+                        Object {
+                          "backgroundColor": "#313132",
+                          "borderColor": "#313132",
+                          "borderRadius": 5,
+                          "borderWidth": 2,
+                          "height": 48,
+                          "marginRight": 8,
+                          "width": 40,
+                        },
+                        false,
+                      ]
+                    }
+                  >
+                    <Text
+                      maxFontSizeMultiplier={1}
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 26,
+                            "fontWeight": "bold",
+                            "lineHeight": 42,
+                            "textAlign": "center",
+                            "textAlignVertical": "center",
+                          },
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <View
+                    onLayout={[Function]}
+                    style={
+                      Array [
+                        Object {
+                          "backgroundColor": "#313132",
+                          "borderColor": "#313132",
+                          "borderRadius": 5,
+                          "borderWidth": 2,
+                          "height": 48,
+                          "marginRight": 8,
+                          "width": 40,
+                        },
+                        false,
+                      ]
+                    }
+                  >
+                    <Text
+                      maxFontSizeMultiplier={1}
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 26,
+                            "fontWeight": "bold",
+                            "lineHeight": 42,
+                            "textAlign": "center",
+                            "textAlignVertical": "center",
+                          },
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <TextInput
+                    accessibilityLabel="PINEnter.EnterPIN"
+                    accessible={true}
+                    autoCapitalize="characters"
+                    autoCorrect={false}
+                    autoFocus={true}
+                    blurOnSubmit={false}
+                    caretHidden={true}
+                    clearButtonMode="never"
+                    disableFullscreenUI={true}
+                    keyboardType="numeric"
+                    maxLength={6}
+                    onBlur={[Function]}
+                    onChangeText={[Function]}
+                    onFocus={[Function]}
+                    onPressOut={[Function]}
+                    spellCheck={false}
+                    style={
                       Object {
-                        "color": "#FFFFFF",
-                        "fontSize": 26,
-                        "fontWeight": "bold",
-                        "lineHeight": 42,
-                        "textAlign": "center",
-                        "textAlignVertical": "center",
-                      },
-                    ]
-                  }
-                >
-                  
-                </Text>
-              </View>
-              <View
-                onLayout={[Function]}
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "#313132",
-                      "borderColor": "#313132",
-                      "borderRadius": 5,
-                      "borderWidth": 2,
-                      "height": 48,
-                      "marginRight": 8,
-                      "width": 40,
-                    },
-                    false,
-                  ]
-                }
-              >
-                <Text
-                  maxFontSizeMultiplier={1}
+                        "bottom": 0,
+                        "fontSize": 1,
+                        "left": 0,
+                        "opacity": 0.01,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                      }
+                    }
+                    testID="com.ariesbifold:id/EnterPIN"
+                    textContentType="password"
+                    underlineColorAndroid="transparent"
+                    value=""
+                  />
+                </View>
+                <View
+                  accessibilityLabel="PINCreate.Show"
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
                   style={
-                    Array [
-                      Object {
-                        "color": "#FFFFFF",
-                        "fontSize": 26,
-                        "fontWeight": "bold",
-                        "lineHeight": 42,
-                        "textAlign": "center",
-                        "textAlignVertical": "center",
-                      },
-                    ]
-                  }
-                >
-                  
-                </Text>
-              </View>
-              <View
-                onLayout={[Function]}
-                style={
-                  Array [
                     Object {
-                      "backgroundColor": "#313132",
-                      "borderColor": "#313132",
-                      "borderRadius": 5,
-                      "borderWidth": 2,
-                      "height": 48,
+                      "marginBottom": 32,
                       "marginRight": 8,
-                      "width": 40,
-                    },
-                    false,
-                  ]
-                }
-              >
-                <Text
-                  maxFontSizeMultiplier={1}
-                  style={
-                    Array [
-                      Object {
-                        "color": "#FFFFFF",
-                        "fontSize": 26,
-                        "fontWeight": "bold",
-                        "lineHeight": 42,
-                        "textAlign": "center",
-                        "textAlignVertical": "center",
-                      },
-                    ]
+                      "opacity": 1,
+                    }
                   }
+                  testID="com.ariesbifold:id/Show"
                 >
-                  
-                </Text>
+                  <Text
+                    allowFontScaling={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "#FFFFFF",
+                          "fontSize": 30,
+                        },
+                        undefined,
+                        Object {
+                          "fontFamily": "Material Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
-              <View
-                onLayout={[Function]}
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "#313132",
-                      "borderColor": "#313132",
-                      "borderRadius": 5,
-                      "borderWidth": 2,
-                      "height": 48,
-                      "marginRight": 8,
-                      "width": 40,
-                    },
-                    false,
-                  ]
-                }
-              >
-                <Text
-                  maxFontSizeMultiplier={1}
-                  style={
-                    Array [
-                      Object {
-                        "color": "#FFFFFF",
-                        "fontSize": 26,
-                        "fontWeight": "bold",
-                        "lineHeight": 42,
-                        "textAlign": "center",
-                        "textAlignVertical": "center",
-                      },
-                    ]
-                  }
-                >
-                  
-                </Text>
-              </View>
-              <View
-                onLayout={[Function]}
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "#313132",
-                      "borderColor": "#313132",
-                      "borderRadius": 5,
-                      "borderWidth": 2,
-                      "height": 48,
-                      "marginRight": 8,
-                      "width": 40,
-                    },
-                    false,
-                  ]
-                }
-              >
-                <Text
-                  maxFontSizeMultiplier={1}
-                  style={
-                    Array [
-                      Object {
-                        "color": "#FFFFFF",
-                        "fontSize": 26,
-                        "fontWeight": "bold",
-                        "lineHeight": 42,
-                        "textAlign": "center",
-                        "textAlignVertical": "center",
-                      },
-                    ]
-                  }
-                >
-                  
-                </Text>
-              </View>
-              <TextInput
-                accessibilityLabel="PINEnter.EnterPIN"
-                accessible={true}
-                autoCapitalize="characters"
-                autoCorrect={false}
-                autoFocus={true}
-                blurOnSubmit={false}
-                caretHidden={true}
-                clearButtonMode="never"
-                disableFullscreenUI={true}
-                keyboardType="numeric"
-                maxLength={6}
-                onBlur={[Function]}
-                onChangeText={[Function]}
-                onFocus={[Function]}
-                onPressOut={[Function]}
-                spellCheck={false}
-                style={
-                  Object {
-                    "bottom": 0,
-                    "fontSize": 1,
-                    "left": 0,
-                    "opacity": 0.01,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  }
-                }
-                testID="com.ariesbifold:id/EnterPIN"
-                textContentType="password"
-                underlineColorAndroid="transparent"
-                value=""
-              />
             </View>
+          </View>
+          <View
+            style={
+              Object {
+                "margin": 20,
+                "marginBottom": 10,
+                "marginTop": "auto",
+              }
+            }
+          >
             <View
-              accessibilityLabel="PINCreate.Show"
+              accessibilityLabel="PINEnter.Unlock"
+              accessibilityState={
+                Object {
+                  "disabled": false,
+                }
+              }
               accessible={true}
               focusable={true}
               onClick={[Function]}
@@ -1892,99 +2011,43 @@ exports[`UseBiometry Screen Toggles use biometrics ok 1`] = `
               onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "marginBottom": 32,
-                  "marginRight": 8,
+                  "backgroundColor": "#42803E",
+                  "borderRadius": 4,
                   "opacity": 1,
+                  "padding": 16,
                 }
               }
-              testID="com.ariesbifold:id/Show"
+              testID="com.ariesbifold:id/Enter"
             >
-              <Text
-                allowFontScaling={false}
+              <View
                 style={
-                  Array [
-                    Object {
-                      "color": "#FFFFFF",
-                      "fontSize": 30,
-                    },
-                    undefined,
-                    Object {
-                      "fontFamily": "Material Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    Object {},
-                  ]
+                  Object {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                  }
                 }
               >
-                
-              </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 18,
+                        "fontWeight": "bold",
+                        "textAlign": "center",
+                      },
+                      false,
+                    ]
+                  }
+                >
+                  PINEnter.Unlock
+                </Text>
+              </View>
             </View>
           </View>
         </View>
-      </View>
-      <View
-        style={
-          Object {
-            "margin": 20,
-            "marginBottom": 10,
-            "marginTop": "auto",
-          }
-        }
-      >
-        <View
-          accessibilityLabel="PINEnter.Unlock"
-          accessibilityState={
-            Object {
-              "disabled": false,
-            }
-          }
-          accessible={true}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Object {
-              "backgroundColor": "#42803E",
-              "borderRadius": 4,
-              "opacity": 1,
-              "padding": 16,
-            }
-          }
-          testID="com.ariesbifold:id/Enter"
-        >
-          <View
-            style={
-              Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "center",
-              }
-            }
-          >
-            <Text
-              style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                    "textAlign": "center",
-                  },
-                  false,
-                ]
-              }
-            >
-              PINEnter.Unlock
-            </Text>
-          </View>
-        </View>
-      </View>
+      </RCTScrollView>
     </RNCSafeAreaView>
   </Modal>
 </RNCSafeAreaView>


### PR DESCRIPTION
# Summary of Changes

Allow dismissing of keyboard by tapping outside of keyboard in empty space (not on buttons or inputs, those function as normal without dismissing the keyboard)

Dismissing the keyboard on iOS with normal zoom and font size:
![iOS_Dismiss](https://user-images.githubusercontent.com/32586431/218231137-35c8f0c3-1bc8-4de2-8234-716d12d7e29e.gif)

Dismissing the keyboard on iOS with max zoom and max font size:
![iOS_Zoom_Dismiss](https://user-images.githubusercontent.com/32586431/218231145-50e0ff45-6b80-43d2-baae-805a5c7d309a.gif)

Dismissing the keyboard on Android:
![Android_Dismiss](https://user-images.githubusercontent.com/32586431/218231155-f53c1059-b6a3-4593-a0c6-d7b9d51876b4.gif)

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
