### PR TITLE
fix: adjust view to prevent inputs hidden by keyboard

### DIFF
--- a/core/App/screens/PINCreate.tsx
+++ b/core/App/screens/PINCreate.tsx
@@ -13,6 +13,9 @@ import {
   TouchableOpacity,
   findNodeHandle,
   ScrollView,
+  KeyboardAvoidingView,
+  Platform,
+  TouchableWithoutFeedback,
 } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialIcons'
@@ -41,6 +44,18 @@ interface ModalState {
   visible: boolean
   title: string
   message: string
+}
+
+const KeyboardView: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  return (
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+      <SafeAreaView style={{ flex: 1 }}>
+        <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+          <ScrollView keyboardShouldPersistTaps={'handled'}>{children}</ScrollView>
+        </KeyboardAvoidingView>
+      </SafeAreaView>
+    </TouchableWithoutFeedback>
+  )
 }
 
 const PINCreate: React.FC<PINCreateProps> = ({ setAuthenticated }) => {
@@ -119,100 +134,98 @@ const PINCreate: React.FC<PINCreateProps> = ({ setAuthenticated }) => {
   // const r: ?React.ElementRef<typeof View>
 
   return (
-    <SafeAreaView>
+    <KeyboardView>
       <StatusBar barStyle={StatusBarStyles.Light} />
-      <ScrollView>
-        <View style={[style.container]}>
-          <Text style={[TextTheme.normal, { marginBottom: 16 }]}>
-            <Text style={{ fontWeight: 'bold' }}>{t('PINCreate.RememberPIN')}</Text> {t('PINCreate.PINDisclaimer')}
-          </Text>
-          <PINInput
-            label={t('PINCreate.EnterPINTitle')}
-            onPINChanged={(p: string) => {
-              setPIN(p)
-              setPINOneValidations(PINCreationValidations(p, PINSecurity.rules))
+      <View style={[style.container]}>
+        <Text style={[TextTheme.normal, { marginBottom: 16 }]}>
+          <Text style={{ fontWeight: 'bold' }}>{t('PINCreate.RememberPIN')}</Text> {t('PINCreate.PINDisclaimer')}
+        </Text>
+        <PINInput
+          label={t('PINCreate.EnterPINTitle')}
+          onPINChanged={(p: string) => {
+            setPIN(p)
+            setPINOneValidations(PINCreationValidations(p, PINSecurity.rules))
 
-              if (p.length === minPINLength) {
-                if (PINTwoInputRef && PINTwoInputRef.current) {
-                  PINTwoInputRef.current.focus()
-                  // NOTE:(jl) `findNodeHandle` will be deprecated in React 18.
-                  // https://reactnative.dev/docs/new-architecture-library-intro#preparing-your-javascript-codebase-for-the-new-react-native-renderer-fabric
-                  const reactTag = findNodeHandle(PINTwoInputRef.current)
-                  if (reactTag) {
-                    AccessibilityInfo.setAccessibilityFocus(reactTag)
-                  }
+            if (p.length === minPINLength) {
+              if (PINTwoInputRef && PINTwoInputRef.current) {
+                PINTwoInputRef.current.focus()
+                // NOTE:(jl) `findNodeHandle` will be deprecated in React 18.
+                // https://reactnative.dev/docs/new-architecture-library-intro#preparing-your-javascript-codebase-for-the-new-react-native-renderer-fabric
+                const reactTag = findNodeHandle(PINTwoInputRef.current)
+                if (reactTag) {
+                  AccessibilityInfo.setAccessibilityFocus(reactTag)
                 }
               }
-            }}
-            testID={testIdWithKey('EnterPIN')}
-            accessibilityLabel={t('PINCreate.EnterPIN')}
-            autoFocus={false}
-          />
-          {PINSecurity.displayHelper && (
-            <View style={{ marginBottom: 16 }}>
-              {PINOneValidations.map((validation, index) => {
-                return (
-                  <View style={{ flexDirection: 'row' }} key={index}>
-                    {validation.isInvalid ? (
-                      <Icon name="clear" size={24} color={ColorPallet.notification.errorIcon} />
-                    ) : (
-                      <Icon name="check" size={24} color={ColorPallet.notification.success} />
-                    )}
-                    <Text style={[TextTheme.normal, { paddingLeft: 4 }]}>
-                      {t(`PINCreate.Helper.${validation.errorName}`)}
-                    </Text>
-                  </View>
-                )
-              })}
-            </View>
-          )}
-          <PINInput
-            label={t('PINCreate.ReenterPIN')}
-            onPINChanged={(p: string) => {
-              setPINTwo(p)
+            }
+          }}
+          testID={testIdWithKey('EnterPIN')}
+          accessibilityLabel={t('PINCreate.EnterPIN')}
+          autoFocus={false}
+        />
+        {PINSecurity.displayHelper && (
+          <View style={{ marginBottom: 16 }}>
+            {PINOneValidations.map((validation, index) => {
+              return (
+                <View style={{ flexDirection: 'row' }} key={index}>
+                  {validation.isInvalid ? (
+                    <Icon name="clear" size={24} color={ColorPallet.notification.errorIcon} />
+                  ) : (
+                    <Icon name="check" size={24} color={ColorPallet.notification.success} />
+                  )}
+                  <Text style={[TextTheme.normal, { paddingLeft: 4 }]}>
+                    {t(`PINCreate.Helper.${validation.errorName}`)}
+                  </Text>
+                </View>
+              )
+            })}
+          </View>
+        )}
+        <PINInput
+          label={t('PINCreate.ReenterPIN')}
+          onPINChanged={(p: string) => {
+            setPINTwo(p)
 
-              if (p.length === minPINLength) {
-                Keyboard.dismiss()
-                if (createPINButtonRef && createPINButtonRef.current) {
-                  // NOTE:(jl) `findNodeHandle` will be deprecated in React 18.
-                  // https://reactnative.dev/docs/new-architecture-library-intro#preparing-your-javascript-codebase-for-the-new-react-native-renderer-fabric
-                  const reactTag = findNodeHandle(createPINButtonRef.current)
-                  if (reactTag) {
-                    AccessibilityInfo.setAccessibilityFocus(reactTag)
-                  }
+            if (p.length === minPINLength) {
+              Keyboard.dismiss()
+              if (createPINButtonRef && createPINButtonRef.current) {
+                // NOTE:(jl) `findNodeHandle` will be deprecated in React 18.
+                // https://reactnative.dev/docs/new-architecture-library-intro#preparing-your-javascript-codebase-for-the-new-react-native-renderer-fabric
+                const reactTag = findNodeHandle(createPINButtonRef.current)
+                if (reactTag) {
+                  AccessibilityInfo.setAccessibilityFocus(reactTag)
                 }
               }
-            }}
-            testID={testIdWithKey('ReenterPIN')}
-            accessibilityLabel={t('PINCreate.ReenterPIN')}
-            autoFocus={false}
-            ref={PINTwoInputRef}
+            }
+          }}
+          testID={testIdWithKey('ReenterPIN')}
+          accessibilityLabel={t('PINCreate.ReenterPIN')}
+          autoFocus={false}
+          ref={PINTwoInputRef}
+        />
+        {modalState.visible && (
+          <AlertModal
+            title={modalState.title}
+            message={modalState.message}
+            submit={() => setModalState({ ...modalState, visible: false })}
           />
-          {modalState.visible && (
-            <AlertModal
-              title={modalState.title}
-              message={modalState.message}
-              submit={() => setModalState({ ...modalState, visible: false })}
-            />
-          )}
-        </View>
-        <View style={{ marginTop: 'auto', margin: 20 }}>
-          <Button
-            title={t('PINCreate.CreatePIN')}
-            testID={testIdWithKey('CreatePIN')}
-            accessibilityLabel={t('PINCreate.CreatePIN')}
-            buttonType={ButtonType.Primary}
-            disabled={!continueEnabled}
-            onPress={async () => {
-              await confirmEntry(PIN, PINTwo)
-            }}
-            ref={createPINButtonRef}
-          >
-            {!continueEnabled && <ButtonLoading />}
-          </Button>
-        </View>
-      </ScrollView>
-    </SafeAreaView>
+        )}
+      </View>
+      <View style={{ marginTop: 'auto', margin: 20 }}>
+        <Button
+          title={t('PINCreate.CreatePIN')}
+          testID={testIdWithKey('CreatePIN')}
+          accessibilityLabel={t('PINCreate.CreatePIN')}
+          buttonType={ButtonType.Primary}
+          disabled={!continueEnabled}
+          onPress={async () => {
+            await confirmEntry(PIN, PINTwo)
+          }}
+          ref={createPINButtonRef}
+        >
+          {!continueEnabled && <ButtonLoading />}
+        </Button>
+      </View>
+    </KeyboardView>
   )
 }
 

--- a/core/App/screens/PINCreate.tsx
+++ b/core/App/screens/PINCreate.tsx
@@ -68,7 +68,7 @@ const PINCreate: React.FC<PINCreateProps> = ({ setAuthenticated }) => {
     title: '',
     message: '',
   })
-
+  const iconSize = 24
   const navigation = useNavigation<StackNavigationProp<AuthenticateStackParams>>()
   const [, dispatch] = useStore()
   const { t } = useTranslation()
@@ -168,9 +168,9 @@ const PINCreate: React.FC<PINCreateProps> = ({ setAuthenticated }) => {
               return (
                 <View style={{ flexDirection: 'row' }} key={index}>
                   {validation.isInvalid ? (
-                    <Icon name="clear" size={24} color={ColorPallet.notification.errorIcon} />
+                    <Icon name="clear" size={iconSize} color={ColorPallet.notification.errorIcon} />
                   ) : (
-                    <Icon name="check" size={24} color={ColorPallet.notification.success} />
+                    <Icon name="check" size={iconSize} color={ColorPallet.notification.success} />
                   )}
                   <Text style={[TextTheme.normal, { paddingLeft: 4 }]}>
                     {t(`PINCreate.Helper.${validation.errorName}`)}


### PR DESCRIPTION
# Summary of Changes

Allow dismissing of keyboard when tapping empty space outside of it and use `KeyboardAvoidingView` and `ScrollView` to make sure inputs can always be visible even with large text + zoom

Here is what it looks like with default settings on iOS:
![create_pin_ios_normal](https://user-images.githubusercontent.com/32586431/220485716-ae46f2ff-0a9f-4f8e-8848-7361184517c6.gif)

Here is what it looks like with max zoom and font on iOS:
![create_pin_ios_zoom](https://user-images.githubusercontent.com/32586431/220485772-0a018c55-8c6f-4e9d-911f-d9bf1c0a9a62.gif)

Here is what it looks like with max zoom and font on Android:
![create_pin_android_zoom](https://user-images.githubusercontent.com/32586431/220485802-775efd6b-4b52-4918-874a-a3390c2401f9.gif)

It looks good and functions properly on Android with default settings as well, I just didn't bother to make a gif of that. You'll have to trust me (or checkout this branch)

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
