### PR TITLE
feat: added error message if biometrics fails

### DIFF
--- a/core/App/constants.ts
+++ b/core/App/constants.ts
@@ -28,6 +28,7 @@ export enum EventTypes {
   ERROR_ADDED = 'ErrorAdded',
   ERROR_REMOVED = 'ErrorRemoved',
   BIOMETRY_UPDATE = 'BiometryUpdate',
+  BIOMETRY_ERROR = 'BiometryError',
 }
 
 export const second = 1000

--- a/core/App/contexts/auth.tsx
+++ b/core/App/contexts/auth.tsx
@@ -1,7 +1,9 @@
 import { agentDependencies } from '@aries-framework/react-native'
 import React, { createContext, useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { DeviceEventEmitter } from 'react-native'
 
+import { EventTypes } from '../constants'
 import { DispatchAction } from '../contexts/reducers/store'
 import { useStore } from '../contexts/store'
 import {
@@ -38,11 +40,17 @@ export const AuthProvider: React.FC = ({ children }) => {
   }
 
   const getWalletCredentials = async (): Promise<WalletSecret | undefined> => {
-    if (walletSecret) {
+    if (walletSecret && walletSecret.key) {
       return walletSecret
     }
 
-    const secret = await loadWalletSecret(t('Biometry.UnlockPromptTitle'), t('Biometry.UnlockPromptDescription'))
+    const { secret, err } = await loadWalletSecret(
+      t('Biometry.UnlockPromptTitle'),
+      t('Biometry.UnlockPromptDescription')
+    )
+
+    DeviceEventEmitter.emit(EventTypes.BIOMETRY_ERROR, err !== undefined)
+
     if (!secret) {
       return
     }

--- a/core/App/localization/en/index.ts
+++ b/core/App/localization/en/index.ts
@@ -173,6 +173,8 @@ const translation = {
     "RepeatPIN": "Please try your PIN again.",
     "EnableBiometrics": "You have to enable biometrics to be able to load the wallet.",
     "BiometricsNotProvided": "Biometrics not provided, you may use PIN to load the wallet.",
+    "BiometricsError": "Biometrics were not successful.",
+    "BiometricsErrorEnterPIN": "Please enter your wallet PIN.",
     "LoggedOut": "You're logged out",
     "LoggedOutDescription": "To protect your information, you're logged out of your wallet if you have not used it for 5 minutes.",
     "BiometricsChanged": "Biometrics unlock has been disabled because your device biometrics changed.",

--- a/core/App/localization/fr/index.ts
+++ b/core/App/localization/fr/index.ts
@@ -173,6 +173,8 @@ const translation = {
         "RepeatPIN": "Essayez votre NIP à nouveau",
         "EnableBiometrics": "Vous devez activer la biométrie pour pouvoir charger le portefeuille.",
         "BiometricsNotProvided": "Biométrie non fournie, vous pouvez utiliser le NIP pour vous connecter au portefeuille.",
+        "BiometricsError": "Biometrics were not successful.",
+        "BiometricsErrorEnterPIN": "Please enter your wallet PIN.",
         "LoggedOut": "Vous avez été déconnecté du portefeuille.",
         "LoggedOutDescription": "Pour protéger vos informations, vous êtes déconnecté de votre portefeuille si vous ne l'avez pas utilisé pendant 5 minutes.",
         "BiometricsChanged": "Le déverrouillage avec la biométrie a été désactivé, car les données biométriques de votre appareil ont changé.",

--- a/core/App/localization/pt-br/index.ts
+++ b/core/App/localization/pt-br/index.ts
@@ -171,7 +171,9 @@ const translation = {
     "BiometricsUnlock": "Destravar com Biometria",
     "IncorrectPIN": "PIN incorreto",
     "EnableBiometrics": "Você deve habilitar a biometria para poder carregar a carteira.",
-    "BiometricsNotProvided": "Biometria não informada, você deve usar o PIN para carregar a carteira."
+    "BiometricsNotProvided": "Biometria não informada, você deve usar o PIN para carregar a carteira.",
+    "BiometricsError": "Biometrics were not successful.",
+    "BiometricsErrorEnterPIN": "Please enter your wallet PIN."
   },
   "Biometry": {
     "Toggle": "Habilitar Biometria",

--- a/core/App/services/keychain.ts
+++ b/core/App/services/keychain.ts
@@ -118,11 +118,21 @@ export const loadWalletKey = async (title?: string, description?: string): Promi
   return JSON.parse(result.password) as WalletKey
 }
 
-export const loadWalletSecret = async (title?: string, description?: string): Promise<WalletSecret | undefined> => {
-  const salt = await loadWalletSalt()
-  const key = await loadWalletKey(title, description)
+export const loadWalletSecret = async (
+  title?: string,
+  description?: string
+): Promise<{ secret: WalletSecret | undefined; err: string }> => {
+  let salt: WalletSalt | undefined
+  let key: WalletKey | undefined
+  let err = ''
+  try {
+    salt = await loadWalletSalt()
+    key = await loadWalletKey(title, description)
+  } catch (e: any) {
+    err = e?.message ?? e
+  }
 
-  return { ...salt, ...key } as WalletSecret
+  return { secret: { ...salt, ...key } as WalletSecret, err }
 }
 
 export const isBiometricsActive = async (): Promise<boolean> => {


### PR DESCRIPTION
# Summary of Changes

Added error text to the PIN enter screen if the biometrics fails:
![image](https://user-images.githubusercontent.com/36937407/221679186-b3c83dd7-6a6c-43f6-b054-d1f93e5a17cb.png)


# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
