### PR TITLE
fix: reset navigation stack for problematic screens

### DIFF
--- a/core/App/screens/AttemptLockout.tsx
+++ b/core/App/screens/AttemptLockout.tsx
@@ -1,4 +1,5 @@
 import { useNavigation } from '@react-navigation/core'
+import { CommonActions } from '@react-navigation/native'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
@@ -110,7 +111,12 @@ const AttemptLockout: React.FC = () => {
       type: DispatchAction.ATTEMPT_UPDATED,
       payload: [{ loginAttempts: state.loginAttempt.loginAttempts, lockoutDate: undefined, servedPenalty: true }],
     })
-    navigation.navigate(Screens.EnterPIN as never)
+    navigation.dispatch(
+      CommonActions.reset({
+        index: 0,
+        routes: [{ name: Screens.EnterPIN }],
+      })
+    )
   }
 
   return (

--- a/core/App/screens/PINCreate.tsx
+++ b/core/App/screens/PINCreate.tsx
@@ -1,4 +1,5 @@
 import { useNavigation } from '@react-navigation/core'
+import { CommonActions } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React, { useState, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -102,7 +103,12 @@ const PINCreate: React.FC<PINCreateProps> = ({ setAuthenticated }) => {
       })
 
       // TODO: Navigate back if in settings
-      navigation.navigate(Screens.UseBiometry)
+      navigation.dispatch(
+        CommonActions.reset({
+          index: 0,
+          routes: [{ name: Screens.UseBiometry }],
+        })
+      )
     } catch (e) {
       // TODO:(jl)
     }

--- a/core/App/screens/PINEnter.tsx
+++ b/core/App/screens/PINEnter.tsx
@@ -1,4 +1,5 @@
 import { useNavigation } from '@react-navigation/core'
+import { CommonActions } from '@react-navigation/native'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
@@ -111,7 +112,12 @@ const PINEnter: React.FC<PINEnterProps> = ({ setAuthenticated, usage = PINEntryU
         { loginAttempts: store.loginAttempt.loginAttempts, lockoutDate: Date.now() + penalty, servedPenalty: false },
       ],
     })
-    navigation.navigate(Screens.AttemptLockout as never)
+    navigation.dispatch(
+      CommonActions.reset({
+        index: 0,
+        routes: [{ name: Screens.AttemptLockout }],
+      })
+    )
   }
 
   const getLockoutPenalty = (attempts: number): number | undefined => {

--- a/core/App/screens/Splash.tsx
+++ b/core/App/screens/Splash.tsx
@@ -11,6 +11,7 @@ import { useAgent } from '@aries-framework/react-hooks'
 import { agentDependencies } from '@aries-framework/react-native'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { useNavigation } from '@react-navigation/core'
+import { CommonActions } from '@react-navigation/native'
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet } from 'react-native'
@@ -117,20 +118,40 @@ const Splash: React.FC = () => {
           const onboardingState = JSON.parse(data) as StoreOnboardingState
           dispatch({ type: DispatchAction.ONBOARDING_UPDATED, payload: [onboardingState] })
           if (onboardingComplete(onboardingState) && !attemptData?.lockoutDate) {
-            navigation.navigate(Screens.EnterPIN as never)
+            navigation.dispatch(
+              CommonActions.reset({
+                index: 0,
+                routes: [{ name: Screens.EnterPIN }],
+              })
+            )
             return
           } else if (onboardingComplete(onboardingState) && attemptData?.lockoutDate) {
             // return to lockout screen if lockout date is set
-            navigation.navigate(Screens.AttemptLockout as never)
+            navigation.dispatch(
+              CommonActions.reset({
+                index: 0,
+                routes: [{ name: Screens.AttemptLockout }],
+              })
+            )
             return
           } else {
             // If onboarding was interrupted we need to pickup from where we left off.
-            navigation.navigate(resumeOnboardingAt(onboardingState) as never)
+            navigation.dispatch(
+              CommonActions.reset({
+                index: 0,
+                routes: [{ name: resumeOnboardingAt(onboardingState) }],
+              })
+            )
           }
           return
         }
         // We have no onboarding state, starting from step zero.
-        navigation.navigate(Screens.Onboarding as never)
+        navigation.dispatch(
+          CommonActions.reset({
+            index: 0,
+            routes: [{ name: Screens.Onboarding }],
+          })
+        )
       } catch (error) {
         // TODO:(am add error handling here)
       }
@@ -178,7 +199,12 @@ const Splash: React.FC = () => {
 
         await newAgent.initialize()
         setAgent(newAgent)
-        navigation.navigate(Stacks.TabStack as never)
+        navigation.dispatch(
+          CommonActions.reset({
+            index: 0,
+            routes: [{ name: Stacks.TabStack }],
+          })
+        )
       } catch (e: unknown) {
         Toast.show({
           type: ToastType.Error,


### PR DESCRIPTION
# Summary of Changes

Resetting the navigation stack when navigating from problematic screens that we don't want users to be able to navigate back to (either with swipe back on iOS or hardware back button on Android)

# Related Issues

Resolves #460 

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
