### PR TITLE
fix: update NotificationListItem to handle different types

### DIFF
--- a/core/App/components/listItems/NotificationListItem.tsx
+++ b/core/App/components/listItems/NotificationListItem.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from '@react-navigation/core'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React, { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, View, Text, TouchableOpacity } from 'react-native'
+import { StyleSheet, View, ViewStyle, Text, TextStyle, TouchableOpacity } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
 import { useConfiguration } from '../../contexts/configuration'
@@ -41,6 +41,13 @@ type DisplayDetails = {
   buttonTitle: string | undefined
 }
 
+type StyleConfig = {
+  containerStyle: ViewStyle
+  textStyle: TextStyle
+  iconColor: string
+  iconName: string
+}
+
 const NotificationListItem: React.FC<NotificationListItemProps> = ({ notificationType, notification }) => {
   const navigation = useNavigation<StackNavigationProp<HomeStackParams>>()
   const { customNotification } = useConfiguration()
@@ -54,6 +61,18 @@ const NotificationListItem: React.FC<NotificationListItemProps> = ({ notificatio
     body: undefined,
     buttonTitle: undefined,
   })
+  const [styleConfig, setStyleConfig] = useState<StyleConfig>({
+    containerStyle: {
+      backgroundColor: ColorPallet.notification.info,
+      borderColor: ColorPallet.notification.infoBorder,
+    },
+    textStyle: {
+      color: ColorPallet.notification.infoText,
+    },
+    iconColor: ColorPallet.notification.infoIcon,
+    iconName: 'info',
+  })
+
   const styles = StyleSheet.create({
     container: {
       borderRadius: 5,
@@ -227,89 +246,70 @@ const NotificationListItem: React.FC<NotificationListItemProps> = ({ notificatio
     })
   }, [notificationType])
 
-  const getContainerStyle = (type: InfoBoxType) => {
-    switch (type) {
+  useEffect(() => {
+    switch (details.type) {
       case InfoBoxType.Success:
-        return {
-          backgroundColor: ColorPallet.notification.success,
-          borderColor: ColorPallet.notification.successBorder,
-        }
+        setStyleConfig({
+          containerStyle: {
+            backgroundColor: ColorPallet.notification.success,
+            borderColor: ColorPallet.notification.successBorder,
+          },
+          textStyle: {
+            color: ColorPallet.notification.successText,
+          },
+          iconColor: ColorPallet.notification.successIcon,
+          iconName: 'check-circle',
+        })
+        break
       case InfoBoxType.Warn:
-        return {
-          backgroundColor: ColorPallet.notification.warn,
-          borderColor: ColorPallet.notification.warnBorder,
-        }
+        setStyleConfig({
+          containerStyle: {
+            backgroundColor: ColorPallet.notification.warn,
+            borderColor: ColorPallet.notification.warnBorder,
+          },
+          textStyle: {
+            color: ColorPallet.notification.warnText,
+          },
+          iconColor: ColorPallet.notification.warnIcon,
+          iconName: 'warning',
+        })
+        break
       case InfoBoxType.Error:
-        return {
-          backgroundColor: ColorPallet.notification.error,
-          borderColor: ColorPallet.notification.errorBorder,
-        }
+        setStyleConfig({
+          containerStyle: {
+            backgroundColor: ColorPallet.notification.error,
+            borderColor: ColorPallet.notification.errorBorder,
+          },
+          textStyle: {
+            color: ColorPallet.notification.errorText,
+          },
+          iconColor: ColorPallet.notification.errorIcon,
+          iconName: 'error',
+        })
+        break
       case InfoBoxType.Info:
       default:
-        return {
-          backgroundColor: ColorPallet.notification.info,
-          borderColor: ColorPallet.notification.infoBorder,
-        }
+        setStyleConfig({
+          containerStyle: {
+            backgroundColor: ColorPallet.notification.info,
+            borderColor: ColorPallet.notification.infoBorder,
+          },
+          textStyle: {
+            color: ColorPallet.notification.infoText,
+          },
+          iconColor: ColorPallet.notification.infoIcon,
+          iconName: 'info',
+        })
     }
-  }
-
-  const getTextStyle = (type: InfoBoxType) => {
-    switch (type) {
-      case InfoBoxType.Success:
-        return {
-          color: ColorPallet.notification.successText,
-        }
-      case InfoBoxType.Warn:
-        return {
-          color: ColorPallet.notification.warnText,
-        }
-      case InfoBoxType.Error:
-        return {
-          color: ColorPallet.notification.errorText,
-        }
-      case InfoBoxType.Info:
-      default:
-        return {
-          color: ColorPallet.notification.infoText,
-        }
-    }
-  }
-
-  const getIconColor = (type: InfoBoxType) => {
-    switch (type) {
-      case InfoBoxType.Success:
-        return ColorPallet.notification.successIcon
-      case InfoBoxType.Warn:
-        return ColorPallet.notification.warnIcon
-      case InfoBoxType.Error:
-        return ColorPallet.notification.errorIcon
-      case InfoBoxType.Info:
-      default:
-        return ColorPallet.notification.infoIcon
-    }
-  }
-
-  const getIconName = (type: InfoBoxType) => {
-    switch (type) {
-      case InfoBoxType.Success:
-        return 'check-circle'
-      case InfoBoxType.Warn:
-        return 'warning'
-      case InfoBoxType.Error:
-        return 'error'
-      case InfoBoxType.Info:
-      default:
-        return 'info'
-    }
-  }
+  }, [details])
 
   return (
-    <View style={[styles.container, getContainerStyle(details.type)]} testID={testIdWithKey('NotificationListItem')}>
+    <View style={[styles.container, styleConfig.containerStyle]} testID={testIdWithKey('NotificationListItem')}>
       <View style={styles.headerContainer}>
         <View style={styles.icon}>
-          <Icon name={getIconName(details.type)} size={iconSize} color={getIconColor(details.type)} />
+          <Icon name={styleConfig.iconName} size={iconSize} color={styleConfig.iconColor} />
         </View>
-        <Text style={[styles.headerText, getTextStyle(details.type)]} testID={testIdWithKey('HeaderText')}>
+        <Text style={[styles.headerText, styleConfig.textStyle]} testID={testIdWithKey('HeaderText')}>
           {details.title}
         </Text>
         {[NotificationType.Custom, NotificationType.ProofRequest, NotificationType.CredentialOffer].includes(
@@ -321,13 +321,13 @@ const NotificationListItem: React.FC<NotificationListItemProps> = ({ notificatio
               testID={testIdWithKey(`Close${notificationType}`)}
               onPress={onClose}
             >
-              <Icon name={'close'} size={iconSize} color={getIconColor(details.type)} />
+              <Icon name={'close'} size={iconSize} color={styleConfig.iconColor} />
             </TouchableOpacity>
           </View>
         )}
       </View>
       <View style={styles.bodyContainer}>
-        <Text style={[styles.bodyText, getTextStyle(details.type)]} testID={testIdWithKey('BodyText')}>
+        <Text style={[styles.bodyText, styleConfig.textStyle]} testID={testIdWithKey('BodyText')}>
           {details.body}
         </Text>
         <Button

--- a/core/App/components/listItems/NotificationListItem.tsx
+++ b/core/App/components/listItems/NotificationListItem.tsx
@@ -18,6 +18,7 @@ import { HomeStackParams, Screens, Stacks } from '../../types/navigators'
 import { parsedSchema } from '../../utils/helpers'
 import { testIdWithKey } from '../../utils/testable'
 import Button, { ButtonType } from '../buttons/Button'
+import { InfoBoxType } from '../misc/InfoBox'
 
 const iconSize = 30
 
@@ -34,6 +35,7 @@ interface NotificationListItemProps {
 }
 
 type DisplayDetails = {
+  type: InfoBoxType
   body: string | undefined
   title: string | undefined
   buttonTitle: string | undefined
@@ -47,14 +49,13 @@ const NotificationListItem: React.FC<NotificationListItemProps> = ({ notificatio
   const { ColorPallet, TextTheme } = useTheme()
   const { agent } = useAgent()
   const [details, setDetails] = useState<DisplayDetails>({
+    type: InfoBoxType.Info,
     title: undefined,
     body: undefined,
     buttonTitle: undefined,
   })
   const styles = StyleSheet.create({
     container: {
-      backgroundColor: ColorPallet.notification.info,
-      borderColor: ColorPallet.notification.infoBorder,
       borderRadius: 5,
       borderWidth: 1,
       padding: 10,
@@ -76,14 +77,12 @@ const NotificationListItem: React.FC<NotificationListItemProps> = ({ notificatio
       flexGrow: 1,
       fontWeight: 'bold',
       alignSelf: 'center',
-      color: ColorPallet.notification.infoText,
     },
     bodyText: {
       ...TextTheme.normal,
       flexShrink: 1,
       marginVertical: 15,
       paddingBottom: 10,
-      color: ColorPallet.notification.infoText,
     },
     icon: {
       marginRight: 10,
@@ -103,6 +102,7 @@ const NotificationListItem: React.FC<NotificationListItemProps> = ({ notificatio
       switch (notificationType) {
         case NotificationType.CredentialOffer:
           resolve({
+            type: InfoBoxType.Info,
             title: t('CredentialOffer.NewCredentialOffer'),
             body: `${name + (version ? ` v${version}` : '')}`,
             buttonTitle: undefined,
@@ -113,19 +113,26 @@ const NotificationListItem: React.FC<NotificationListItemProps> = ({ notificatio
           agent?.proofs.findRequestMessage(proofId).then((message) => {
             if (message instanceof V1RequestPresentationMessage && message.indyProofRequest) {
               resolve({
+                type: InfoBoxType.Info,
                 title: t('ProofRequest.NewProofRequest'),
                 body: message.indyProofRequest.name,
                 buttonTitle: undefined,
               })
             } else {
               //TODO:(jl) Should we have a default message or stick with an empty string?
-              resolve({ title: t('ProofRequest.NewProofRequest'), body: '', buttonTitle: undefined })
+              resolve({
+                type: InfoBoxType.Info,
+                title: t('ProofRequest.NewProofRequest'),
+                body: '',
+                buttonTitle: undefined,
+              })
             }
           })
           break
         }
         case NotificationType.Revocation:
           resolve({
+            type: InfoBoxType.Error,
             title: t('CredentialDetails.NewRevoked'),
             body: `${name + (version ? ` v${version}` : '')}`,
             buttonTitle: undefined,
@@ -133,6 +140,7 @@ const NotificationListItem: React.FC<NotificationListItemProps> = ({ notificatio
           break
         case NotificationType.Custom:
           resolve({
+            type: InfoBoxType.Info,
             title: t(customNotification.title as any),
             body: t(customNotification.description as any),
             buttonTitle: t(customNotification.buttonTitle as any),
@@ -219,13 +227,89 @@ const NotificationListItem: React.FC<NotificationListItemProps> = ({ notificatio
     })
   }, [notificationType])
 
+  const getContainerStyle = (type: InfoBoxType) => {
+    switch (type) {
+      case InfoBoxType.Success:
+        return {
+          backgroundColor: ColorPallet.notification.success,
+          borderColor: ColorPallet.notification.successBorder,
+        }
+      case InfoBoxType.Warn:
+        return {
+          backgroundColor: ColorPallet.notification.warn,
+          borderColor: ColorPallet.notification.warnBorder,
+        }
+      case InfoBoxType.Error:
+        return {
+          backgroundColor: ColorPallet.notification.error,
+          borderColor: ColorPallet.notification.errorBorder,
+        }
+      case InfoBoxType.Info:
+      default:
+        return {
+          backgroundColor: ColorPallet.notification.info,
+          borderColor: ColorPallet.notification.infoBorder,
+        }
+    }
+  }
+
+  const getTextStyle = (type: InfoBoxType) => {
+    switch (type) {
+      case InfoBoxType.Success:
+        return {
+          color: ColorPallet.notification.successText,
+        }
+      case InfoBoxType.Warn:
+        return {
+          color: ColorPallet.notification.warnText,
+        }
+      case InfoBoxType.Error:
+        return {
+          color: ColorPallet.notification.errorText,
+        }
+      case InfoBoxType.Info:
+      default:
+        return {
+          color: ColorPallet.notification.infoText,
+        }
+    }
+  }
+
+  const getIconColor = (type: InfoBoxType) => {
+    switch (type) {
+      case InfoBoxType.Success:
+        return ColorPallet.notification.successIcon
+      case InfoBoxType.Warn:
+        return ColorPallet.notification.warnIcon
+      case InfoBoxType.Error:
+        return ColorPallet.notification.errorIcon
+      case InfoBoxType.Info:
+      default:
+        return ColorPallet.notification.infoIcon
+    }
+  }
+
+  const getIconName = (type: InfoBoxType) => {
+    switch (type) {
+      case InfoBoxType.Success:
+        return 'check-circle'
+      case InfoBoxType.Warn:
+        return 'warning'
+      case InfoBoxType.Error:
+        return 'error'
+      case InfoBoxType.Info:
+      default:
+        return 'info'
+    }
+  }
+
   return (
-    <View style={styles.container} testID={testIdWithKey('NotificationListItem')}>
+    <View style={[styles.container, getContainerStyle(details.type)]} testID={testIdWithKey('NotificationListItem')}>
       <View style={styles.headerContainer}>
-        <View style={[styles.icon]}>
-          <Icon name={'info'} size={iconSize} color={ColorPallet.notification.infoIcon} />
+        <View style={styles.icon}>
+          <Icon name={getIconName(details.type)} size={iconSize} color={getIconColor(details.type)} />
         </View>
-        <Text style={styles.headerText} testID={testIdWithKey('HeaderText')}>
+        <Text style={[styles.headerText, getTextStyle(details.type)]} testID={testIdWithKey('HeaderText')}>
           {details.title}
         </Text>
         {[NotificationType.Custom, NotificationType.ProofRequest, NotificationType.CredentialOffer].includes(
@@ -237,13 +321,13 @@ const NotificationListItem: React.FC<NotificationListItemProps> = ({ notificatio
               testID={testIdWithKey(`Close${notificationType}`)}
               onPress={onClose}
             >
-              <Icon name={'close'} size={iconSize} color={ColorPallet.notification.infoIcon} />
+              <Icon name={'close'} size={iconSize} color={getIconColor(details.type)} />
             </TouchableOpacity>
           </View>
         )}
       </View>
       <View style={styles.bodyContainer}>
-        <Text style={styles.bodyText} testID={testIdWithKey('BodyText')}>
+        <Text style={[styles.bodyText, getTextStyle(details.type)]} testID={testIdWithKey('BodyText')}>
           {details.body}
         </Text>
         <Button

--- a/core/App/localization/en/index.ts
+++ b/core/App/localization/en/index.ts
@@ -242,7 +242,7 @@ const translation = {
     "Revoked": "Revoked",
     "CredentialRevokedMessageTitle": "This credential is revoked",
     "CredentialRevokedMessageBody": "This credential may no longer work for some proof requests. You will need to update the credential with the issuer.",
-    "NewRevoked": "Credential Was Revoked",
+    "NewRevoked": "Credential revoked",
     "RemoveTitle": "Remove credential from your wallet",
     "RemoveCaption": "You will lose your ability to prove the information on this credential with this Wallet.",
     "CredentialNotFound": "Credential not found",

--- a/core/App/localization/fr/index.ts
+++ b/core/App/localization/fr/index.ts
@@ -241,6 +241,7 @@ const translation = {
         "Revoked": "Révoqué",
         "CredentialRevokedMessageTitle": "Ce justificatif est révoqué",
         "CredentialRevokedMessageBody": "Ce justificatif peut ne plus fonctionner pour certaines demandes de preuve. Vous devrez mettre à jour le justificatif avec l'émetteur.",
+        "NewRevoked": "Credential revoked (FR)",
         "RemoveTitle": "Retirer le justificatif du portefeuille",
         "RemoveCaption": "Vous allez perdre la capacité d'utiliser ce portefeuille afin de prouver l'information se trouvant sur ce justificatif.",
         "CredentialNotFound": "Justificatif non trouvé",

--- a/core/App/localization/pt-br/index.ts
+++ b/core/App/localization/pt-br/index.ts
@@ -230,6 +230,7 @@ const translation = {
     "Revoked": "Revogada",
     "CredentialRevokedMessageTitle": "Esta credencial está revogada",
     "CredentialRevokedMessageBody": "Esta credencial não funcionará mais para algumas requisições de prova. Voce precisará atualizar a credencial com o emissor.",
+    "NewRevoked": "Credential revoked (PT-BR)",
     "RemoveTitle": "Remover a credencial da sua carteira",
     "RemoveCaption": "Você perderá a habilidade de prover as informações desta credencial com essa carteira.",
     "CredentialNotFound": "Credencial não encontrada",


### PR DESCRIPTION
# Summary of Changes

Refactored `NotificationListItem` to handle the different styling types (error, success, info, warn) and change revocation notifications to use the error type. Also fixed the i18n for `NewRevoked`

Here's what it looks like:
![revoc_notices](https://user-images.githubusercontent.com/32586431/223882955-40421fc2-950e-4a17-b6b6-b1d8fac4593f.gif)

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
