### PR TITLE
fix: extend cred offer accept timer, use config

### DIFF
--- a/packages/legacy/core/App/screens/CredentialOfferAccept.tsx
+++ b/packages/legacy/core/App/screens/CredentialOfferAccept.tsx
@@ -9,12 +9,11 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import CredentialAdded from '../components/animated/CredentialAdded'
 import CredentialPending from '../components/animated/CredentialPending'
 import Button, { ButtonType } from '../components/buttons/Button'
+import { useConfiguration } from '../contexts/configuration'
 import { useTheme } from '../contexts/theme'
 import { Screens, TabStacks } from '../types/navigators'
 import { statusBarStyleForColor, StatusBarStyles } from '../utils/luminance'
 import { testIdWithKey } from '../utils/testable'
-
-const connectionTimerDelay = 5000 // in ms
 
 enum DeliveryStatus {
   Pending,
@@ -36,6 +35,8 @@ const CredentialOfferAccept: React.FC<CredentialOfferAcceptProps> = ({ visible, 
   const credential = useCredentialById(credentialId)
   const navigation = useNavigation()
   const { ListItems } = useTheme()
+  const { connectionTimerDelay } = useConfiguration()
+  const connTimerDelay = connectionTimerDelay ?? 10000 // in ms
   const styles = StyleSheet.create({
     container: {
       ...ListItems.credentialOfferBackground,
@@ -90,7 +91,7 @@ const CredentialOfferAccept: React.FC<CredentialOfferAcceptProps> = ({ visible, 
     const timer = setTimeout(() => {
       setShouldShowDelayMessage(true)
       setTimerDidFire(true)
-    }, connectionTimerDelay)
+    }, connTimerDelay)
 
     setTimer(timer)
 

--- a/packages/legacy/core/__tests__/screens/CredentialOfferAccept.test.tsx
+++ b/packages/legacy/core/__tests__/screens/CredentialOfferAccept.test.tsx
@@ -5,8 +5,10 @@ import fs from 'fs'
 import path from 'path'
 import React from 'react'
 
+import { ConfigurationContext } from '../../App/contexts/configuration'
 import CredentialOfferAccept from '../../App/screens/CredentialOfferAccept'
 import { testIdWithKey } from '../../App/utils/testable'
+import configurationContext from '../contexts/configuration'
 import timeTravel from '../helpers/timetravel'
 
 jest.mock('@react-navigation/core', () => {
@@ -28,7 +30,11 @@ useCredentialById.mockReturnValue(credentialRecord)
 
 describe('displays a credential accept screen', () => {
   test('renders correctly', () => {
-    const tree = render(<CredentialOfferAccept visible={true} credentialId={credentialId} />)
+    const tree = render(
+      <ConfigurationContext.Provider value={configurationContext}>
+        <CredentialOfferAccept visible={true} credentialId={credentialId} />
+      </ConfigurationContext.Provider>
+    )
 
     const doneButton = tree.queryByTestId('Done')
 
@@ -38,10 +44,14 @@ describe('displays a credential accept screen', () => {
   })
 
   test('transitions to taking too delay message', async () => {
-    const tree = render(<CredentialOfferAccept visible={true} credentialId={credentialId} />)
+    const tree = render(
+      <ConfigurationContext.Provider value={configurationContext}>
+        <CredentialOfferAccept visible={true} credentialId={credentialId} />
+      </ConfigurationContext.Provider>
+    )
 
     await waitFor(() => {
-      timeTravel(10000)
+      timeTravel(11000)
     })
 
     const backToHomeButton = tree.getByTestId(testIdWithKey('BackToHome'))
@@ -55,7 +65,11 @@ describe('displays a credential accept screen', () => {
   test('transitions to offer accepted', () => {
     credentialRecord.state = CredentialState.CredentialReceived
 
-    const tree = render(<CredentialOfferAccept visible={true} credentialId={credentialId} />)
+    const tree = render(
+      <ConfigurationContext.Provider value={configurationContext}>
+        <CredentialOfferAccept visible={true} credentialId={credentialId} />
+      </ConfigurationContext.Provider>
+    )
 
     const doneButton = tree.getByTestId(testIdWithKey('Done'))
     const backToHomeButton = tree.queryByTestId(testIdWithKey('BackToHome'))

--- a/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOfferAccept.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOfferAccept.test.tsx.snap
@@ -522,7 +522,7 @@ exports[`displays a credential accept screen transitions to taking too delay mes
                   "opacity": 1,
                   "transform": Array [
                     Object {
-                      "translateY": -80.9205021307228,
+                      "translateY": -16.252128433746066,
                     },
                   ],
                 }


### PR DESCRIPTION
# Summary of Changes

Makes use of new configuration option and extends default time to 10 seconds for credential offer acceptance. 

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
