### PR TITLE
fix: make connection flow configurable

### DIFF
--- a/packages/legacy/core/App/contexts/configuration.tsx
+++ b/packages/legacy/core/App/contexts/configuration.tsx
@@ -37,6 +37,7 @@ export interface ConfigurationContext {
   customNotification: NotificationConfiguration
   useCustomNotifications: () => { total: number; notifications: any }
   connectionTimerDelay?: number
+  autoRedirectConnectionToHome?: boolean
 }
 
 export const ConfigurationContext = createContext<ConfigurationContext>(null as unknown as ConfigurationContext)

--- a/packages/legacy/core/App/screens/Connection.tsx
+++ b/packages/legacy/core/App/screens/Connection.tsx
@@ -18,7 +18,7 @@ import { testIdWithKey } from '../utils/testable'
 type ConnectionProps = StackScreenProps<DeliveryStackParams, Screens.Connection>
 
 const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
-  const { connectionTimerDelay } = useConfiguration()
+  const { connectionTimerDelay, autoRedirectConnectionToHome } = useConfiguration()
   const connTimerDelay = connectionTimerDelay ?? 10000 // in ms
 
   if (!navigation || !route) {
@@ -91,7 +91,7 @@ const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
     setState((prev) => ({ ...prev, shouldShowDelayMessage: value }))
   }
   useEffect(() => {
-    if (shouldShowDelayMessage && connectionIsActive && !notificationRecord) {
+    if (autoRedirectConnectionToHome && shouldShowDelayMessage && connectionIsActive && !notificationRecord) {
       setShouldShowDelayMessage(false)
       setModalVisible(false)
       navigation.getParent()?.navigate(TabStacks.HomeStack, { screen: Screens.Home })
@@ -175,7 +175,7 @@ const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
             <ConnectionLoading />
           </View>
 
-          {shouldShowDelayMessage && !connectionIsActive && (
+          {shouldShowDelayMessage && (
             <Text style={[TextTheme.normal, styles.delayMessageText]} testID={testIdWithKey('TakingTooLong')}>
               {t('Connection.TakingTooLong')}
             </Text>


### PR DESCRIPTION
# Summary of Changes

Adjusts the recently changed connection flow to be configurable. Simply add `autoRedirectConnectionToHome: true` to your configuration to use the new flow, or change nothing to go back to the old flow.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
