### PR TITLE
fix: add alias support for credential details and refactor

### DIFF
--- a/packages/legacy/core/App/components/misc/CredentialCard10.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard10.tsx
@@ -1,5 +1,4 @@
 import { CredentialExchangeRecord } from '@aries-framework/core'
-import { useConnectionById } from '@aries-framework/react-hooks'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Dimensions, ImageBackground, StyleSheet, Text, View, ViewStyle, Image } from 'react-native'
@@ -10,7 +9,7 @@ import { useTheme } from '../../contexts/theme'
 import { GenericFn } from '../../types/fn'
 import { CardLayoutOverlay10, CredentialOverlay } from '../../types/oca'
 import { credentialTextColor, isValidIndyCredential, toImageSource } from '../../utils/credential'
-import { formatTime } from '../../utils/helpers'
+import { formatTime, getCredentialConnectionLabel } from '../../utils/helpers'
 import { testIdWithKey } from '../../utils/testable'
 
 interface CredentialCard10Props {
@@ -69,11 +68,7 @@ const CredentialCard10: React.FC<CredentialCard10Props> = ({ credential, style =
   const [overlay, setOverlay] = useState<CredentialOverlay<CardLayoutOverlay10>>({})
 
   const [isRevoked, setIsRevoked] = useState<boolean>(false)
-  let alias = ''
-  if (credential.connectionId !== undefined) {
-    const connection = useConnectionById(credential.connectionId)
-    alias = connection?.alias || connection?.theirLabel || ''
-  }
+  const credentialConnectionLabel = getCredentialConnectionLabel(credential)
 
   const styles = StyleSheet.create({
     container: {
@@ -132,7 +127,11 @@ const CredentialCard10: React.FC<CredentialCard10Props> = ({ credential, style =
 
     const resolveBundle = async () => {
       const bundle = await OCABundleResolver.resolve(credential, i18n.language)
-      const defaultBundle = await OCABundleResolver.resolveDefaultBundle(credential, i18n.language, alias)
+      const defaultBundle = await OCABundleResolver.resolveDefaultBundle(
+        credential,
+        i18n.language,
+        credentialConnectionLabel
+      )
       return { bundle, defaultBundle }
     }
 

--- a/packages/legacy/core/App/components/misc/CredentialCard11.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard11.tsx
@@ -1,5 +1,4 @@
 import { CredentialExchangeRecord } from '@aries-framework/core'
-import { useConnectionById } from '@aries-framework/react-hooks'
 import startCase from 'lodash.startcase'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -14,6 +13,7 @@ import { GenericFn } from '../../types/fn'
 import { CardLayoutOverlay11, CredentialOverlay } from '../../types/oca'
 import { Attribute, Field, Predicate } from '../../types/record'
 import { credentialTextColor, isValidIndyCredential, toImageSource } from '../../utils/credential'
+import { getCredentialConnectionLabel } from '../../utils/helpers'
 import { testIdWithKey } from '../../utils/testable'
 
 interface CredentialCard11Props {
@@ -81,11 +81,7 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
   const { OCABundleResolver } = useConfiguration()
 
   const [isRevoked, setIsRevoked] = useState<boolean>(credential?.revocationNotification !== undefined)
-  let alias = ''
-  if (credential?.connectionId !== undefined) {
-    const connection = useConnectionById(credential.connectionId)
-    alias = connection?.alias || connection?.theirLabel || ''
-  }
+  const credentialConnectionLabel = getCredentialConnectionLabel(credential)
 
   const [overlay, setOverlay] = useState<CredentialOverlay<CardLayoutOverlay11>>({})
 
@@ -178,12 +174,16 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
         schemaId,
         credName,
         i18n.language,
-        alias
+        credentialConnectionLabel
       )
 
       if (credential && isValidIndyCredential(credential)) {
         bundle = await OCABundleResolver.resolve(credential, i18n.language)
-        defaultBundle = await OCABundleResolver.resolveDefaultBundle(credential, i18n.language, alias)
+        defaultBundle = await OCABundleResolver.resolveDefaultBundle(
+          credential,
+          i18n.language,
+          credentialConnectionLabel
+        )
       }
       return { bundle, defaultBundle }
     }

--- a/packages/legacy/core/App/screens/CredentialDetails.tsx
+++ b/packages/legacy/core/App/screens/CredentialDetails.tsx
@@ -125,7 +125,11 @@ const CredentialDetails: React.FC<CredentialDetailsProps> = ({ navigation, route
 
     const resolveBundle = async () => {
       const bundle = await OCABundleResolver.resolve(credential)
-      const defaultBundle = await OCABundleResolver.resolveDefaultBundle(credential)
+      const defaultBundle = await OCABundleResolver.resolveDefaultBundle(
+        credential,
+        i18n.language,
+        credentialConnectionLabel
+      )
       return { bundle, defaultBundle }
     }
 

--- a/packages/legacy/core/App/utils/helpers.ts
+++ b/packages/legacy/core/App/utils/helpers.ts
@@ -141,9 +141,12 @@ export function getCredentialConnectionLabel(credential?: CredentialExchangeReco
     return ''
   }
 
-  return credential?.connectionId
-    ? useConnectionById(credential.connectionId)?.theirLabel
-    : credential?.connectionId ?? ''
+  if (credential.connectionId) {
+    const connection = useConnectionById(credential.connectionId)
+    return connection?.alias || connection?.theirLabel || credential.connectionId
+  }
+
+  return 'Unknown Contact'
 }
 
 export function getConnectionImageUrl(connectionId: string) {


### PR DESCRIPTION
# Summary of Changes

Extended support for alias fallbacks to credential details screen, and refactored the existing code for the fallbacks into a helper function.

Before:
![IMG_0021](https://user-images.githubusercontent.com/32586431/229936950-46e445c7-c182-4339-9b7e-508e9abeda3e.PNG)

After:
![IMG_0020](https://user-images.githubusercontent.com/32586431/229936977-55775fa4-4ac1-4e0e-92dd-680faea608d3.PNG)

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
