### PR TITLE
fix: corrected getting of proof request template

### DIFF
--- a/packages/legacy/core/App/hooks/proof-request-templates.ts
+++ b/packages/legacy/core/App/hooks/proof-request-templates.ts
@@ -1,0 +1,14 @@
+import { useMemo } from 'react'
+
+import { ProofRequestTemplate } from '../../verifier'
+import { useConfiguration } from '../contexts/configuration'
+
+export const useTemplates = (): Array<ProofRequestTemplate> => {
+  const { proofRequestTemplates } = useConfiguration()
+  return proofRequestTemplates || []
+}
+
+export const useTemplate = (templateId: string): ProofRequestTemplate | undefined => {
+  const { proofRequestTemplates } = useConfiguration()
+  return useMemo(() => proofRequestTemplates?.find((template) => template.id === templateId), [templateId])
+}

--- a/packages/legacy/core/App/screens/ListProofRequests.tsx
+++ b/packages/legacy/core/App/screens/ListProofRequests.tsx
@@ -9,6 +9,7 @@ import { ProofRequestTemplate, hasPredicates, isParameterizable } from '../../ve
 import EmptyList from '../components/misc/EmptyList'
 import { useConfiguration } from '../contexts/configuration'
 import { useTheme } from '../contexts/theme'
+import { useTemplates } from '../hooks/proof-request-templates'
 import { ProofRequestsStackParams, Screens } from '../types/navigators'
 import { MetaOverlay, OverlayType } from '../types/oca'
 import { testIdWithKey } from '../utils/testable'
@@ -114,8 +115,7 @@ const ListProofRequests: React.FC<ListProofRequestsProps> = ({ navigation, route
 
   const { connectionId } = route?.params
 
-  const configuration = useConfiguration()
-  const proofRequestTemplates = configuration.proofRequestTemplates || []
+  const proofRequestTemplates = useTemplates()
 
   return (
     <SafeAreaView style={style.container} edges={['left', 'right']}>

--- a/packages/legacy/core/App/screens/ProofRequesting.tsx
+++ b/packages/legacy/core/App/screens/ProofRequesting.tsx
@@ -19,6 +19,7 @@ import LoadingIndicator from '../components/animated/LoadingIndicator'
 import Button, { ButtonType } from '../components/buttons/Button'
 import QRRenderer from '../components/misc/QRRenderer'
 import { useTheme } from '../contexts/theme'
+import { useTemplate } from '../hooks/proof-request-templates'
 import { ProofRequestsStackParams, Screens } from '../types/navigators'
 import { testIdWithKey } from '../utils/testable'
 
@@ -102,18 +103,23 @@ const ProofRequesting: React.FC<ProofRequestingProps> = ({ route, navigation }) 
 
   const [generating, setGenerating] = useState(true)
   const [message, setMessage] = useState<string | undefined>(undefined)
-  const [invitationUrl, setInitationUrl] = useState<string | undefined>(undefined)
+  const [invitationUrl, setInvitationUrl] = useState<string | undefined>(undefined)
   const [recordId, setRecordId] = useState<string | undefined>(undefined)
+
+  const template = useTemplate(templateId)
+  if (!template) {
+    throw new Error('Unable to find proof request template')
+  }
 
   const createProofRequest = useCallback(async () => {
     try {
       setMessage(undefined)
       setGenerating(true)
-      const result = await createConnectionlessProofRequestInvitation(agent, templateId, predicateValues)
+      const result = await createConnectionlessProofRequestInvitation(agent, template, predicateValues)
       if (result) {
         setRecordId(result.proofRecord.id)
         setMessage(JSON.stringify(result.invitation.toJSON()))
-        setInitationUrl(result.invitationUrl)
+        setInvitationUrl(result.invitationUrl)
         linkProofWithTemplate(agent, result.proofRecord, templateId)
       }
     } finally {

--- a/packages/legacy/core/__tests__/screens/ProofRequesting.test.tsx
+++ b/packages/legacy/core/__tests__/screens/ProofRequesting.test.tsx
@@ -7,6 +7,7 @@ import { defaultProofRequestTemplates } from '../../verifier/constants'
 import { testIdWithKey } from '../../App'
 import ProofRequesting from '../../App/screens/ProofRequesting'
 import * as proofRequestUtils from '../../verifier/utils/proof-request'
+import * as proofRequestTemplatesHooks from '../../App/hooks/proof-request-templates'
 import {
   INDY_PROOF_REQUEST_ATTACHMENT_ID,
   OutOfBandInvitation,
@@ -31,7 +32,8 @@ jest.mock('react-native-device-info', () => () => jest.fn())
 jest.useFakeTimers('legacy')
 jest.spyOn(global, 'setTimeout')
 
-const templateId = defaultProofRequestTemplates[0].id
+const template = defaultProofRequestTemplates[0]
+const templateId = template.id
 
 const proof_request = {
   name: 'proof-request',
@@ -85,6 +87,7 @@ describe('ProofRequesting Component', () => {
     jest.clearAllMocks()
 
     jest.spyOn(proofRequestUtils, 'createConnectionlessProofRequestInvitation').mockReturnValue(Promise.resolve(data))
+    jest.spyOn(proofRequestTemplatesHooks, 'useTemplate').mockReturnValue(template)
   })
 
   const renderView = (params?: { templateId: string; predicateValues: any }) => {

--- a/packages/legacy/core/verifier/__tests__/verifier/__snapshots__/proof-request.test.ts.snap
+++ b/packages/legacy/core/verifier/__tests__/verifier/__snapshots__/proof-request.test.ts.snap
@@ -63,32 +63,3 @@ Object {
   },
 }
 `;
-
-exports[`Helpers Build indy proof request from template id 1`] = `
-Object {
-  "indy": Object {
-    "name": "Student full name",
-    "nonce": "1677766511505",
-    "requestedAttributes": Map {
-      "referent_0" => Object {
-        "name": "student_first_name",
-        "restrictions": Array [
-          Object {
-            "schema_id": "XUxBrVSALWHLeycAUhrNr9:3:CL:26293:Student Card",
-          },
-        ],
-      },
-      "referent_1" => Object {
-        "name": "student_last_name",
-        "restrictions": Array [
-          Object {
-            "schema_id": "XUxBrVSALWHLeycAUhrNr9:3:CL:26293:Student Card",
-          },
-        ],
-      },
-    },
-    "requestedPredicates": Map {},
-    "version": "0.0.1",
-  },
-}
-`;

--- a/packages/legacy/core/verifier/__tests__/verifier/proof-request.test.ts
+++ b/packages/legacy/core/verifier/__tests__/verifier/proof-request.test.ts
@@ -1,8 +1,6 @@
 import {
   buildProofRequestDataForTemplate,
-  buildProofRequestDataForTemplateId,
-  hasPredicates,
-  isParameterizable,
+  hasPredicates
 } from '../../utils/proof-request'
 import SpyInstance = jest.SpyInstance
 import { defaultProofRequestTemplates } from '../../constants'
@@ -23,12 +21,6 @@ describe('Helpers', () => {
   test('Build indy proof request from template containing two requested attributes and predicate', async () => {
     const template = defaultProofRequestTemplates[1]
     const proofRequest = buildProofRequestDataForTemplate(template)
-    expect(proofRequest).toMatchSnapshot()
-  })
-
-  test('Build indy proof request from template id', async () => {
-    const templateId = defaultProofRequestTemplates[0].id
-    const proofRequest = buildProofRequestDataForTemplateId(templateId)
     expect(proofRequest).toMatchSnapshot()
   })
 

--- a/packages/legacy/core/verifier/index.ts
+++ b/packages/legacy/core/verifier/index.ts
@@ -36,9 +36,7 @@ export {
 export type { CreateProofRequestInvitationResult, SendProofRequestResult } from './utils/proof-request'
 export {
   findProofRequestMessage,
-  getProofRequestTemplate,
   buildProofRequestDataForTemplate,
-  buildProofRequestDataForTemplateId,
   createConnectionlessProofRequestInvitation,
   sendProofRequest,
   hasPredicates,

--- a/packages/legacy/core/verifier/utils/proof-request.ts
+++ b/packages/legacy/core/verifier/utils/proof-request.ts
@@ -7,7 +7,6 @@ import {
   V1RequestPresentationMessage,
 } from '@aries-framework/core'
 
-import { defaultProofRequestTemplates } from '../constants'
 import {
   IndyRequestedAttribute,
   IndyRequestedPredicate,
@@ -28,13 +27,6 @@ export const findProofRequestMessage = async (agent: Agent, id: string): Promise
   } else {
     return undefined
   }
-}
-
-/*
- * Find Proof Request template for provided id
- * */
-export const getProofRequestTemplate = (id: string): ProofRequestTemplate | undefined => {
-  return defaultProofRequestTemplates.find((template) => template.id === id)
 }
 
 /*
@@ -84,17 +76,6 @@ export const buildProofRequestDataForTemplate = (
   }
 }
 
-export const buildProofRequestDataForTemplateId = (
-  templateId: string,
-  customPredicateValues?: Record<string, Record<string, number>>
-) => {
-  const template = getProofRequestTemplate(templateId)
-  if (!template) {
-    return undefined
-  }
-  return buildProofRequestDataForTemplate(template, customPredicateValues)
-}
-
 export interface CreateProofRequestInvitationResult {
   request: AgentMessage
   proofRecord: ProofExchangeRecord
@@ -107,10 +88,10 @@ export interface CreateProofRequestInvitationResult {
  * */
 export const createConnectionlessProofRequestInvitation = async (
   agent: Agent,
-  templateId: string,
+  template: ProofRequestTemplate,
   customPredicateValues?: Record<string, Record<string, number>>
 ): Promise<CreateProofRequestInvitationResult | undefined> => {
-  const proofFormats = buildProofRequestDataForTemplateId(templateId, customPredicateValues)
+  const proofFormats = buildProofRequestDataForTemplate(template, customPredicateValues)
   if (!proofFormats) {
     return undefined
   }
@@ -141,11 +122,11 @@ export interface SendProofRequestResult {
  * */
 export const sendProofRequest = async (
   agent: Agent,
-  templateId: string,
+  template: ProofRequestTemplate,
   connectionId: string,
   customPredicateValues?: Record<string, Record<string, number>>
 ): Promise<SendProofRequestResult | undefined> => {
-  const proofFormats = buildProofRequestDataForTemplateId(templateId, customPredicateValues)
+  const proofFormats = buildProofRequestDataForTemplate(template, customPredicateValues)
   if (!proofFormats) {
     return undefined
   }


### PR DESCRIPTION
# Summary of Changes

Issue: The logic of getting the proof request template was incorrect because the function searched for the request in the default constant. Instead, it must search in the application configuration, so if the app overrides the templates the proper one will be found. 

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [ ] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [ ] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [ ] Updated documentation as needed for changed code and new or modified features;
- [ ] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
