### PR TITLE
fix: set restrictions for requested attributes properly

### DIFF
--- a/packages/legacy/core/verifier/__tests__/verifier/__snapshots__/proof-request.test.ts.snap
+++ b/packages/legacy/core/verifier/__tests__/verifier/__snapshots__/proof-request.test.ts.snap
@@ -6,19 +6,35 @@ Object {
     "name": "Student full name",
     "nonce": "1677766511505",
     "requestedAttributes": Map {
-      "referent_0" => Object {
+      "referent_0" => ProofAttributeInfo {
         "name": "student_first_name",
+        "names": undefined,
+        "nonRevoked": undefined,
         "restrictions": Array [
-          Object {
-            "schema_id": "XUxBrVSALWHLeycAUhrNr9:3:CL:26293:Student Card",
+          AttributeFilter {
+            "attributeValue": undefined,
+            "credentialDefinitionId": undefined,
+            "issuerDid": undefined,
+            "schemaId": "XUxBrVSALWHLeycAUhrNr9:3:CL:26293:Student Card",
+            "schemaIssuerDid": undefined,
+            "schemaName": undefined,
+            "schemaVersion": undefined,
           },
         ],
       },
-      "referent_1" => Object {
+      "referent_1" => ProofAttributeInfo {
         "name": "student_last_name",
+        "names": undefined,
+        "nonRevoked": undefined,
         "restrictions": Array [
-          Object {
-            "schema_id": "XUxBrVSALWHLeycAUhrNr9:3:CL:26293:Student Card",
+          AttributeFilter {
+            "attributeValue": undefined,
+            "credentialDefinitionId": undefined,
+            "issuerDid": undefined,
+            "schemaId": "XUxBrVSALWHLeycAUhrNr9:3:CL:26293:Student Card",
+            "schemaIssuerDid": undefined,
+            "schemaName": undefined,
+            "schemaVersion": undefined,
           },
         ],
       },
@@ -35,26 +51,41 @@ Object {
     "name": "Student full name and expiration date",
     "nonce": "1677766511505",
     "requestedAttributes": Map {
-      "referent_0" => Object {
+      "referent_0" => ProofAttributeInfo {
+        "name": undefined,
         "names": Array [
           "student_first_name",
           "student_last_name",
         ],
+        "nonRevoked": undefined,
         "restrictions": Array [
-          Object {
-            "schema_id": "XUxBrVSALWHLeycAUhrNr9:3:CL:26293:Student Card",
+          AttributeFilter {
+            "attributeValue": undefined,
+            "credentialDefinitionId": undefined,
+            "issuerDid": undefined,
+            "schemaId": "XUxBrVSALWHLeycAUhrNr9:3:CL:26293:Student Card",
+            "schemaIssuerDid": undefined,
+            "schemaName": undefined,
+            "schemaVersion": undefined,
           },
         ],
       },
     },
     "requestedPredicates": Map {
-      "referent_1" => Object {
+      "referent_1" => ProofPredicateInfo {
         "name": "expiry_date",
+        "nonRevoked": undefined,
         "predicateType": ">=",
         "predicateValue": 20240101,
         "restrictions": Array [
-          Object {
-            "schema_id": "XUxBrVSALWHLeycAUhrNr9:3:CL:26293:Student Card",
+          AttributeFilter {
+            "attributeValue": undefined,
+            "credentialDefinitionId": undefined,
+            "issuerDid": undefined,
+            "schemaId": "XUxBrVSALWHLeycAUhrNr9:3:CL:26293:Student Card",
+            "schemaIssuerDid": undefined,
+            "schemaName": undefined,
+            "schemaVersion": undefined,
           },
         ],
       },

--- a/packages/legacy/core/verifier/types/proof-reqeust-template.ts
+++ b/packages/legacy/core/verifier/types/proof-reqeust-template.ts
@@ -5,7 +5,7 @@ export interface IndyRequestedPredicate {
   name: string
   predicateType: PredicateType
   predicateValue: number
-  restrictions?: Array<Record<string, unknown>>
+  restrictions?: Array<Record<string, string>>
   nonRevoked?: IndyRevocationInterval
   parameterizable?: boolean
 }
@@ -14,7 +14,7 @@ export interface IndyRequestedAttribute {
   label?: string
   name?: string
   names?: Array<string>
-  restrictions?: Array<Record<string, unknown>>
+  restrictions?: Array<Record<string, string>>
   revealed?: boolean
   nonRevoked?: IndyRevocationInterval
 }


### PR DESCRIPTION
# Summary of Changes

During the testing of the maximum possible number of requested attributes that can be set in a proof request, I noticed that generated request message does not actually contain the attribute restrictions (schema_id) we defined in the request template. 
It happens that AFJ requires the building of a special custom data type for passing indy proof request restrictions otherwise they are just ignored.  

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [ ] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [ ] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
