### PR TITLE
fix: primary and second attr not displaying on cred

### DIFF
--- a/packages/legacy/core/App/components/misc/CredentialCard11.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard11.tsx
@@ -179,6 +179,7 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
   useEffect(() => {
     const params = {
       identifiers: credential ? getCredentialIdentifiers(credential) : { schemaId, credentialDefinitionId: credDefId },
+      attributes: proof ? [] : credential?.credentialAttributes,
       meta: {
         credName: credName,
         credConnectionId: credential?.connectionId,


### PR DESCRIPTION
# Summary of Changes

Previously the primary and secondary attributes were not displaying on the credential card. Fixed credential card layout so that attributes are displayed

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [ ] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [ ] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [ ] Updated documentation as needed for changed code and new or modified features;
- [ ] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
