### PR TITLE
fix: error when credential is removed from wallet

### DIFF
--- a/packages/legacy/core/App/screens/CredentialDetails.tsx
+++ b/packages/legacy/core/App/screens/CredentialDetails.tsx
@@ -6,14 +6,12 @@ import React, { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { DeviceEventEmitter, Image, ImageBackground, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import Toast from 'react-native-toast-message'
 
 import CredentialCard from '../components/misc/CredentialCard'
 import InfoBox, { InfoBoxType } from '../components/misc/InfoBox'
 import CommonRemoveModal from '../components/modals/CommonRemoveModal'
 import Record from '../components/record/Record'
 import RecordRemove from '../components/record/RecordRemove'
-import { ToastType } from '../components/toast/BaseToast'
 import { EventTypes } from '../constants'
 import { useConfiguration } from '../contexts/configuration'
 import { useTheme } from '../contexts/theme'
@@ -44,24 +42,20 @@ const CredentialDetails: React.FC<CredentialDetailsProps> = ({ navigation, route
   }
 
   const { credentialId } = route?.params
-
   const { agent } = useAgent()
   const { t, i18n } = useTranslation()
   const { TextTheme, ColorPallet } = useTheme()
   const { OCABundleResolver } = useConfiguration()
-
   const [isRevoked, setIsRevoked] = useState<boolean>(false)
   const [revocationDate, setRevocationDate] = useState<string>('')
   const [isRemoveModalDisplayed, setIsRemoveModalDisplayed] = useState<boolean>(false)
   const [isRevokedMessageHidden, setIsRevokedMessageHidden] = useState<boolean>(false)
-
   const [overlay, setOverlay] = useState<CredentialOverlay<CardLayoutOverlay11>>({
     bundle: undefined,
     presentationFields: [],
     metaOverlay: undefined,
     cardLayoutOverlay: undefined,
   })
-
   const credential = useCredentialById(credentialId)
   const credentialConnectionLabel = getCredentialConnectionLabel(credential)
 
@@ -155,11 +149,6 @@ const CredentialDetails: React.FC<CredentialDetailsProps> = ({ navigation, route
     }
   }, [isRevoked])
 
-  const goBackToListCredentials = () => {
-    navigation.pop()
-    navigation.navigate(Screens.Credentials)
-  }
-
   const handleOnRemove = () => {
     setIsRemoveModalDisplayed(true)
   }
@@ -169,12 +158,10 @@ const CredentialDetails: React.FC<CredentialDetailsProps> = ({ navigation, route
       if (!(agent && credential)) {
         return
       }
-      await agent.credentials.deleteById(credential.id)
-      Toast.show({
-        type: ToastType.Success,
-        text1: t('CredentialDetails.CredentialRemoved'),
-      })
-      goBackToListCredentials()
+
+      DeviceEventEmitter.emit('FooDelete', credential.id)
+
+      navigation.pop()
     } catch (err: unknown) {
       const error = new BifoldError(t('Error.Title1032'), t('Error.Message1032'), (err as Error).message, 1025)
 

--- a/packages/legacy/core/App/screens/ListCredentials.tsx
+++ b/packages/legacy/core/App/screens/ListCredentials.tsx
@@ -1,19 +1,14 @@
 import { CredentialState } from '@aries-framework/core'
-import { useCredentialByState, useAgent } from '@aries-framework/react-hooks'
+import { useCredentialByState } from '@aries-framework/react-hooks'
 import { useNavigation } from '@react-navigation/core'
-import { useFocusEffect } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { FlatList, View, DeviceEventEmitter } from 'react-native'
-import Toast from 'react-native-toast-message'
+import { FlatList, View } from 'react-native'
 
 import CredentialCard from '../components/misc/CredentialCard'
-import { ToastType } from '../components/toast/BaseToast'
-import { EventTypes } from '../constants'
 import { useConfiguration } from '../contexts/configuration'
 import { useTheme } from '../contexts/theme'
-import { BifoldError } from '../types/error'
 import { CredentialStackParams, Screens } from '../types/navigators'
 
 const ListCredentials: React.FC = () => {
@@ -23,37 +18,8 @@ const ListCredentials: React.FC = () => {
     ...useCredentialByState(CredentialState.CredentialReceived),
     ...useCredentialByState(CredentialState.Done),
   ]
-  const { agent } = useAgent()
   const navigation = useNavigation<StackNavigationProp<CredentialStackParams>>()
   const { ColorPallet } = useTheme()
-  const [credentialToRemove, setCredentialToRemove] = useState<string | undefined>(undefined)
-
-  useEffect(() => {
-    const handle = DeviceEventEmitter.addListener('FooDelete', (value?: string) => {
-      setCredentialToRemove(value)
-    })
-
-    return () => {
-      handle.remove()
-    }
-  }, [])
-
-  useFocusEffect(() => {
-    if (credentialToRemove && agent) {
-      agent.credentials
-        .deleteById(credentialToRemove)
-        .then(() => {
-          Toast.show({
-            type: ToastType.Success,
-            text1: t('CredentialDetails.CredentialRemoved'),
-          })
-        })
-        .catch((err: unknown) => {
-          const error = new BifoldError(t('Error.Title1032'), t('Error.Message1032'), (err as Error).message, 1025)
-          DeviceEventEmitter.emit(EventTypes.ERROR_ADDED, error)
-        })
-    }
-  })
 
   return (
     <View>
@@ -72,7 +38,7 @@ const ListCredentials: React.FC = () => {
             >
               <CredentialCard
                 credential={credential}
-                onPress={() => navigation.navigate(Screens.CredentialDetails, { credentialId: credential.id })}
+                onPress={() => navigation.navigate(Screens.CredentialDetails, { credential })}
               />
             </View>
           )

--- a/packages/legacy/core/App/types/navigators.ts
+++ b/packages/legacy/core/App/types/navigators.ts
@@ -1,3 +1,4 @@
+import { CredentialExchangeRecord } from '@aries-framework/core'
 import { NavigatorScreenParams } from '@react-navigation/core'
 
 import { DeclineType } from './decline'
@@ -102,7 +103,7 @@ export type ProofRequestsStackParams = {
 
 export type CredentialStackParams = {
   [Screens.Credentials]: undefined
-  [Screens.CredentialDetails]: { credentialId: string }
+  [Screens.CredentialDetails]: { credential: CredentialExchangeRecord }
 }
 
 export type HomeStackParams = {

--- a/packages/legacy/core/__tests__/screens/ListCredentials.test.tsx
+++ b/packages/legacy/core/__tests__/screens/ListCredentials.test.tsx
@@ -82,6 +82,7 @@ describe('displays a credentials list screen', () => {
           <ListCredentials />
         </ConfigurationContext.Provider>
       )
+
       await act(async () => {
         const credentialItemInstances = await findAllByText('Person', { exact: false })
 
@@ -92,7 +93,7 @@ describe('displays a credentials list screen', () => {
         fireEvent(credentialItemInstance, 'press')
 
         expect(navigation.navigate).toBeCalledWith('Credential Details', {
-          credentialId: testOpenVPCredentialRecord.id,
+          credential: testOpenVPCredentialRecord,
         })
       })
     })


### PR DESCRIPTION
# Summary of Changes

There was an issue that when the credential is deleted the details screen fails because the credential it was looking up no longer exists. Fixed by passing in the credential so the lookup `useCredentialById` is no longer needed.

# Related Issues

Fixes #705

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
