### PR TITLE
fix: hide cred attributes if not present in oca

### DIFF
--- a/packages/legacy/core/App/types/oca.ts
+++ b/packages/legacy/core/App/types/oca.ts
@@ -323,9 +323,11 @@ export class OCABundleResolver implements OCABundleResolverType {
     language?: string
   }): Promise<Field[]> {
     const bundle = await this.resolve(params)
-    const presentationFields = [...params.attributes]
-
+    let presentationFields = [...params.attributes]
     if (bundle?.captureBase?.attributes) {
+      // if the oca brandaing has the attrbutes set, only display those attributes
+      const bundleFields = Object.keys(bundle.captureBase.attributes)
+      presentationFields = presentationFields.filter((item) => item.name && bundleFields.includes(item.name))
       for (let i = 0; i < presentationFields.length; i++) {
         const presentationField = presentationFields[i]
         const key = presentationField.name || ''


### PR DESCRIPTION
# Summary of Changes

Previously the credential offer and detail screen would display all credential attributes. I changed the functionality so that if the oca branding has the `attributes` attribute then it will only display the attributes listed in the oca bundle. otherwise it will display all attributes

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
