### PR TITLE
fix: gate in-app tour behind dev mode

### DIFF
--- a/packages/legacy/core/App/screens/Home.tsx
+++ b/packages/legacy/core/App/screens/Home.tsx
@@ -83,7 +83,12 @@ const Home: React.FC<HomeProps> = ({ navigation }) => {
   }
 
   useEffect(() => {
-    const shouldShowTour = enableToursConfig && store.tours.enableTours && !store.tours.seenHomeTour
+    const shouldShowTour =
+      store.preferences.developerModeEnabled &&
+      enableToursConfig &&
+      store.tours.enableTours &&
+      !store.tours.seenHomeTour
+
     if (shouldShowTour && screenIsFocused) {
       if (store.tours.seenToursPrompt) {
         dispatch({

--- a/packages/legacy/core/App/screens/Settings.tsx
+++ b/packages/legacy/core/App/screens/Settings.tsx
@@ -149,22 +149,7 @@ const Settings: React.FC<SettingsProps> = ({ navigation }) => {
     ...(settings || []),
   ]
 
-  if (store.preferences.developerModeEnabled) {
-    const section = settingsSections.find((item) => item.header.title === t('Settings.AppSettings'))
-    if (section) {
-      section.data = [
-        ...section.data,
-        {
-          title: t('Settings.Developer'),
-          accessibilityLabel: t('Settings.Developer'),
-          testID: testIdWithKey('DeveloperOptions'),
-          onPress: () => navigation.navigate(Screens.Developer),
-        },
-      ]
-    }
-  }
-
-  if (enableTours) {
+  if (enableTours && store.preferences.developerModeEnabled) {
     const section = settingsSections.find((item) => item.header.title === t('Settings.AppSettings'))
     if (section) {
       section.data = [
@@ -175,6 +160,21 @@ const Settings: React.FC<SettingsProps> = ({ navigation }) => {
           accessibilityLabel: t('Settings.AppGuides'),
           testID: testIdWithKey('AppGuides'),
           onPress: () => navigation.navigate(Screens.Tours),
+        },
+      ]
+    }
+  }
+
+  if (store.preferences.developerModeEnabled) {
+    const section = settingsSections.find((item) => item.header.title === t('Settings.AppSettings'))
+    if (section) {
+      section.data = [
+        ...section.data,
+        {
+          title: t('Settings.Developer'),
+          accessibilityLabel: t('Settings.Developer'),
+          testID: testIdWithKey('DeveloperOptions'),
+          onPress: () => navigation.navigate(Screens.Developer),
         },
       ]
     }


### PR DESCRIPTION
# Summary of Changes

Hides in-app tours and settings option unless developer mode is enabled

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
