### PR TITLE
fixed truncation for long titles on chat screen

### DIFF
--- a/packages/legacy/core/App/screens/Chat.tsx
+++ b/packages/legacy/core/App/screens/Chat.tsx
@@ -149,6 +149,7 @@ const Chat: React.FC<ChatProps> = ({ navigation, route }) => {
     navigation.setOptions({
       title: theirLabel,
       headerTitleAlign: 'center',
+      headerTitleContainerStyle: { maxWidth: '65%' },
       headerRight: () => <InfoIcon connectionId={connection?.id} />,
     })
   }, [connection])


### PR DESCRIPTION
# Summary of Changes

Set the max width property for headerTitleStyle attribute, stops long title in chat screen from pushing right header icon off the page
![image](https://user-images.githubusercontent.com/36937407/235541446-f10641f1-a8c0-44e2-991a-e9382a03c9a1.png)

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
