### PR TITLE
fix: add missing revocation content, precise date

### DIFF
--- a/packages/legacy/core/App/screens/CredentialDetails.tsx
+++ b/packages/legacy/core/App/screens/CredentialDetails.tsx
@@ -50,6 +50,7 @@ const CredentialDetails: React.FC<CredentialDetailsProps> = ({ navigation, route
   const { OCABundleResolver } = useConfiguration()
   const [isRevoked, setIsRevoked] = useState<boolean>(false)
   const [revocationDate, setRevocationDate] = useState<string>('')
+  const [preciseRevocationDate, setPreciseRevocationDate] = useState<string>('')
   const [isRemoveModalDisplayed, setIsRemoveModalDisplayed] = useState<boolean>(false)
   const [isRevokedMessageHidden, setIsRevokedMessageHidden] = useState<boolean>(false)
 
@@ -129,6 +130,7 @@ const CredentialDetails: React.FC<CredentialDetailsProps> = ({ navigation, route
     if (credential?.revocationNotification?.revocationDate) {
       const date = new Date(credential.revocationNotification.revocationDate)
       setRevocationDate(formatTime(date))
+      setPreciseRevocationDate(formatTime(date, { long: true }))
     }
 
     const params = {
@@ -311,36 +313,51 @@ const CredentialDetails: React.FC<CredentialDetailsProps> = ({ navigation, route
 
   const footer = () => {
     return (
-      <View style={{ marginBottom: 30 }}>
+      <View style={{ marginBottom: 50 }}>
         {credentialConnectionLabel ? (
           <View
             style={{
-              backgroundColor: isRevoked ? ColorPallet.notification.error : ColorPallet.brand.secondaryBackground,
+              backgroundColor: ColorPallet.brand.secondaryBackground,
               marginTop: paddingVertical,
               paddingHorizontal,
               paddingVertical,
             }}
           >
-            <>
-              <Text testID={testIdWithKey('IssuerName')}>
-                <Text style={[TextTheme.title, isRevoked && { color: ColorPallet.grayscale.mediumGrey }]}>
-                  {t('CredentialDetails.IssuedBy') + ' '}
-                </Text>
-                <Text style={[TextTheme.normal, isRevoked && { color: ColorPallet.grayscale.mediumGrey }]}>
-                  {credentialConnectionLabel}
-                </Text>
+            <Text testID={testIdWithKey('IssuerName')}>
+              <Text style={[TextTheme.title, isRevoked && { color: ColorPallet.grayscale.mediumGrey }]}>
+                {t('CredentialDetails.IssuedBy') + ' '}
               </Text>
-              {isRevoked ? (
-                <Text testID={testIdWithKey('RevokedDate')}>
-                  <Text style={[TextTheme.title, { color: ColorPallet.notification.errorText }]}>
-                    {t('CredentialDetails.Revoked') + ': '}
-                  </Text>
-                  <Text style={[TextTheme.normal, { color: ColorPallet.notification.errorText }]}>
-                    {revocationDate}
-                  </Text>
-                </Text>
-              ) : null}
-            </>
+              <Text style={[TextTheme.normal, isRevoked && { color: ColorPallet.grayscale.mediumGrey }]}>
+                {credentialConnectionLabel}
+              </Text>
+            </Text>
+          </View>
+        ) : null}
+        {isRevoked ? (
+          <View
+            style={{
+              backgroundColor: ColorPallet.notification.error,
+              marginTop: paddingVertical,
+              paddingHorizontal,
+              paddingVertical,
+            }}
+          >
+            <Text testID={testIdWithKey('RevokedDate')}>
+              <Text style={[TextTheme.title, { color: ColorPallet.notification.errorText }]}>
+                {t('CredentialDetails.Revoked') + ': '}
+              </Text>
+              <Text style={[TextTheme.normal, { color: ColorPallet.notification.errorText }]}>
+                {preciseRevocationDate}
+              </Text>
+            </Text>
+            <Text
+              style={[TextTheme.normal, { color: ColorPallet.notification.errorText, marginTop: paddingVertical }]}
+              testID={testIdWithKey('RevocationMessage')}
+            >
+              {credential?.revocationNotification?.comment
+                ? credential.revocationNotification.comment
+                : t('CredentialDetails.CredentialRevokedMessageBody')}
+            </Text>
           </View>
         ) : null}
         <RecordRemove onRemove={callOnRemove} />


### PR DESCRIPTION
# Summary of Changes

Updated the CredentialDetails screen to show the revocation message and made the date used towards the bottom precise 

Here's what it looks like:
![IMG_0023](https://user-images.githubusercontent.com/32586431/236339131-8793bf69-0879-46e5-a67b-b464637918db.PNG)
![IMG_0024](https://user-images.githubusercontent.com/32586431/236339147-8569d13a-c3a8-4255-a0f0-f7d70b5b99d5.PNG)

Here's what a non-revoked CredentialDetails screen looks like:
![IMG_B43D3F1FD252-1](https://user-images.githubusercontent.com/32586431/236339997-8b1a43e1-bb05-4f9a-9d3a-7c657dd31cf4.jpeg)

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
