### PR TITLE
fix: replaced any with appropriate data type

### DIFF
--- a/packages/legacy/core/App/components/buttons/Button.tsx
+++ b/packages/legacy/core/App/components/buttons/Button.tsx
@@ -21,8 +21,11 @@ export interface ButtonProps {
   disabled?: boolean
 }
 
-const Button: React.FC<ButtonProps & React.RefAttributes<HTMLInputElement | undefined>> = forwardRef(
-  ({ title, buttonType, accessibilityLabel, testID, onPress, disabled = false, children }, ref: any) => {
+const Button: React.FC<ButtonProps & React.RefAttributes<TouchableOpacity>> = forwardRef(
+  (
+    { title, buttonType, accessibilityLabel, testID, onPress, disabled = false, children },
+    ref: React.LegacyRef<TouchableOpacity>
+  ) => {
     const accessible = accessibilityLabel && accessibilityLabel !== '' ? true : false
     const { Buttons, heavyOpacity } = useTheme()
     const buttonStyles = {

--- a/packages/legacy/core/App/components/inputs/PINInput.tsx
+++ b/packages/legacy/core/App/components/inputs/PINInput.tsx
@@ -1,6 +1,6 @@
 import React, { useState, forwardRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native'
 import { CodeField, Cursor, useClearByFocusCell } from 'react-native-confirmation-code-field'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
@@ -18,8 +18,8 @@ interface PINInputProps {
 
 // TODO:(jl) Would be great if someone can figure out the proper type for
 // ref below.
-const PINInput: React.FC<PINInputProps & React.RefAttributes<HTMLInputElement | undefined>> = forwardRef(
-  ({ label, onPINChanged, testID, accessibilityLabel, autoFocus = false }, ref: any) => {
+const PINInput: React.FC<PINInputProps & React.RefAttributes<TextInput>> = forwardRef(
+  ({ label, onPINChanged, testID, accessibilityLabel, autoFocus = false }, ref: React.Ref<TextInput>) => {
     // const accessible = accessibilityLabel && accessibilityLabel !== '' ? true : false
     const [PIN, setPIN] = useState('')
     const [showPIN, setShowPIN] = useState(false)

--- a/packages/legacy/core/App/components/inputs/PINInput.tsx
+++ b/packages/legacy/core/App/components/inputs/PINInput.tsx
@@ -19,7 +19,7 @@ interface PINInputProps {
 // TODO:(jl) Would be great if someone can figure out the proper type for
 // ref below.
 const PINInput: React.FC<PINInputProps & React.RefAttributes<TextInput>> = forwardRef(
-  ({ label, onPINChanged, testID, accessibilityLabel, autoFocus = false }, ref: React.Ref<TextInput>) => {
+  ({ label, onPINChanged, testID, accessibilityLabel, autoFocus = false }, ref: React.Ref<TextInput> | null) => {
     // const accessible = accessibilityLabel && accessibilityLabel !== '' ? true : false
     const [PIN, setPIN] = useState('')
     const [showPIN, setShowPIN] = useState(false)

--- a/packages/legacy/core/App/components/inputs/PINInput.tsx
+++ b/packages/legacy/core/App/components/inputs/PINInput.tsx
@@ -19,7 +19,7 @@ interface PINInputProps {
 // TODO:(jl) Would be great if someone can figure out the proper type for
 // ref below.
 const PINInput: React.FC<PINInputProps & React.RefAttributes<TextInput>> = forwardRef(
-  ({ label, onPINChanged, testID, accessibilityLabel, autoFocus = false }, ref: React.Ref<TextInput> | null) => {
+  ({ label, onPINChanged, testID, accessibilityLabel, autoFocus = false }, ref: React.Ref<TextInput>) => {
     // const accessible = accessibilityLabel && accessibilityLabel !== '' ? true : false
     const [PIN, setPIN] = useState('')
     const [showPIN, setShowPIN] = useState(false)

--- a/packages/legacy/core/App/components/misc/CardWatermark.tsx
+++ b/packages/legacy/core/App/components/misc/CardWatermark.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Text, View } from 'react-native'
+import { StyleProp, Text, TextStyle, View } from 'react-native'
 
 import { useTheme } from '../../contexts/theme'
 
@@ -7,12 +7,12 @@ interface CardWatermarkProps {
   watermark: string
   height: number
   width: number
-  style?: any
+  style?: StyleProp<TextStyle>
 }
 
 const CardWatermark: React.FC<CardWatermarkProps> = ({ watermark, style, height, width }) => {
   const { TextTheme } = useTheme()
-  const fontSize = style?.fontSize ?? TextTheme.normal.fontSize
+  const fontSize = Number((style as React.CSSProperties)?.fontSize ?? TextTheme.normal.fontSize)
   return (
     <View style={{ position: 'absolute', left: '-50%', top: '-100%', width: '200%', height: '200%' }}>
       {Array.from({ length: Math.ceil((height * 2) / (fontSize + fontSize / 4) + 1) }).map((_, i) => (

--- a/packages/legacy/core/App/screens/PINCreate.tsx
+++ b/packages/legacy/core/App/screens/PINCreate.tsx
@@ -65,8 +65,8 @@ const PINCreate: React.FC<PINCreateProps> = ({ setAuthenticated }) => {
 
   const { ColorPallet, TextTheme } = useTheme()
   const { ButtonLoading } = useAnimatedComponents()
-  const PINTwoInputRef = useRef<TextInput>()
-  const createPINButtonRef = useRef<TouchableOpacity>()
+  const PINTwoInputRef = useRef<TextInput>(null)
+  const createPINButtonRef = useRef<TouchableOpacity>(null)
 
   const style = StyleSheet.create({
     screenContainer: {


### PR DESCRIPTION
# Summary of Changes

Replaced `any` with appropriate data type in following components

- [Button](https://github.com/hyperledger/aries-mobile-agent-react-native/blob/main/packages/legacy/core/App/components/buttons/Button.tsx)
- [PINInput](https://github.com/hyperledger/aries-mobile-agent-react-native/blob/main/packages/legacy/core/App/components/inputs/PINInput.tsx)
- [CardWatermark](https://github.com/hyperledger/aries-mobile-agent-react-native/blob/main/packages/legacy/core/App/components/misc/CardWatermark.tsx)

# Related Issues

NA

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
