### PR TITLE
fix: enable i18n in onboarding via refactor

### DIFF
--- a/packages/legacy/core/App/contexts/configuration.tsx
+++ b/packages/legacy/core/App/contexts/configuration.tsx
@@ -4,7 +4,7 @@ import { createContext, ReducerAction, useContext } from 'react'
 import { ProofRequestTemplate } from '../../verifier'
 import { EmptyListProps } from '../components/misc/EmptyList'
 import { RecordProps } from '../components/record/Record'
-import OnboardingPages from '../screens/OnboardingPages'
+import { OnboardingProps } from '../screens/Onboarding'
 import { ScanProps } from '../screens/Scan'
 import { OCABundleResolver } from '../types/oca'
 import { PINSecurityParams } from '../types/security'
@@ -20,7 +20,7 @@ interface NotificationConfiguration {
 }
 
 export interface ConfigurationContext {
-  pages: typeof OnboardingPages
+  onboarding: React.FC<OnboardingProps>
   splash: React.FC
   terms: React.FC
   homeContentView: React.FC

--- a/packages/legacy/core/App/defaultConfiguration.ts
+++ b/packages/legacy/core/App/defaultConfiguration.ts
@@ -9,7 +9,7 @@ import { PINRules } from './constants'
 import { ConfigurationContext } from './contexts/configuration'
 import { useNotifications } from './hooks/notifications'
 import Developer from './screens/Developer'
-import OnboardingPages from './screens/OnboardingPages'
+import Onboarding from './screens/Onboarding'
 import Scan from './screens/Scan'
 import Splash from './screens/Splash'
 import Terms from './screens/Terms'
@@ -17,7 +17,7 @@ import UseBiometry from './screens/UseBiometry'
 import * as oca from './types/oca'
 
 export const defaultConfiguration: ConfigurationContext = {
-  pages: OnboardingPages,
+  onboarding: Onboarding,
   splash: Splash,
   terms: Terms,
   developer: Developer,

--- a/packages/legacy/core/App/index.ts
+++ b/packages/legacy/core/App/index.ts
@@ -1,6 +1,3 @@
-/* eslint-disable import/no-cycle */
-import type { OnboardingStyleSheet } from './screens/Onboarding'
-
 import { Agent } from '@aries-framework/core'
 import AgentProvider from '@aries-framework/react-hooks'
 
@@ -76,7 +73,7 @@ export type { ConfigurationContext } from './contexts/configuration'
 export type { TourStep } from './contexts/tour/tour-context'
 export type { GenericFn } from './types/fn'
 export type { AuthenticateStackParams } from './types/navigators'
-export type { OnboardingStyleSheet }
+export type { OnboardingStyleSheet } from './types/onboarding'
 export type { WalletSecret } from './types/security'
 export type { ReducerAction } from './contexts/reducers/store'
 export type {

--- a/packages/legacy/core/App/localization/en/index.ts
+++ b/packages/legacy/core/App/localization/en/index.ts
@@ -435,6 +435,14 @@ const translation = {
     "Hidden": "Hidden",
     "InvalidDate": "Invalid Date: "
   },
+  "Onboarding": {
+    "Page1Title": "Lorem ipsum dolor sit amet",
+    "Page1Body": "Ipsum faucibus vitae aliquet nec ullamcorper sit amet risus.",
+    "Page2Title": "Excepteur sint occaecat",
+    "Page2Body": "Mollis aliquam ut porttitor leo a diam sollicitudin tempor.",
+    "Page3Title": "Ornare suspendisse sed nisi lacus",
+    "Page3Body": "Enim facilisis gravida neque convallis a cras semper. Suscipit adipiscing bibendum est ultricies integer quis auctor elit sed.",
+  },
   "Screens": {
     "Splash": "Splash",
     "Onboarding": "Onboarding",

--- a/packages/legacy/core/App/localization/fr/index.ts
+++ b/packages/legacy/core/App/localization/fr/index.ts
@@ -427,6 +427,14 @@ const translation = {
         "Hidden": "Masqué",
         "InvalidDate": "Date invalide: ",
     },
+    "Onboarding": {
+        "Page1Title": "Lorem ipsum dolor sit amet (FR)",
+        "Page1Body": "Ipsum faucibus vitae aliquet nec ullamcorper sit amet risus. (FR)",
+        "Page2Title": "Excepteur sint occaecat (FR)",
+        "Page2Body": "Mollis aliquam ut porttitor leo a diam sollicitudin tempor. (FR)",
+        "Page3Title": "Ornare suspendisse sed nisi lacus (FR)",
+        "Page3Body": "Enim facilisis gravida neque convallis a cras semper. Suscipit adipiscing bibendum est ultricies integer quis auctor elit sed. (FR)",
+    },
     "Screens": {
         "Splash": "Page de garde",
         "Onboarding": "Inscription",

--- a/packages/legacy/core/App/localization/pt-br/index.ts
+++ b/packages/legacy/core/App/localization/pt-br/index.ts
@@ -415,6 +415,14 @@ const translation = {
     "HideAll": "Esconder todos",
     "Hidden": "Escondido"
   },
+  "Onboarding": {
+    "Page1Title": "Lorem ipsum dolor sit amet (PT-BR)",
+    "Page1Body": "Ipsum faucibus vitae aliquet nec ullamcorper sit amet risus. (PT-BR)",
+    "Page2Title": "Excepteur sint occaecat (PT-BR)",
+    "Page2Body": "Mollis aliquam ut porttitor leo a diam sollicitudin tempor. (PT-BR)",
+    "Page3Title": "Ornare suspendisse sed nisi lacus (PT-BR)",
+    "Page3Body": "Enim facilisis gravida neque convallis a cras semper. Suscipit adipiscing bibendum est ultricies integer quis auctor elit sed. (PT-BR)",
+  },
   "Screens": {
     "Splash": "Splash",
     "Onboarding": "Onboarding",

--- a/packages/legacy/core/App/navigators/RootStack.tsx
+++ b/packages/legacy/core/App/navigators/RootStack.tsx
@@ -13,7 +13,6 @@ import { useStore } from '../contexts/store'
 import { useTheme } from '../contexts/theme'
 import { useDeepLinks } from '../hooks/deep-links'
 import AttemptLockout from '../screens/AttemptLockout'
-import Onboarding from '../screens/Onboarding'
 import { createCarouselStyle } from '../screens/OnboardingPages'
 import PINCreate from '../screens/PINCreate'
 import PINEnter from '../screens/PINEnter'
@@ -42,7 +41,7 @@ const RootStack: React.FC = () => {
   const theme = useTheme()
   const defaultStackOptions = createDefaultStackOptions(theme)
   const OnboardingTheme = theme.OnboardingTheme
-  const { pages, terms, splash, useBiometry } = useConfiguration()
+  const { onboarding: Onboarding, terms, splash, useBiometry } = useConfiguration()
   useDeepLinks()
 
   const lockoutUser = async () => {
@@ -200,7 +199,7 @@ const RootStack: React.FC = () => {
               {...props}
               nextButtonText={t('Global.Next')}
               previousButtonText={t('Global.Back')}
-              pages={pages(onTutorialCompleted, OnboardingTheme)}
+              onTutorialCompleted={onTutorialCompleted}
               style={carousel}
             />
           )}

--- a/packages/legacy/core/App/navigators/SettingStack.tsx
+++ b/packages/legacy/core/App/navigators/SettingStack.tsx
@@ -7,7 +7,6 @@ import { EventTypes } from '../constants'
 import { useConfiguration } from '../contexts/configuration'
 import { useTheme } from '../contexts/theme'
 import Language from '../screens/Language'
-import Onboarding from '../screens/Onboarding'
 import { createCarouselStyle } from '../screens/OnboardingPages'
 import PINCreate from '../screens/PINCreate'
 import PINRecreate from '../screens/PINRecreate'
@@ -24,7 +23,7 @@ const SettingStack: React.FC = () => {
   const theme = useTheme()
   const [biometryUpdatePending, setBiometryUpdatePending] = useState<boolean>(false)
   const { t } = useTranslation()
-  const { pages, terms, developer } = useConfiguration()
+  const { onboarding: Onboarding, terms, developer } = useConfiguration()
   const defaultStackOptions = createDefaultStackOptions(theme)
   const OnboardingTheme = theme.OnboardingTheme
   const carousel = createCarouselStyle(OnboardingTheme)
@@ -91,7 +90,7 @@ const SettingStack: React.FC = () => {
             {...props}
             nextButtonText={t('Global.Next')}
             previousButtonText={t('Global.Back')}
-            pages={pages(() => null, OnboardingTheme)}
+            onTutorialCompleted={() => null}
             style={carousel}
             disableSkip={true}
           />

--- a/packages/legacy/core/App/screens/Onboarding.tsx
+++ b/packages/legacy/core/App/screens/Onboarding.tsx
@@ -10,34 +10,28 @@ import HeaderRight from '../components/buttons/HeaderRightSkip'
 import { Pagination } from '../components/misc/Pagination'
 import { DispatchAction } from '../contexts/reducers/store'
 import { useStore } from '../contexts/store'
+import { useTheme } from '../contexts/theme'
+import { GenericFn } from '../types/fn'
 import { AuthenticateStackParams, Screens } from '../types/navigators'
+import { OnboardingStyleSheet } from '../types/onboarding'
 import { testIdWithKey } from '../utils/testable'
+
+import OnboardingPages from './OnboardingPages'
 
 const { width } = Dimensions.get('window')
 
-export interface OnboardingStyleSheet {
-  container: Record<string, any>
-  carouselContainer: Record<string, any>
-  pagerContainer: Record<string, any>
-  pagerDot: Record<string, any>
-  pagerDotActive: Record<string, any>
-  pagerDotInactive: Record<string, any>
-  pagerPosition: Record<string, any>
-  pagerNavigationButton: Record<string, any>
-}
-
-interface OnboardingProps {
-  pages: Array<Element>
+export interface OnboardingProps {
   nextButtonText: string
   previousButtonText: string
+  onTutorialCompleted: GenericFn
   style: OnboardingStyleSheet
   disableSkip?: boolean
 }
 
 const Onboarding: React.FC<OnboardingProps> = ({
-  pages,
   nextButtonText,
   previousButtonText,
+  onTutorialCompleted,
   style,
   disableSkip = false,
 }) => {
@@ -47,6 +41,8 @@ const Onboarding: React.FC<OnboardingProps> = ({
   const { t } = useTranslation()
   const navigation = useNavigation<StackNavigationProp<AuthenticateStackParams>>()
   const [, dispatch] = useStore()
+  const { OnboardingTheme } = useTheme()
+  const pages = OnboardingPages(onTutorialCompleted, OnboardingTheme)
 
   const onViewableItemsChangedRef = useRef(({ viewableItems }: any) => {
     if (!viewableItems[0]) {

--- a/packages/legacy/core/App/screens/OnboardingPages.tsx
+++ b/packages/legacy/core/App/screens/OnboardingPages.tsx
@@ -1,16 +1,14 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, Text, View } from 'react-native'
-import { SvgProps } from 'react-native-svg'
 
 import CredentialList from '../assets/img/credential-list.svg'
 import ScanShare from '../assets/img/scan-share.svg'
 import SecureImage from '../assets/img/secure-image.svg'
 import Button, { ButtonType } from '../components/buttons/Button'
 import { GenericFn } from '../types/fn'
+import { OnboardingStyleSheet } from '../types/onboarding'
 import { testIdWithKey } from '../utils/testable'
-
-import { OnboardingStyleSheet } from './Onboarding'
 
 export const createCarouselStyle = (OnboardingTheme: any): OnboardingStyleSheet => {
   return StyleSheet.create({
@@ -83,7 +81,49 @@ const createImageDisplayOptions = (OnboardingTheme: any) => {
   }
 }
 
-const customPages = (onTutorialCompleted: GenericFn, OnboardingTheme: any) => {
+const firstPage = (OnboardingTheme: any) => {
+  const { t } = useTranslation()
+  const styles = createStyles(OnboardingTheme)
+  const imageDisplayOptions = createImageDisplayOptions(OnboardingTheme)
+  return (
+    <ScrollView style={{ padding: 20 }}>
+      <View style={{ alignItems: 'center' }}>
+        <CredentialList {...imageDisplayOptions} />
+      </View>
+      <View style={{ marginBottom: 20 }}>
+        <Text style={[styles.headerText, { fontSize: 18 }]} testID={testIdWithKey('HeaderText')}>
+          {t('Onboarding.Page1Title')}
+        </Text>
+        <Text style={[styles.bodyText, { marginTop: 25 }]} testID={testIdWithKey('BodyText')}>
+          {t('Onboarding.Page1Body')}
+        </Text>
+      </View>
+    </ScrollView>
+  )
+}
+
+const secondPage = (OnboardingTheme: any) => {
+  const { t } = useTranslation()
+  const styles = createStyles(OnboardingTheme)
+  const imageDisplayOptions = createImageDisplayOptions(OnboardingTheme)
+  return (
+    <ScrollView style={{ padding: 20 }}>
+      <View style={{ alignItems: 'center' }}>
+        <ScanShare {...imageDisplayOptions} />
+      </View>
+      <View style={{ marginBottom: 20 }}>
+        <Text style={[styles.headerText, { fontSize: 18 }]} testID={testIdWithKey('HeaderText')}>
+          {t('Onboarding.Page2Title')}
+        </Text>
+        <Text style={[styles.bodyText, { marginTop: 25 }]} testID={testIdWithKey('BodyText')}>
+          {t('Onboarding.Page2Body')}
+        </Text>
+      </View>
+    </ScrollView>
+  )
+}
+
+const thirdPage = (onTutorialCompleted: GenericFn, OnboardingTheme: any) => {
   const { t } = useTranslation()
   const styles = createStyles(OnboardingTheme)
   const imageDisplayOptions = createImageDisplayOptions(OnboardingTheme)
@@ -95,11 +135,10 @@ const customPages = (onTutorialCompleted: GenericFn, OnboardingTheme: any) => {
         </View>
         <View style={{ marginBottom: 20 }}>
           <Text style={[styles.headerText, { fontSize: 18 }]} testID={testIdWithKey('HeaderText')}>
-            Ornare suspendisse sed nisi lacus
+            {t('Onboarding.Page3Title')}
           </Text>
           <Text style={[styles.bodyText, { marginTop: 25 }]} testID={testIdWithKey('BodyText')}>
-            Enim facilisis gravida neque convallis a cras semper. Suscipit adipiscing bibendum est ultricies integer
-            quis auctor elit sed.
+            {t('Onboarding.Page3Body')}
           </Text>
         </View>
       </ScrollView>
@@ -116,42 +155,8 @@ const customPages = (onTutorialCompleted: GenericFn, OnboardingTheme: any) => {
   )
 }
 
-const guides: Array<{ image: React.FC<SvgProps>; title: string; body: string }> = [
-  {
-    image: CredentialList,
-    title: 'Lorem ipsum dolor sit amet',
-    body: 'Ipsum faucibus vitae aliquet nec ullamcorper sit amet risus.',
-  },
-  {
-    image: ScanShare,
-    title: 'Excepteur sint occaecat ',
-    body: 'Mollis aliquam ut porttitor leo a diam sollicitudin tempor.',
-  },
-]
-
-const createPageWith = (image: React.FC<SvgProps>, title: string, body: string, OnboardingTheme: any) => {
-  const styles = createStyles(OnboardingTheme)
-  const imageDisplayOptions = createImageDisplayOptions(OnboardingTheme)
-  return (
-    <ScrollView style={{ padding: 20 }}>
-      <View style={{ alignItems: 'center' }}>{image(imageDisplayOptions)}</View>
-      <View style={{ marginBottom: 20 }}>
-        <Text style={[styles.headerText, { fontSize: 18 }]} testID={testIdWithKey('HeaderText')}>
-          {title}
-        </Text>
-        <Text style={[styles.bodyText, { marginTop: 25 }]} testID={testIdWithKey('BodyText')}>
-          {body}
-        </Text>
-      </View>
-    </ScrollView>
-  )
-}
-
 const OnboardingPages = (onTutorialCompleted: GenericFn, OnboardingTheme: any): Array<Element> => {
-  return [
-    ...guides.map((g) => createPageWith(g.image, g.title, g.body, OnboardingTheme)),
-    customPages(onTutorialCompleted, OnboardingTheme),
-  ]
+  return [firstPage(OnboardingTheme), secondPage(OnboardingTheme), thirdPage(onTutorialCompleted, OnboardingTheme)]
 }
 
 export default OnboardingPages

--- a/packages/legacy/core/App/types/onboarding.ts
+++ b/packages/legacy/core/App/types/onboarding.ts
@@ -1,0 +1,10 @@
+export interface OnboardingStyleSheet {
+  container: Record<string, any>
+  carouselContainer: Record<string, any>
+  pagerContainer: Record<string, any>
+  pagerDot: Record<string, any>
+  pagerDotActive: Record<string, any>
+  pagerDotInactive: Record<string, any>
+  pagerPosition: Record<string, any>
+  pagerNavigationButton: Record<string, any>
+}

--- a/packages/legacy/core/__tests__/contexts/configuration.ts
+++ b/packages/legacy/core/__tests__/contexts/configuration.ts
@@ -5,7 +5,7 @@ import { OCABundleResolver } from '../../App/types/oca'
 import { defaultProofRequestTemplates } from '../../verifier'
 
 const configurationContext: ConfigurationContext = {
-  pages: () => [],
+  onboarding: () => null,
   terms: () => null,
   splash: () => null,
   homeContentView: () => null,

--- a/packages/legacy/core/__tests__/screens/Onboarding.test.tsx
+++ b/packages/legacy/core/__tests__/screens/Onboarding.test.tsx
@@ -1,11 +1,11 @@
 import { render } from '@testing-library/react-native'
 import React from 'react'
-import { Text } from 'react-native'
 
 import * as themeContext from '../../App/contexts/theme' // note we're importing with a * to import all the exports
-import Onboarding, { OnboardingStyleSheet } from '../../App/screens/Onboarding'
+import Onboarding from '../../App/screens/Onboarding'
 import { createCarouselStyle } from '../../App/screens/OnboardingPages'
 import { OnboardingTheme, theme } from '../../App/theme'
+import { OnboardingStyleSheet } from '../../App/types/onboarding'
 
 export const carousel: OnboardingStyleSheet = createCarouselStyle(OnboardingTheme)
 
@@ -16,19 +16,12 @@ jest.mock('@react-navigation/native', () => {
   return require('../../__mocks__/custom/@react-navigation/native')
 })
 
-const pages = [
-  <>
-    <Text testID={'bodyText'}>Hello</Text>
-  </>,
-  <>
-    <Text testID={'bodyText'}>World</Text>
-  </>,
-]
-
 describe('Onboarding', () => {
   test('Renders correctly', () => {
     jest.spyOn(themeContext, 'useTheme').mockImplementation(() => theme)
-    const tree = render(<Onboarding pages={pages} nextButtonText="Next" previousButtonText="Back" style={carousel} />)
+    const tree = render(
+      <Onboarding onTutorialCompleted={() => null} nextButtonText="Next" previousButtonText="Back" style={carousel} />
+    )
 
     expect(tree).toMatchSnapshot()
   })
@@ -36,10 +29,10 @@ describe('Onboarding', () => {
   test('Pages exist', async () => {
     jest.spyOn(themeContext, 'useTheme').mockImplementation(() => theme)
     const { findAllByTestId } = render(
-      <Onboarding pages={pages} nextButtonText="Next" previousButtonText="Back" style={carousel} />
+      <Onboarding onTutorialCompleted={() => null} nextButtonText="Next" previousButtonText="Back" style={carousel} />
     )
-    const foundPages = await findAllByTestId('bodyText')
+    const foundPages = await findAllByTestId('BodyText', { exact: false })
 
-    expect(foundPages.length).toBe(2)
+    expect(foundPages.length).toBe(3)
   })
 })

--- a/packages/legacy/core/__tests__/screens/__snapshots__/Onboarding.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/Onboarding.test.tsx.snap
@@ -20,19 +20,215 @@ exports[`Onboarding Renders correctly 1`] = `
   <RCTScrollView
     data={
       Array [
-        <React.Fragment>
-          <Text
-            testID="bodyText"
+        <ScrollView
+          style={
+            Object {
+              "padding": 20,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+              }
+            }
           >
-            Hello
-          </Text>
-        </React.Fragment>,
-        <React.Fragment>
-          <Text
-            testID="bodyText"
+            <
+              fill="#FFFFFF"
+              height={180}
+              width={180}
+            />
+          </View>
+          <View
+            style={
+              Object {
+                "marginBottom": 20,
+              }
+            }
           >
-            World
-          </Text>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 32,
+                    "fontWeight": "bold",
+                  },
+                  Object {
+                    "fontSize": 18,
+                  },
+                ]
+              }
+              testID="com.ariesbifold:id/HeaderText"
+            >
+              Onboarding.Page1Title
+            </Text>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#FFFFFF",
+                    "flexShrink": 1,
+                    "fontSize": 18,
+                    "fontWeight": "normal",
+                  },
+                  Object {
+                    "marginTop": 25,
+                  },
+                ]
+              }
+              testID="com.ariesbifold:id/BodyText"
+            >
+              Onboarding.Page1Body
+            </Text>
+          </View>
+        </ScrollView>,
+        <ScrollView
+          style={
+            Object {
+              "padding": 20,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+              }
+            }
+          >
+            <
+              fill="#FFFFFF"
+              height={180}
+              width={180}
+            />
+          </View>
+          <View
+            style={
+              Object {
+                "marginBottom": 20,
+              }
+            }
+          >
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 32,
+                    "fontWeight": "bold",
+                  },
+                  Object {
+                    "fontSize": 18,
+                  },
+                ]
+              }
+              testID="com.ariesbifold:id/HeaderText"
+            >
+              Onboarding.Page2Title
+            </Text>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#FFFFFF",
+                    "flexShrink": 1,
+                    "fontSize": 18,
+                    "fontWeight": "normal",
+                  },
+                  Object {
+                    "marginTop": 25,
+                  },
+                ]
+              }
+              testID="com.ariesbifold:id/BodyText"
+            >
+              Onboarding.Page2Body
+            </Text>
+          </View>
+        </ScrollView>,
+        <React.Fragment>
+          <ScrollView
+            style={
+              Object {
+                "padding": 20,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                }
+              }
+            >
+              <
+                fill="#FFFFFF"
+                height={180}
+                width={180}
+              />
+            </View>
+            <View
+              style={
+                Object {
+                  "marginBottom": 20,
+                }
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    Object {
+                      "color": "#FFFFFF",
+                      "fontSize": 32,
+                      "fontWeight": "bold",
+                    },
+                    Object {
+                      "fontSize": 18,
+                    },
+                  ]
+                }
+                testID="com.ariesbifold:id/HeaderText"
+              >
+                Onboarding.Page3Title
+              </Text>
+              <Text
+                style={
+                  Array [
+                    Object {
+                      "color": "#FFFFFF",
+                      "flexShrink": 1,
+                      "fontSize": 18,
+                      "fontWeight": "normal",
+                    },
+                    Object {
+                      "marginTop": 25,
+                    },
+                  ]
+                }
+                testID="com.ariesbifold:id/BodyText"
+              >
+                Onboarding.Page3Body
+              </Text>
+            </View>
+          </ScrollView>
+          <View
+            style={
+              Object {
+                "margin": 20,
+                "marginTop": "auto",
+              }
+            }
+          >
+            <ForwardRef
+              accessibilityLabel="Global.GetStarted"
+              buttonType={1}
+              onPress={[Function]}
+              testID="com.ariesbifold:id/GetStarted"
+              title="Global.GetStarted"
+            />
+          </View>
         </React.Fragment>,
       ]
     }
@@ -102,11 +298,72 @@ exports[`Onboarding Renders correctly 1`] = `
             ]
           }
         >
-          <Text
-            testID="bodyText"
+          <RCTScrollView
+            style={
+              Object {
+                "padding": 20,
+              }
+            }
           >
-            Hello
-          </Text>
+            <View>
+              <View
+                style={
+                  Object {
+                    "alignItems": "center",
+                  }
+                }
+              >
+                <
+                  fill="#FFFFFF"
+                  height={180}
+                  width={180}
+                />
+              </View>
+              <View
+                style={
+                  Object {
+                    "marginBottom": 20,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 32,
+                        "fontWeight": "bold",
+                      },
+                      Object {
+                        "fontSize": 18,
+                      },
+                    ]
+                  }
+                  testID="com.ariesbifold:id/HeaderText"
+                >
+                  Onboarding.Page1Title
+                </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "flexShrink": 1,
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      },
+                      Object {
+                        "marginTop": 25,
+                      },
+                    ]
+                  }
+                  testID="com.ariesbifold:id/BodyText"
+                >
+                  Onboarding.Page1Body
+                </Text>
+              </View>
+            </View>
+          </RCTScrollView>
         </View>
       </View>
       <View
@@ -133,11 +390,227 @@ exports[`Onboarding Renders correctly 1`] = `
             ]
           }
         >
-          <Text
-            testID="bodyText"
+          <RCTScrollView
+            style={
+              Object {
+                "padding": 20,
+              }
+            }
           >
-            World
-          </Text>
+            <View>
+              <View
+                style={
+                  Object {
+                    "alignItems": "center",
+                  }
+                }
+              >
+                <
+                  fill="#FFFFFF"
+                  height={180}
+                  width={180}
+                />
+              </View>
+              <View
+                style={
+                  Object {
+                    "marginBottom": 20,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 32,
+                        "fontWeight": "bold",
+                      },
+                      Object {
+                        "fontSize": 18,
+                      },
+                    ]
+                  }
+                  testID="com.ariesbifold:id/HeaderText"
+                >
+                  Onboarding.Page2Title
+                </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "flexShrink": 1,
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      },
+                      Object {
+                        "marginTop": 25,
+                      },
+                    ]
+                  }
+                  testID="com.ariesbifold:id/BodyText"
+                >
+                  Onboarding.Page2Body
+                </Text>
+              </View>
+            </View>
+          </RCTScrollView>
+        </View>
+      </View>
+      <View
+        onLayout={[Function]}
+        style={
+          Array [
+            Object {
+              "flexDirection": "row",
+            },
+            null,
+          ]
+        }
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "width": 750,
+              },
+              Object {
+                "backgroundColor": "#000000",
+                "flexDirection": "column",
+              },
+            ]
+          }
+        >
+          <RCTScrollView
+            style={
+              Object {
+                "padding": 20,
+              }
+            }
+          >
+            <View>
+              <View
+                style={
+                  Object {
+                    "alignItems": "center",
+                  }
+                }
+              >
+                <
+                  fill="#FFFFFF"
+                  height={180}
+                  width={180}
+                />
+              </View>
+              <View
+                style={
+                  Object {
+                    "marginBottom": 20,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 32,
+                        "fontWeight": "bold",
+                      },
+                      Object {
+                        "fontSize": 18,
+                      },
+                    ]
+                  }
+                  testID="com.ariesbifold:id/HeaderText"
+                >
+                  Onboarding.Page3Title
+                </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "flexShrink": 1,
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      },
+                      Object {
+                        "marginTop": 25,
+                      },
+                    ]
+                  }
+                  testID="com.ariesbifold:id/BodyText"
+                >
+                  Onboarding.Page3Body
+                </Text>
+              </View>
+            </View>
+          </RCTScrollView>
+          <View
+            style={
+              Object {
+                "margin": 20,
+                "marginTop": "auto",
+              }
+            }
+          >
+            <View
+              accessibilityLabel="Global.GetStarted"
+              accessibilityState={
+                Object {
+                  "disabled": false,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              nativeID="animatedComponent"
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "backgroundColor": "#42803E",
+                  "borderRadius": 4,
+                  "opacity": 1,
+                  "padding": 16,
+                }
+              }
+              testID="com.ariesbifold:id/GetStarted"
+            >
+              <View
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 18,
+                        "fontWeight": "bold",
+                        "textAlign": "center",
+                      },
+                      false,
+                    ]
+                  }
+                >
+                  Global.GetStarted
+                </Text>
+              </View>
+            </View>
+          </View>
         </View>
       </View>
     </View>
@@ -212,6 +685,28 @@ exports[`Onboarding Renders correctly 1`] = `
         style={
           Object {
             "backgroundColor": "rgba(66, 128, 62, 1)",
+            "borderColor": "#42803E",
+            "borderRadius": 5,
+            "borderStyle": "solid",
+            "borderWidth": 1,
+            "height": 10,
+            "marginHorizontal": 5,
+            "opacity": 1,
+            "transform": Array [
+              Object {
+                "scale": 1,
+              },
+            ],
+            "width": 10,
+          }
+        }
+      />
+      <View
+        collapsable={false}
+        nativeID="animatedComponent"
+        style={
+          Object {
+            "backgroundColor": "rgba(255, 255, 255, 1)",
             "borderColor": "#42803E",
             "borderRadius": 5,
             "borderStyle": "solid",


### PR DESCRIPTION
# Summary of Changes

Due to previous organization of the onboarding part of the app, the onboarding pages were not included with the i18n. This change includes i18n and some reorganizing to ensure a language settings change would be effective. This will be a breaking change, that will require extensions of Bifold to include their own `Onboarding` component rather a `pages` function. You can use Bifold's `Onboarding` component as an example, it's not a very complex component and you can still make use of your pages function with slight modification

Here's an image of the i18n in action:
![IMG_0029](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/32586431/9d28f5d1-8dfb-4107-aae5-e23d4395711a)

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
