### PR TITLE
chore: increase minimum touch target to 44px by 44px

### DIFF
--- a/packages/legacy/core/App/components/buttons/HeaderLeftBack.tsx
+++ b/packages/legacy/core/App/components/buttons/HeaderLeftBack.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
+import { hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 
 const defaultIconSize = 38
@@ -49,6 +50,7 @@ const HeaderLeftBack: React.FC<HeaderLeftBackProps> = ({
       onPress={onPress}
       style={[style.touchableArea]}
       disabled={disabled}
+      hitSlop={hitSlop}
     >
       <View style={style.container}>
         <Icon name={icon || 'chevron-left'} size={size || defaultIconSize} color={ColorPallet.brand.headerIcon} />

--- a/packages/legacy/core/App/components/buttons/HeaderRightHome.tsx
+++ b/packages/legacy/core/App/components/buttons/HeaderRightHome.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { StyleSheet, TouchableOpacity } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
+import { hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 import { Screens, TabStacks } from '../../types/navigators'
 import { testIdWithKey } from '../../utils/testable'
@@ -28,6 +29,7 @@ const HeaderRightHome: React.FC = () => {
       onPress={() => {
         navigation.getParent()?.navigate(TabStacks.HomeStack, { screen: Screens.Home })
       }}
+      hitSlop={hitSlop}
     >
       <Icon name="home" size={defaultIconSize} color={ColorPallet.brand.headerIcon} />
     </TouchableOpacity>

--- a/packages/legacy/core/App/components/buttons/HeaderRightSkip.tsx
+++ b/packages/legacy/core/App/components/buttons/HeaderRightSkip.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 
+import { hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 
 interface HeaderButtonProps {
@@ -40,6 +41,7 @@ const HeaderRight: React.FC<HeaderButtonProps> = ({ title, testID, accessibility
       onPress={onPress}
       style={[style.touchableArea]}
       disabled={disabled}
+      hitSlop={hitSlop}
     >
       <View style={style.container}>
         <Text style={[style.title]}>{title}</Text>

--- a/packages/legacy/core/App/components/chat/ChatMessage.tsx
+++ b/packages/legacy/core/App/components/chat/ChatMessage.tsx
@@ -4,6 +4,7 @@ import { TouchableOpacity, View } from 'react-native'
 import { Bubble, IMessage, Message } from 'react-native-gifted-chat'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
+import { hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 import { formatTime } from '../../utils/helpers'
 import { testIdWithKey } from '../../utils/testable'
@@ -94,6 +95,7 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({ messageProps }) => {
             style={{
               ...theme.openButtonStyle,
             }}
+            hitSlop={hitSlop}
           >
             <Text style={{ ...theme.openButtonTextStyle }}>{t('Chat.OpenItem')}</Text>
           </TouchableOpacity>

--- a/packages/legacy/core/App/components/inputs/CheckBoxRow.tsx
+++ b/packages/legacy/core/App/components/inputs/CheckBoxRow.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { View, StyleSheet, TouchableOpacity, Text } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
+import { hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 
 interface Props {
@@ -36,6 +37,7 @@ const CheckBoxRow: React.FC<Props> = ({ title, accessibilityLabel, testID, check
         accessibilityLabel={accessibilityLabel}
         testID={testID}
         onPress={onPress}
+        hitSlop={hitSlop}
       >
         {checked ? (
           <Icon name={'check-box'} size={36} color={Inputs.checkBoxColor.color} />

--- a/packages/legacy/core/App/components/inputs/PINInput.tsx
+++ b/packages/legacy/core/App/components/inputs/PINInput.tsx
@@ -4,7 +4,7 @@ import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-nativ
 import { CodeField, Cursor, useClearByFocusCell } from 'react-native-confirmation-code-field'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
-import { minPINLength } from '../../constants'
+import { hitSlop, minPINLength } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 import { testIdWithKey } from '../../utils/testable'
 
@@ -110,6 +110,7 @@ const PINInput: React.FC<PINInputProps & React.RefAttributes<TextInput>> = forwa
             accessibilityLabel={showPIN ? t('PINCreate.Hide') : t('PINCreate.Show')}
             testID={showPIN ? testIdWithKey('Hide') : testIdWithKey('Show')}
             onPress={() => setShowPIN(!showPIN)}
+            hitSlop={hitSlop}
           >
             <Icon color={PINInputTheme.icon.color} name={showPIN ? 'visibility-off' : 'visibility'} size={30}></Icon>
           </TouchableOpacity>

--- a/packages/legacy/core/App/components/inputs/SingleSelectBlock.tsx
+++ b/packages/legacy/core/App/components/inputs/SingleSelectBlock.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { StyleSheet, TouchableOpacity, View } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
+import { hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 import Text from '../texts/Text'
 
@@ -40,7 +41,7 @@ const SingleSelectBlock: React.FC<Props> = ({ selection, onSelect, initialSelect
   return (
     <View style={styles.container}>
       {selection.map((item) => (
-        <TouchableOpacity key={item.id} style={styles.row} onPress={() => handleSelect(item)}>
+        <TouchableOpacity key={item.id} style={styles.row} onPress={() => handleSelect(item)} hitSlop={hitSlop}>
           <Text style={Inputs.singleSelectText}>{item.value}</Text>
           {item.id === selected.id ? <Icon name={'check'} size={25} color={Inputs.singleSelectIcon.color} /> : null}
         </TouchableOpacity>

--- a/packages/legacy/core/App/components/listItems/NotificationListItem.tsx
+++ b/packages/legacy/core/App/components/listItems/NotificationListItem.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next'
 import { StyleSheet, View, ViewStyle, Text, TextStyle, DeviceEventEmitter, TouchableOpacity } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
-import { EventTypes } from '../../constants'
+import { EventTypes, hitSlop } from '../../constants'
 import { useConfiguration } from '../../contexts/configuration'
 import { useStore } from '../../contexts/store'
 import { useTheme } from '../../contexts/theme'
@@ -367,6 +367,7 @@ const NotificationListItem: React.FC<NotificationListItemProps> = ({ notificatio
               accessibilityLabel={t('Global.Close')}
               testID={testIdWithKey(`Close${notificationType}`)}
               onPress={onClose}
+              hitSlop={hitSlop}
             >
               <Icon name={'close'} size={iconSize} color={styleConfig.iconColor} />
             </TouchableOpacity>

--- a/packages/legacy/core/App/components/misc/ConnectionAlert.tsx
+++ b/packages/legacy/core/App/components/misc/ConnectionAlert.tsx
@@ -2,9 +2,10 @@ import { useNavigation } from '@react-navigation/core'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, Text, View } from 'react-native'
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
+import { hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 import { RootStackParams, Screens, Stacks } from '../../types/navigators'
 import PopupModal from '../modals/PopupModal'
@@ -79,7 +80,14 @@ const ConnectionAlert: React.FC<ConnectionAlertProps> = ({ connectionID }) => {
     <View style={styles.notifyTextContainer}>
       <View style={styles.row}>
         <Text style={styles.notifyTitle}>{t('ConnectionAlert.AddedContacts')}</Text>
-        <Icon name={'information-outline'} size={30} style={styles.informationIcon} onPress={toggleInfoCard} />
+        <TouchableOpacity
+          testID={t('Global.Info')}
+          accessibilityLabel={t('Global.Info')}
+          onPress={toggleInfoCard}
+          hitSlop={hitSlop}
+        >
+          <Icon name={'information-outline'} size={30} style={styles.informationIcon} />
+        </TouchableOpacity>
       </View>
       {infoCardVisible && (
         <PopupModal

--- a/packages/legacy/core/App/components/misc/InfoBox.tsx
+++ b/packages/legacy/core/App/components/misc/InfoBox.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { StyleSheet, View, Text, Dimensions, TouchableOpacity } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
+import { hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 import { GenericFn } from '../../types/fn'
 import { testIdWithKey } from '../../utils/testable'
@@ -191,6 +192,7 @@ const InfoBox: React.FC<BifoldErrorProps> = ({
             testID={testIdWithKey('ShowDetails')}
             style={{ marginVertical: 14 }}
             onPress={onShowDetailsTouched}
+            hitSlop={hitSlop}
           >
             <View style={{ flexDirection: 'row' }}>
               <Text style={styles.showDetailsText}>{t('Global.ShowDetails')} </Text>

--- a/packages/legacy/core/App/components/misc/InfoIcon.tsx
+++ b/packages/legacy/core/App/components/misc/InfoIcon.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { StyleSheet, TouchableOpacity } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
+import { hitSlop } from '../../constants'
 import { ColorPallet } from '../../theme'
 import { RootStackParams, Screens, Stacks } from '../../types/navigators'
 import { testIdWithKey } from '../../utils/testable'
@@ -35,6 +36,7 @@ const InfoIcon: React.FC<InfoProps> = ({ connectionId }) => {
           params: { connectionId: connectionId },
         })
       }
+      hitSlop={hitSlop}
     >
       <Icon name="information" size={24} color={ColorPallet.brand.headerIcon}></Icon>
     </TouchableOpacity>

--- a/packages/legacy/core/App/components/misc/Pagination.tsx
+++ b/packages/legacy/core/App/components/misc/Pagination.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Animated, Text, TouchableOpacity, View } from 'react-native'
 import { ScalingDot } from 'react-native-animated-pagination-dots'
 
+import { hitSlop } from '../../constants'
 import { testIdWithKey } from '../../utils/testable'
 
 interface IPaginationStyleSheet {
@@ -58,6 +59,7 @@ export const Pagination: React.FC<IPaginationProps> = ({
         accessibilityLabel={t('Global.Back')}
         testID={testIdWithKey('Back')}
         onPress={previous}
+        hitSlop={hitSlop}
       >
         <Text
           style={[
@@ -83,6 +85,7 @@ export const Pagination: React.FC<IPaginationProps> = ({
         accessibilityLabel={t('Global.Next')}
         testID={testIdWithKey('Next')}
         onPress={next}
+        hitSlop={hitSlop}
       >
         <Text
           style={[

--- a/packages/legacy/core/App/components/misc/QRScannerClose.tsx
+++ b/packages/legacy/core/App/components/misc/QRScannerClose.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { StyleSheet, TouchableOpacity, View } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
+import { hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 import { testIdWithKey } from '../../utils/testable'
 
@@ -31,6 +32,7 @@ const CloseButton: React.FC<Props> = ({ onPress }) => {
         testID={testIdWithKey('ScanClose')}
         style={styles.button}
         onPress={onPress}
+        hitSlop={hitSlop}
       >
         <Icon name="close" size={24} color={ColorPallet.grayscale.white}></Icon>
       </TouchableOpacity>

--- a/packages/legacy/core/App/components/misc/QRScannerTorch.tsx
+++ b/packages/legacy/core/App/components/misc/QRScannerTorch.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { TouchableOpacity, StyleSheet } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
+import { hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 import { ITheme } from '../../theme'
 import { testIdWithKey } from '../../utils/testable'
@@ -41,6 +42,7 @@ const TorchButton: React.FC<Props> = ({ active, onPress, children }) => {
       testID={testIdWithKey('ScanTorch')}
       style={[styles.container, { backgroundColor: active ? theme.ColorPallet.grayscale.white : undefined }]}
       onPress={onPress}
+      hitSlop={hitSlop}
     >
       {children}
     </TouchableOpacity>

--- a/packages/legacy/core/App/components/misc/SettingsMenu.tsx
+++ b/packages/legacy/core/App/components/misc/SettingsMenu.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { StyleSheet, TouchableOpacity } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
+import { hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 import { RootStackParams, Screens, Stacks } from '../../types/navigators'
 import { testIdWithKey } from '../../utils/testable'
@@ -26,6 +27,7 @@ const SettingsMenu: React.FC = () => {
       testID={testIdWithKey('Settings')}
       style={styles.button}
       onPress={() => navigation.navigate(Stacks.SettingStack, { screen: Screens.Settings })}
+      hitSlop={hitSlop}
     >
       <Icon name="menu" size={24} color={ColorPallet.brand.headerIcon}></Icon>
     </TouchableOpacity>

--- a/packages/legacy/core/App/components/modals/AppGuideModal.tsx
+++ b/packages/legacy/core/App/components/modals/AppGuideModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Modal, StyleSheet, View, Text, Dimensions, TouchableOpacity } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
+import { hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 import { GenericFn } from '../../types/fn'
 import { testIdWithKey } from '../../utils/testable'
@@ -88,8 +89,13 @@ const AppGuideModal: React.FC<AppGuideModalProps> = ({
                 {title}
               </Text>
             </View>
-            <View style={styles.dismissIcon} testID={testIdWithKey('Dismiss')}>
-              <TouchableOpacity onPress={onDismissPressed}>
+            <View style={styles.dismissIcon}>
+              <TouchableOpacity
+                onPress={onDismissPressed}
+                testID={testIdWithKey('Dismiss')}
+                accessibilityLabel={t('Global.Dismiss')}
+                hitSlop={hitSlop}
+              >
                 <Icon name={dismissIconName} size={iconSize} color={iconColor} />
               </TouchableOpacity>
             </View>

--- a/packages/legacy/core/App/components/modals/CommonRemoveModal.tsx
+++ b/packages/legacy/core/App/components/modals/CommonRemoveModal.tsx
@@ -9,6 +9,7 @@ import Icon from 'react-native-vector-icons/MaterialIcons'
 import CredentialDeclined from '../../assets/img/credential-declined.svg'
 import CustomNotificationDecline from '../../assets/img/delete-notification.svg'
 import ProofDeclined from '../../assets/img/proof-declined.svg'
+import { hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 import { GenericFn } from '../../types/fn'
 import { ModalUsage } from '../../types/remove'
@@ -245,7 +246,12 @@ const CommonRemoveModal: React.FC<CommonRemoveModalProps> = ({ usage, visible, o
   return (
     <Modal transparent={true} visible={visible} animationType="slide">
       <View style={[styles.headerView]}>
-        <TouchableOpacity accessibilityLabel="Close" testID="Close" onPress={() => onCancel && onCancel()}>
+        <TouchableOpacity
+          accessibilityLabel={t('Global.Close')}
+          testID={testIdWithKey('Close')}
+          onPress={() => onCancel && onCancel()}
+          hitSlop={hitSlop}
+        >
           <Icon name={'close'} size={42} color={TextTheme.modalNormal.color} />
         </TouchableOpacity>
       </View>

--- a/packages/legacy/core/App/components/modals/DismissiblePopupModal.tsx
+++ b/packages/legacy/core/App/components/modals/DismissiblePopupModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Modal, StyleSheet, View, Text, Dimensions, TouchableOpacity, TouchableWithoutFeedback } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
+import { hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 import { GenericFn } from '../../types/fn'
 import { testIdWithKey } from '../../utils/testable'
@@ -102,8 +103,13 @@ const DismissiblePopupModal: React.FC<DismissiblePopupModalProps> = ({
                     {title}
                   </Text>
                 </View>
-                <View style={[styles.dismissIcon]} testID={testIdWithKey('Dismiss')}>
-                  <TouchableOpacity onPress={onDismissPressed}>
+                <View style={[styles.dismissIcon]}>
+                  <TouchableOpacity
+                    onPress={onDismissPressed}
+                    testID={testIdWithKey('Dismiss')}
+                    accessibilityLabel={t('Global.Dismiss')}
+                    hitSlop={hitSlop}
+                  >
                     <Icon name={dismissIconName} size={iconSize} color={iconColor} />
                   </TouchableOpacity>
                 </View>

--- a/packages/legacy/core/App/components/modals/NotificationModal.tsx
+++ b/packages/legacy/core/App/components/modals/NotificationModal.tsx
@@ -6,6 +6,7 @@ import { Modal, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
+import { hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 import { HomeStackParams, Screens } from '../../types/navigators'
 import { testIdWithKey } from '../../utils/testable'
@@ -92,6 +93,7 @@ const NotificationModal: React.FC<NotificationModalProps> = ({
               testID={testIdWithKey('Home')}
               style={styles.iconButton}
               onPress={onHome || closeHome}
+              hitSlop={hitSlop}
             >
               <Icon name="home" size={24} color={ColorPallet.notification.infoText}></Icon>
             </TouchableOpacity>

--- a/packages/legacy/core/App/components/tour/TourBox.tsx
+++ b/packages/legacy/core/App/components/tour/TourBox.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, TouchableOpacity, View, useWindowDimensions } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
-import { tourMargin } from '../../constants'
+import { tourMargin, hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 import { RenderProps } from '../../contexts/tour/tour-context'
 import { testIdWithKey } from '../../utils/testable'
@@ -81,7 +81,6 @@ export function TourBox(props: TourBoxProps): ReactElement {
   const [paginationDots, setPaginationDots] = useState<PaginationDotTypes[]>([])
   const [xPos, setXPos] = useState(0)
   const swipeThreshold = 75
-  const hitSlop = { top: 20, bottom: 20, left: 50, right: 50 }
 
   const styles = StyleSheet.create({
     container: {
@@ -187,8 +186,13 @@ export function TourBox(props: TourBoxProps): ReactElement {
             {title}
           </Text>
         </View>
-        <View style={[styles.dismissIcon]} testID={testIdWithKey('Dismiss')}>
-          <TouchableOpacity onPress={stop}>
+        <View style={[styles.dismissIcon]}>
+          <TouchableOpacity
+            onPress={stop}
+            testID={testIdWithKey('Close')}
+            accessibilityLabel={t('Global.Close')}
+            hitSlop={hitSlop}
+          >
             <Icon name={dismissIconName} size={iconSize} color={iconColor} />
           </TouchableOpacity>
         </View>
@@ -198,7 +202,12 @@ export function TourBox(props: TourBoxProps): ReactElement {
       {(!hideLeft || !hideRight) && (
         <View style={styles.footerContainer}>
           {!hideLeft && (
-            <TouchableOpacity testID={testIdWithKey('Back')} onPress={handleLeft} hitSlop={hitSlop}>
+            <TouchableOpacity
+              accessibilityLabel={leftText}
+              testID={testIdWithKey('Back')}
+              onPress={handleLeft}
+              hitSlop={hitSlop}
+            >
               <Text style={styles.navText}>{leftText}</Text>
             </TouchableOpacity>
           )}
@@ -212,7 +221,12 @@ export function TourBox(props: TourBoxProps): ReactElement {
             )}
           </View>
           {!hideRight && (
-            <TouchableOpacity testID={testIdWithKey('Next')} onPress={handleRight} hitSlop={hitSlop}>
+            <TouchableOpacity
+              accessibilityLabel={rightText}
+              testID={testIdWithKey('Next')}
+              onPress={handleRight}
+              hitSlop={hitSlop}
+            >
               <Text style={styles.navText}>{rightText}</Text>
             </TouchableOpacity>
           )}

--- a/packages/legacy/core/App/components/views/FauxNavigationBar.tsx
+++ b/packages/legacy/core/App/components/views/FauxNavigationBar.tsx
@@ -4,6 +4,7 @@ import { StyleSheet, View, Text, Platform } from 'react-native'
 import { TouchableOpacity } from 'react-native-gesture-handler'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
+import { hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 import { GenericFn } from '../../types/fn'
 import { testIdWithKey } from '../../utils/testable'
@@ -53,6 +54,7 @@ const FauxNavigationBar: React.FC<FauxNavigationBarProps> = ({ title, onHomeTouc
               accessibilityLabel={t('Global.Home')}
               testID={testIdWithKey('HomeButton')}
               onPress={onHomeTouched}
+              hitSlop={hitSlop}
             >
               <Icon name="home" size={defaultIconSize} color={ColorPallet.brand.headerIcon} />
             </TouchableOpacity>

--- a/packages/legacy/core/App/constants.ts
+++ b/packages/legacy/core/App/constants.ts
@@ -76,3 +76,5 @@ export const PINRules: PINValidationRules = {
 export const domain = 'didcomm://invite'
 
 export const tourMargin = 25
+
+export const hitSlop = { top: 44, bottom: 44, left: 44, right: 44 }

--- a/packages/legacy/core/__tests__/components/__snapshots__/CheckBoxRow.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/CheckBoxRow.test.tsx.snap
@@ -16,6 +16,14 @@ exports[`CheckBoxRow Component Renders correctly 1`] = `
     accessible={true}
     collapsable={false}
     focusable={true}
+    hitSlop={
+      Object {
+        "bottom": 44,
+        "left": 44,
+        "right": 44,
+        "top": 44,
+      }
+    }
     nativeID="animatedComponent"
     onClick={[Function]}
     onResponderGrant={[Function]}

--- a/packages/legacy/core/__tests__/components/__snapshots__/CommonRemoveModal.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/CommonRemoveModal.test.tsx.snap
@@ -24,10 +24,18 @@ exports[`CommonRemoveModal Component Credential offer decline renders correctly 
     }
   >
     <View
-      accessibilityLabel="Close"
+      accessibilityLabel="Global.Close"
       accessible={true}
       collapsable={false}
       focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 44,
+          "left": 44,
+          "right": 44,
+          "top": 44,
+        }
+      }
       nativeID="animatedComponent"
       onClick={[Function]}
       onResponderGrant={[Function]}
@@ -41,7 +49,7 @@ exports[`CommonRemoveModal Component Credential offer decline renders correctly 
           "opacity": 1,
         }
       }
-      testID="Close"
+      testID="com.ariesbifold:id/Close"
     >
       <Text
         allowFontScaling={false}
@@ -334,10 +342,18 @@ exports[`CommonRemoveModal Component Custom notification decline renders correct
     }
   >
     <View
-      accessibilityLabel="Close"
+      accessibilityLabel="Global.Close"
       accessible={true}
       collapsable={false}
       focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 44,
+          "left": 44,
+          "right": 44,
+          "top": 44,
+        }
+      }
       nativeID="animatedComponent"
       onClick={[Function]}
       onResponderGrant={[Function]}
@@ -351,7 +367,7 @@ exports[`CommonRemoveModal Component Custom notification decline renders correct
           "opacity": 1,
         }
       }
-      testID="Close"
+      testID="com.ariesbifold:id/Close"
     >
       <Text
         allowFontScaling={false}
@@ -649,10 +665,18 @@ exports[`CommonRemoveModal Component Proof request decline renders correctly 1`]
     }
   >
     <View
-      accessibilityLabel="Close"
+      accessibilityLabel="Global.Close"
       accessible={true}
       collapsable={false}
       focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 44,
+          "left": 44,
+          "right": 44,
+          "top": 44,
+        }
+      }
       nativeID="animatedComponent"
       onClick={[Function]}
       onResponderGrant={[Function]}
@@ -666,7 +690,7 @@ exports[`CommonRemoveModal Component Proof request decline renders correctly 1`]
           "opacity": 1,
         }
       }
-      testID="Close"
+      testID="com.ariesbifold:id/Close"
     >
       <Text
         allowFontScaling={false}
@@ -973,10 +997,18 @@ exports[`CommonRemoveModal Component Remove contact renders correctly 1`] = `
     }
   >
     <View
-      accessibilityLabel="Close"
+      accessibilityLabel="Global.Close"
       accessible={true}
       collapsable={false}
       focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 44,
+          "left": 44,
+          "right": 44,
+          "top": 44,
+        }
+      }
       nativeID="animatedComponent"
       onClick={[Function]}
       onResponderGrant={[Function]}
@@ -990,7 +1022,7 @@ exports[`CommonRemoveModal Component Remove contact renders correctly 1`] = `
           "opacity": 1,
         }
       }
-      testID="Close"
+      testID="com.ariesbifold:id/Close"
     >
       <Text
         allowFontScaling={false}
@@ -1491,10 +1523,18 @@ exports[`CommonRemoveModal Component Remove credential renders correctly 1`] = `
     }
   >
     <View
-      accessibilityLabel="Close"
+      accessibilityLabel="Global.Close"
       accessible={true}
       collapsable={false}
       focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 44,
+          "left": 44,
+          "right": 44,
+          "top": 44,
+        }
+      }
       nativeID="animatedComponent"
       onClick={[Function]}
       onResponderGrant={[Function]}
@@ -1508,7 +1548,7 @@ exports[`CommonRemoveModal Component Remove credential renders correctly 1`] = `
           "opacity": 1,
         }
       }
-      testID="Close"
+      testID="com.ariesbifold:id/Close"
     >
       <Text
         allowFontScaling={false}
@@ -2117,10 +2157,18 @@ exports[`CommonRemoveModal Component Rerenders correctly when not visible 1`] = 
     }
   >
     <View
-      accessibilityLabel="Close"
+      accessibilityLabel="Global.Close"
       accessible={true}
       collapsable={false}
       focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 44,
+          "left": 44,
+          "right": 44,
+          "top": 44,
+        }
+      }
       nativeID="animatedComponent"
       onClick={[Function]}
       onResponderGrant={[Function]}
@@ -2134,7 +2182,7 @@ exports[`CommonRemoveModal Component Rerenders correctly when not visible 1`] = 
           "opacity": 1,
         }
       }
-      testID="Close"
+      testID="com.ariesbifold:id/Close"
     >
       <Text
         allowFontScaling={false}

--- a/packages/legacy/core/__tests__/components/__snapshots__/DismissiblePopupModal.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/DismissiblePopupModal.test.tsx.snap
@@ -129,12 +129,20 @@ exports[`DismissiblePopupModal Component Renders correctly with call to action 1
                 },
               ]
             }
-            testID="com.ariesbifold:id/Dismiss"
           >
             <View
+              accessibilityLabel="Global.Dismiss"
               accessible={true}
               collapsable={false}
               focusable={true}
+              hitSlop={
+                Object {
+                  "bottom": 44,
+                  "left": 44,
+                  "right": 44,
+                  "top": 44,
+                }
+              }
               nativeID="animatedComponent"
               onClick={[Function]}
               onResponderGrant={[Function]}
@@ -148,6 +156,7 @@ exports[`DismissiblePopupModal Component Renders correctly with call to action 1
                   "opacity": 1,
                 }
               }
+              testID="com.ariesbifold:id/Dismiss"
             >
               <Text
                 allowFontScaling={false}
@@ -386,12 +395,20 @@ exports[`DismissiblePopupModal Component Renders correctly without call to actio
                 },
               ]
             }
-            testID="com.ariesbifold:id/Dismiss"
           >
             <View
+              accessibilityLabel="Global.Dismiss"
               accessible={true}
               collapsable={false}
               focusable={true}
+              hitSlop={
+                Object {
+                  "bottom": 44,
+                  "left": 44,
+                  "right": 44,
+                  "top": 44,
+                }
+              }
               nativeID="animatedComponent"
               onClick={[Function]}
               onResponderGrant={[Function]}
@@ -405,6 +422,7 @@ exports[`DismissiblePopupModal Component Renders correctly without call to actio
                   "opacity": 1,
                 }
               }
+              testID="com.ariesbifold:id/Dismiss"
             >
               <Text
                 allowFontScaling={false}

--- a/packages/legacy/core/__tests__/components/__snapshots__/FauxNavigationBar.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/FauxNavigationBar.test.tsx.snap
@@ -48,6 +48,14 @@ Array [
       </Text>
       <RNGestureHandlerButton
         collapsable={false}
+        hitSlop={
+          Object {
+            "bottom": 44,
+            "left": 44,
+            "right": 44,
+            "top": 44,
+          }
+        }
         onGestureEvent={[Function]}
         onGestureHandlerEvent={[Function]}
         onGestureHandlerStateChange={[Function]}
@@ -59,6 +67,14 @@ Array [
           accessibilityLabel="Global.Home"
           accessible={true}
           collapsable={false}
+          hitSlop={
+            Object {
+              "bottom": 44,
+              "left": 44,
+              "right": 44,
+              "top": 44,
+            }
+          }
           nativeID="animatedComponent"
           style={
             Object {

--- a/packages/legacy/core/__tests__/components/__snapshots__/HeaderLeftBack.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/HeaderLeftBack.test.tsx.snap
@@ -11,6 +11,14 @@ exports[`Header Left Button Component Renders correctly 1`] = `
   accessible={true}
   collapsable={false}
   focusable={true}
+  hitSlop={
+    Object {
+      "bottom": 44,
+      "left": 44,
+      "right": 44,
+      "top": 44,
+    }
+  }
   nativeID="animatedComponent"
   onClick={[Function]}
   onResponderGrant={[Function]}

--- a/packages/legacy/core/__tests__/components/__snapshots__/HeaderRightHome.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/HeaderRightHome.test.tsx.snap
@@ -6,6 +6,14 @@ exports[`Header Right Home Component Renders correctly 1`] = `
   accessible={true}
   collapsable={false}
   focusable={true}
+  hitSlop={
+    Object {
+      "bottom": 44,
+      "left": 44,
+      "right": 44,
+      "top": 44,
+    }
+  }
   nativeID="animatedComponent"
   onClick={[Function]}
   onResponderGrant={[Function]}

--- a/packages/legacy/core/__tests__/components/__snapshots__/HeaderRightSkip.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/HeaderRightSkip.test.tsx.snap
@@ -11,6 +11,14 @@ exports[`Header Right Button Component Renders correctly 1`] = `
   accessible={true}
   collapsable={false}
   focusable={true}
+  hitSlop={
+    Object {
+      "bottom": 44,
+      "left": 44,
+      "right": 44,
+      "top": 44,
+    }
+  }
   nativeID="animatedComponent"
   onClick={[Function]}
   onResponderGrant={[Function]}

--- a/packages/legacy/core/__tests__/components/__snapshots__/InfoBox.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/InfoBox.test.tsx.snap
@@ -83,6 +83,14 @@ exports[`ErrorModal Component Renders correctly as Error 1`] = `
       accessible={true}
       collapsable={false}
       focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 44,
+          "left": 44,
+          "right": 44,
+          "top": 44,
+        }
+      }
       nativeID="animatedComponent"
       onClick={[Function]}
       onResponderGrant={[Function]}
@@ -281,6 +289,14 @@ exports[`ErrorModal Component Renders correctly as Info 1`] = `
       accessible={true}
       collapsable={false}
       focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 44,
+          "left": 44,
+          "right": 44,
+          "top": 44,
+        }
+      }
       nativeID="animatedComponent"
       onClick={[Function]}
       onResponderGrant={[Function]}
@@ -479,6 +495,14 @@ exports[`ErrorModal Component Renders correctly as Success 1`] = `
       accessible={true}
       collapsable={false}
       focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 44,
+          "left": 44,
+          "right": 44,
+          "top": 44,
+        }
+      }
       nativeID="animatedComponent"
       onClick={[Function]}
       onResponderGrant={[Function]}
@@ -677,6 +701,14 @@ exports[`ErrorModal Component Renders correctly as Warning 1`] = `
       accessible={true}
       collapsable={false}
       focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 44,
+          "left": 44,
+          "right": 44,
+          "top": 44,
+        }
+      }
       nativeID="animatedComponent"
       onClick={[Function]}
       onResponderGrant={[Function]}

--- a/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
@@ -1026,30 +1026,56 @@ exports[`displays a credential offer screen accepting a credential 1`] = `
                 >
                   ConnectionAlert.AddedContacts
                 </Text>
-                <Text
-                  allowFontScaling={false}
-                  onPress={[Function]}
-                  style={
-                    Array [
-                      Object {
-                        "color": undefined,
-                        "fontSize": 30,
-                      },
-                      Object {
-                        "color": "#FFFFFF",
-                        "marginLeft": 10,
-                      },
-                      Object {
-                        "fontFamily": "Material Design Icons",
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
-                      },
-                      Object {},
-                    ]
+                <View
+                  accessibilityLabel="Global.Info"
+                  accessible={true}
+                  focusable={true}
+                  hitSlop={
+                    Object {
+                      "bottom": 44,
+                      "left": 44,
+                      "right": 44,
+                      "top": 44,
+                    }
                   }
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    Object {
+                      "opacity": 1,
+                    }
+                  }
+                  testID="Global.Info"
                 >
-                  󰋽
-                </Text>
+                  <Text
+                    allowFontScaling={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": undefined,
+                          "fontSize": 30,
+                        },
+                        Object {
+                          "color": "#FFFFFF",
+                          "marginLeft": 10,
+                        },
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰋽
+                  </Text>
+                </View>
               </View>
               <Text
                 style={
@@ -1412,9 +1438,17 @@ exports[`displays a credential offer screen accepting a credential 1`] = `
       }
     >
       <View
-        accessibilityLabel="Close"
+        accessibilityLabel="Global.Close"
         accessible={true}
         focusable={true}
+        hitSlop={
+          Object {
+            "bottom": 44,
+            "left": 44,
+            "right": 44,
+            "top": 44,
+          }
+        }
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -1427,7 +1461,7 @@ exports[`displays a credential offer screen accepting a credential 1`] = `
             "opacity": 1,
           }
         }
-        testID="Close"
+        testID="com.ariesbifold:id/Close"
       >
         <Text
           allowFontScaling={false}
@@ -2719,30 +2753,56 @@ exports[`displays a credential offer screen declining a credential 1`] = `
                 >
                   ConnectionAlert.AddedContacts
                 </Text>
-                <Text
-                  allowFontScaling={false}
-                  onPress={[Function]}
-                  style={
-                    Array [
-                      Object {
-                        "color": undefined,
-                        "fontSize": 30,
-                      },
-                      Object {
-                        "color": "#FFFFFF",
-                        "marginLeft": 10,
-                      },
-                      Object {
-                        "fontFamily": "Material Design Icons",
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
-                      },
-                      Object {},
-                    ]
+                <View
+                  accessibilityLabel="Global.Info"
+                  accessible={true}
+                  focusable={true}
+                  hitSlop={
+                    Object {
+                      "bottom": 44,
+                      "left": 44,
+                      "right": 44,
+                      "top": 44,
+                    }
                   }
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    Object {
+                      "opacity": 1,
+                    }
+                  }
+                  testID="Global.Info"
                 >
-                  󰋽
-                </Text>
+                  <Text
+                    allowFontScaling={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": undefined,
+                          "fontSize": 30,
+                        },
+                        Object {
+                          "color": "#FFFFFF",
+                          "marginLeft": 10,
+                        },
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰋽
+                  </Text>
+                </View>
               </View>
               <Text
                 style={
@@ -3105,9 +3165,17 @@ exports[`displays a credential offer screen declining a credential 1`] = `
       }
     >
       <View
-        accessibilityLabel="Close"
+        accessibilityLabel="Global.Close"
         accessible={true}
         focusable={true}
+        hitSlop={
+          Object {
+            "bottom": 44,
+            "left": 44,
+            "right": 44,
+            "top": 44,
+          }
+        }
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -3120,7 +3188,7 @@ exports[`displays a credential offer screen declining a credential 1`] = `
             "opacity": 1,
           }
         }
-        testID="Close"
+        testID="com.ariesbifold:id/Close"
       >
         <Text
           allowFontScaling={false}
@@ -4414,30 +4482,56 @@ exports[`displays a credential offer screen renders correctly 1`] = `
                 >
                   ConnectionAlert.AddedContacts
                 </Text>
-                <Text
-                  allowFontScaling={false}
-                  onPress={[Function]}
-                  style={
-                    Array [
-                      Object {
-                        "color": undefined,
-                        "fontSize": 30,
-                      },
-                      Object {
-                        "color": "#FFFFFF",
-                        "marginLeft": 10,
-                      },
-                      Object {
-                        "fontFamily": "Material Design Icons",
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
-                      },
-                      Object {},
-                    ]
+                <View
+                  accessibilityLabel="Global.Info"
+                  accessible={true}
+                  focusable={true}
+                  hitSlop={
+                    Object {
+                      "bottom": 44,
+                      "left": 44,
+                      "right": 44,
+                      "top": 44,
+                    }
                   }
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    Object {
+                      "opacity": 1,
+                    }
+                  }
+                  testID="Global.Info"
                 >
-                  󰋽
-                </Text>
+                  <Text
+                    allowFontScaling={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": undefined,
+                          "fontSize": 30,
+                        },
+                        Object {
+                          "color": "#FFFFFF",
+                          "marginLeft": 10,
+                        },
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰋽
+                  </Text>
+                </View>
               </View>
               <Text
                 style={
@@ -4800,9 +4894,17 @@ exports[`displays a credential offer screen renders correctly 1`] = `
       }
     >
       <View
-        accessibilityLabel="Close"
+        accessibilityLabel="Global.Close"
         accessible={true}
         focusable={true}
+        hitSlop={
+          Object {
+            "bottom": 44,
+            "left": 44,
+            "right": 44,
+            "top": 44,
+          }
+        }
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -4815,7 +4917,7 @@ exports[`displays a credential offer screen renders correctly 1`] = `
             "opacity": 1,
           }
         }
-        testID="Close"
+        testID="com.ariesbifold:id/Close"
       >
         <Text
           allowFontScaling={false}

--- a/packages/legacy/core/__tests__/screens/__snapshots__/Onboarding.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/Onboarding.test.tsx.snap
@@ -157,6 +157,14 @@ exports[`Onboarding Renders correctly 1`] = `
       accessible={true}
       collapsable={false}
       focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 44,
+          "left": 44,
+          "right": 44,
+          "top": 44,
+        }
+      }
       nativeID="animatedComponent"
       onClick={[Function]}
       onResponderGrant={[Function]}
@@ -256,6 +264,14 @@ exports[`Onboarding Renders correctly 1`] = `
       accessible={true}
       collapsable={false}
       focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 44,
+          "left": 44,
+          "right": 44,
+          "top": 44,
+        }
+      }
       nativeID="animatedComponent"
       onClick={[Function]}
       onResponderGrant={[Function]}

--- a/packages/legacy/core/__tests__/screens/__snapshots__/PINEnter.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/PINEnter.test.tsx.snap
@@ -318,6 +318,14 @@ exports[`displays a PIN create screen PIN create renders correctly 1`] = `
                   accessible={true}
                   collapsable={false}
                   focusable={true}
+                  hitSlop={
+                    Object {
+                      "bottom": 44,
+                      "left": 44,
+                      "right": 44,
+                      "top": 44,
+                    }
+                  }
                   nativeID="animatedComponent"
                   onClick={[Function]}
                   onResponderGrant={[Function]}

--- a/packages/legacy/core/__tests__/screens/__snapshots__/UseBiometry.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/UseBiometry.test.tsx.snap
@@ -550,6 +550,14 @@ exports[`UseBiometry Screen Renders correctly when biometry available 1`] = `
                       accessibilityLabel="PINCreate.Show"
                       accessible={true}
                       focusable={true}
+                      hitSlop={
+                        Object {
+                          "bottom": 44,
+                          "left": 44,
+                          "right": 44,
+                          "top": 44,
+                        }
+                      }
                       onClick={[Function]}
                       onResponderGrant={[Function]}
                       onResponderMove={[Function]}
@@ -1197,6 +1205,14 @@ exports[`UseBiometry Screen Renders correctly when biometry not available 1`] = 
                       accessible={true}
                       collapsable={false}
                       focusable={true}
+                      hitSlop={
+                        Object {
+                          "bottom": 44,
+                          "left": 44,
+                          "right": 44,
+                          "top": 44,
+                        }
+                      }
                       nativeID="animatedComponent"
                       onClick={[Function]}
                       onResponderGrant={[Function]}
@@ -1900,6 +1916,14 @@ exports[`UseBiometry Screen Toggles use biometrics ok 1`] = `
                       accessibilityLabel="PINCreate.Show"
                       accessible={true}
                       focusable={true}
+                      hitSlop={
+                        Object {
+                          "bottom": 44,
+                          "left": 44,
+                          "right": 44,
+                          "top": 44,
+                        }
+                      }
                       onClick={[Function]}
                       onResponderGrant={[Function]}
                       onResponderMove={[Function]}


### PR DESCRIPTION
# Summary of Changes

Increases the minimum touch target of `TouchableOpacity` components to 44px by 44px. I also fixed a few `accessibilityLabel` and `testID` issues that I came across. I didn't change the touch target of `TouchableOpacity` components that had many large children (ie. our base button and touchable sections that had a lot of content like `CredentialCard`) because they are already well over 44px by 44px. I touched many files but it's mostly tiny changes.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
