### PR TITLE
fix: format verifier dates where possible

### DIFF
--- a/packages/legacy/core/App/screens/ProofRequestDetails.tsx
+++ b/packages/legacy/core/App/screens/ProofRequestDetails.tsx
@@ -1,6 +1,6 @@
 import { useAgent } from '@aries-framework/react-hooks'
 import { StackScreenProps } from '@react-navigation/stack'
-import React, { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FlatList, StyleSheet, Text, TextInput, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
@@ -19,7 +19,7 @@ import { useTemplate } from '../hooks/proof-request-templates'
 import { Screens, ProofRequestsStackParams } from '../types/navigators'
 import { MetaOverlay, OverlayType } from '../types/oca'
 import { Attribute, Field, Predicate } from '../types/record'
-import { formatTime } from '../utils/helpers'
+import { formatIfDate } from '../utils/helpers'
 import { buildFieldsFromIndyProofRequestTemplate } from '../utils/oca'
 import { parseSchemaFromId } from '../utils/schema'
 import { testIdWithKey } from '../utils/testable'
@@ -29,24 +29,6 @@ type ProofRequestDetailsProps = StackScreenProps<ProofRequestsStackParams, Scree
 interface ProofRequestAttributesCardParams {
   data: IndyProofRequestTemplatePayloadData
   onChangeValue: (schema: string, label: string, name: string, value: string) => void
-}
-
-const formatIfDate = (
-  format: string | undefined,
-  value: string | number | null,
-  setter: Dispatch<SetStateAction<string | number | null>>
-) => {
-  const potentialDate = value ? value.toString() : null
-  if (format === 'YYYYMMDD' && potentialDate && potentialDate.length === format.length) {
-    const year = potentialDate.substring(0, 4)
-    const month = potentialDate.substring(4, 6)
-    const day = potentialDate.substring(6, 8)
-    // NOTE: JavaScript counts months from 0 to 11: January = 0, December = 11.
-    const date = new Date(Number(year), Number(month) - 1, Number(day))
-    if (!isNaN(date.getDate())) {
-      setter(formatTime(date))
-    }
-  }
 }
 
 const AttributeItem: React.FC<{ item: Attribute }> = ({ item }) => {

--- a/packages/legacy/core/App/utils/helpers.ts
+++ b/packages/legacy/core/App/utils/helpers.ts
@@ -17,7 +17,7 @@ import { Buffer } from 'buffer'
 import { WalletQuery } from 'indy-sdk-react-native'
 import moment from 'moment'
 import { ParsedUrl, parseUrl } from 'query-string'
-import { ReactNode } from 'react'
+import { Dispatch, ReactNode, SetStateAction } from 'react'
 
 import { domain } from '../constants'
 import { i18n } from '../localization/index'
@@ -119,6 +119,24 @@ export function formatTime(time: Date, params?: { long?: boolean; format?: strin
     }
   }
   return formattedTime
+}
+
+export function formatIfDate(
+  format: string | undefined,
+  value: string | number | null,
+  setter: Dispatch<SetStateAction<string | number | null>>
+) {
+  const potentialDate = value ? value.toString() : null
+  if (format === 'YYYYMMDD' && potentialDate && potentialDate.length === format.length) {
+    const year = potentialDate.substring(0, 4)
+    const month = potentialDate.substring(4, 6)
+    const day = potentialDate.substring(6, 8)
+    // NOTE: JavaScript counts months from 0 to 11: January = 0, December = 11.
+    const date = new Date(Number(year), Number(month) - 1, Number(day))
+    if (!isNaN(date.getDate())) {
+      setter(formatTime(date))
+    }
+  }
 }
 
 /**

--- a/packages/legacy/core/__tests__/utils/__snapshots__/helpers.test.ts.snap
+++ b/packages/legacy/core/__tests__/utils/__snapshots__/helpers.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Helpers Sorts retrieved credentials by revocation 1`] = `
+exports[`credentialSortFn Sorts retrieved credentials by revocation 1`] = `
 Array [
   Object {
     "credentialId": "4e91a381-7ed6-4ea7-8011-39a11cbd0c18",

--- a/packages/legacy/core/__tests__/utils/helpers.test.ts
+++ b/packages/legacy/core/__tests__/utils/helpers.test.ts
@@ -1,17 +1,54 @@
 import fs from 'fs'
 import path from 'path'
 
-import { credentialSortFn } from '../../App/utils/helpers'
+import { credentialSortFn, formatIfDate } from '../../App/utils/helpers'
 
 const proofCredentialPath = path.join(__dirname, '../fixtures/proof-credential.json')
 const credentials = JSON.parse(fs.readFileSync(proofCredentialPath, 'utf8'))
 
-describe('Helpers', () => {
+describe('credentialSortFn', () => {
   test('Sorts retrieved credentials by revocation', async () => {
     const key = '0_surname_uuid'
     const { requestedAttributes } = credentials
     const sortedCreds = requestedAttributes[key].sort(credentialSortFn)
 
     expect(sortedCreds).toMatchSnapshot()
+  })
+})
+
+describe('formatIfDate', () => {
+  let setter = jest.fn()
+
+  beforeEach(() => {
+    setter = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('without format', () => {
+    formatIfDate(undefined, '20020523', setter)
+    expect(setter).toBeCalledTimes(0)
+  })
+
+  test('with format and string date', () => {
+    formatIfDate('YYYYMMDD', '20020523', setter)
+    expect(setter).toBeCalledTimes(1)
+  })
+
+  test('with format and number date', () => {
+    formatIfDate('YYYYMMDD', 20020523, setter)
+    expect(setter).toBeCalledTimes(1)
+  })
+
+  test('with format but invalid string date', () => {
+    formatIfDate('YYYYMMDD', '203', setter)
+    expect(setter).toBeCalledTimes(0)
+  })
+
+  test('with format but invalid number date', () => {
+    formatIfDate('YYYYMMDD', 203, setter)
+    expect(setter).toBeCalledTimes(0)
   })
 })


### PR DESCRIPTION
# Summary of Changes

Formatting dates in verifier where possible - I couldn't format the dates of parametrizable predicates, they had to remain numbers for proper functionality. Dates in proof requests themselves (as they appear to the holder) still need formatting, but that is for another PR.

Here is what the ProofRequestDetails screen looks like now:
<img width="371" alt="Screenshot 2023-05-30 at 3 10 08 PM" src="https://github.com/hyperledger/aries-mobile-agent-react-native/assets/32586431/b1fb77f0-7c30-4896-89fd-a368c736c11c">

Here is a parametrizable predicate (needs to remain a number):
<img width="371" alt="Screenshot 2023-05-30 at 3 10 38 PM" src="https://github.com/hyperledger/aries-mobile-agent-react-native/assets/32586431/d4a2264f-bd5f-4a35-a70b-531dd3826d58">

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
