### PR TITLE
feat: Improved accessibilty for credential cards

### DIFF
--- a/packages/legacy/core/App/components/misc/CredentialCard10.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard10.tsx
@@ -275,8 +275,10 @@ const CredentialCard10: React.FC<CredentialCard10Props> = ({ credential, style =
 
   return (
     <TouchableOpacity
-      accessible={false}
-      accessibilityLabel={typeof onPress === 'undefined' ? undefined : t('Credentials.CredentialDetails')}
+      accessible={true}
+      accessibilityLabel={`${
+        overlay.metaOverlay?.issuerName ? `${t('Credentials.IssuedBy')} ${overlay.metaOverlay?.issuerName}` : ''
+      }, ${overlay.metaOverlay?.watermark ?? ''} ${overlay.metaOverlay?.name ?? ''}`}
       disabled={typeof onPress === 'undefined' ? true : false}
       onPress={onPress}
       style={[styles.container, style]}

--- a/packages/legacy/core/App/components/misc/CredentialCard11.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard11.tsx
@@ -444,7 +444,13 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
 
   const CredentialCard: React.FC<{ status?: CredentialStatus }> = ({ status }) => {
     return (
-      <View style={styles.cardContainer}>
+      <View
+        style={styles.cardContainer}
+        accessible={!proof}
+        accessibilityLabel={`${
+          overlay.metaOverlay?.issuerName ? `${t('Credentials.IssuedBy')} ${overlay.metaOverlay?.issuerName}` : ''
+        }, ${overlay.metaOverlay?.watermark ?? ''} ${overlay.metaOverlay?.name ?? ''}`}
+      >
         <CredentialCardSecondaryBody />
         <CredentialCardLogo />
         <CredentialCardPrimaryBody />

--- a/packages/legacy/core/App/localization/en/index.ts
+++ b/packages/legacy/core/App/localization/en/index.ts
@@ -261,6 +261,8 @@ const translation = {
     "CredentialsNotFound": "Credentials not found",
     "CredentialDetails": "Credential Details",
     "EmptyList": "Your wallet is empty. Your accepted credentials will be added here.",
+    "IssuedBy": "Issued by",
+    "Credential": "credential"
   },
   "CredentialDetails": {
     "Id": "Id:",

--- a/packages/legacy/core/App/localization/fr/index.ts
+++ b/packages/legacy/core/App/localization/fr/index.ts
@@ -260,6 +260,8 @@ const translation = {
         "CredentialsNotFound": "Justificatifs non trouvés",
         "CredentialDetails": "Détails des justificatifs",
         "EmptyList": "Votre portefeuille est vide. Vos justificatifs acceptés seront ajoutés ici.",
+        "IssuedBy": "Issued by (FR)",
+        "Credential": "credential (FR)"
     },
     "CredentialDetails": {
         "Id": "Identifiant :",

--- a/packages/legacy/core/App/localization/pt-br/index.ts
+++ b/packages/legacy/core/App/localization/pt-br/index.ts
@@ -243,6 +243,8 @@ const translation = {
     "CredentialsNotFound": "Credenciais não encontradas",
     "CredentialDetails": "Detalhes da Credencial",
     "EmptyList": "Sua carteira está vazia. Suas credenciais aceitas serão adicionadas aqui.",
+    "IssuedBy": "Issued by (PT-BR)",
+    "Credential": "credential (PT-BR)"
   },
   "CredentialDetails": {
     "Id": "Id:",

--- a/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
@@ -340,6 +340,8 @@ exports[`displays a credential offer screen accepting a credential 1`] = `
                     testID="com.ariesbifold:id/CredentialCard"
                   >
                     <View
+                      accessibilityLabel="Credentials.IssuedBy faber.agent,  Credential"
+                      accessible={true}
                       style={
                         Object {
                           "flexDirection": "row",
@@ -2074,6 +2076,8 @@ exports[`displays a credential offer screen declining a credential 1`] = `
                     testID="com.ariesbifold:id/CredentialCard"
                   >
                     <View
+                      accessibilityLabel="Credentials.IssuedBy faber.agent,  Credential"
+                      accessible={true}
                       style={
                         Object {
                           "flexDirection": "row",
@@ -3810,6 +3814,8 @@ exports[`displays a credential offer screen renders correctly 1`] = `
                     testID="com.ariesbifold:id/CredentialCard"
                   >
                     <View
+                      accessibilityLabel="Credentials.IssuedBy faber.agent,  Credential"
+                      accessible={true}
                       style={
                         Object {
                           "flexDirection": "row",


### PR DESCRIPTION
# Summary of Changes

Previously:
- Difficult to select credentials from list screen
- Screen reader would read repetitive watermark
Changes:
- Made credential cards accessible as a single element in the list screen
- Changed accessibility label to be `Issued by <ISSUER_NAME>, <WATERMARK> <CREDENTIAL_NAME>`


https://github.com/hyperledger/aries-mobile-agent-react-native/assets/36937407/3253c1bd-c999-40e5-a988-d6f85816b07d


# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
