### PR TITLE
feat: improved proof request card accessiblity

### DIFF
--- a/packages/legacy/core/App/components/misc/CardWatermark.tsx
+++ b/packages/legacy/core/App/components/misc/CardWatermark.tsx
@@ -19,7 +19,7 @@ const CardWatermark: React.FC<CardWatermarkProps> = ({ watermark, style, height,
   return (
     <View style={{ position: 'absolute', left: '-50%', top: '-100%', width: '200%', height: '200%' }}>
       {Array.from({ length: Math.ceil((height * 2) / fontSize + 1) }).map((_, i) => (
-        <Text key={i} numberOfLines={1} style={style}>
+        <Text accessible={false} key={i} numberOfLines={1} style={style}>
           {watermarkText}
         </Text>
       ))}

--- a/packages/legacy/core/App/components/misc/CredentialCard10.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard10.tsx
@@ -278,7 +278,7 @@ const CredentialCard10: React.FC<CredentialCard10Props> = ({ credential, style =
       accessible={true}
       accessibilityLabel={`${
         overlay.metaOverlay?.issuerName ? `${t('Credentials.IssuedBy')} ${overlay.metaOverlay?.issuerName}` : ''
-      }, ${overlay.metaOverlay?.watermark ?? ''} ${overlay.metaOverlay?.name ?? ''}`}
+      }, ${overlay.metaOverlay?.watermark ?? ''} ${overlay.metaOverlay?.name ?? ''} ${t('Credentials.Credential')}.`}
       disabled={typeof onPress === 'undefined' ? true : false}
       onPress={onPress}
       style={[styles.container, style]}

--- a/packages/legacy/core/App/components/misc/CredentialCard11.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard11.tsx
@@ -97,6 +97,8 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
     (field) => field.name === overlay?.cardLayoutOverlay?.secondaryAttribute?.name
   )
 
+  const cardData = [...(displayItems ?? []), primaryField, secondaryField]
+
   const getSecondaryBackgroundColor = () => {
     if (proof) {
       return overlay.cardLayoutOverlay?.primaryBackgroundColor
@@ -281,7 +283,12 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
     )
   }
 
+  const parseAttribute = (item: (Attribute & Predicate) | undefined) => {
+    return { label: item?.label ?? startCase(item?.name ?? ''), value: item?.value || `${item?.pType} ${item?.pValue}` }
+  }
+
   const renderCardAttribute = (item: Attribute & Predicate) => {
+    const { label, value } = parseAttribute(item)
     return (
       item && (
         <View style={{ marginTop: 15 }}>
@@ -293,14 +300,12 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
                 color={ListItems.proofError.color}
                 size={ListItems.recordAttributeText.fontSize}
               />
-              <AttributeLabel label={item?.label ?? startCase(item?.name ?? '')} />
+              <AttributeLabel label={label} />
             </View>
           ) : (
-            <AttributeLabel label={item?.label ?? startCase(item?.name ?? '')} />
+            <AttributeLabel label={label} />
           )}
-          {!(item?.value || item?.pValue) ? null : (
-            <AttributeValue value={item?.value || `${item?.pType} ${item?.pValue}`} />
-          )}
+          {!(item?.value || item?.pValue) ? null : <AttributeValue value={value} />}
         </View>
       )
     )
@@ -358,7 +363,7 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
             </View>
           )}
           <FlatList
-            data={[...(displayItems ?? []), primaryField, secondaryField]}
+            data={cardData}
             scrollEnabled={false}
             renderItem={({ item }) => {
               return renderCardAttribute(item as Attribute & Predicate)
@@ -446,10 +451,20 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
     return (
       <View
         style={styles.cardContainer}
-        accessible={!proof}
-        accessibilityLabel={`${
-          overlay.metaOverlay?.issuerName ? `${t('Credentials.IssuedBy')} ${overlay.metaOverlay?.issuerName}` : ''
-        }, ${overlay.metaOverlay?.watermark ?? ''} ${overlay.metaOverlay?.name ?? ''}`}
+        accessible={true}
+        accessibilityLabel={
+          `${
+            overlay.metaOverlay?.issuerName ? `${t('Credentials.IssuedBy')} ${overlay.metaOverlay?.issuerName}` : ''
+          }, ${overlay.metaOverlay?.watermark ?? ''} ${overlay.metaOverlay?.name ?? ''} ${t(
+            'Credentials.Credential'
+          )}.` +
+          cardData.map((item) => {
+            const { label, value } = parseAttribute(item as (Attribute & Predicate) | undefined)
+            if (label && value) {
+              return ` ${label}, ${value}`
+            }
+          })
+        }
       >
         <CredentialCardSecondaryBody />
         <CredentialCardLogo />

--- a/packages/legacy/core/App/navigators/TabStack.tsx
+++ b/packages/legacy/core/App/navigators/TabStack.tsx
@@ -91,8 +91,14 @@ const TabStack: React.FC = () => {
                       alignItems: 'center',
                     }}
                   >
-                    <View style={{ ...TabTheme.focusTabIconStyle }}>
+                    <View
+                      accessible={true}
+                      accessibilityRole={'button'}
+                      accessibilityLabel={t('TabStack.Scan')}
+                      style={{ ...TabTheme.focusTabIconStyle }}
+                    >
                       <Icon
+                        accessible={false}
                         name="qrcode-scan"
                         color={TabTheme.tabBarButtonIconStyle.color}
                         size={32}

--- a/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
@@ -340,7 +340,7 @@ exports[`displays a credential offer screen accepting a credential 1`] = `
                     testID="com.ariesbifold:id/CredentialCard"
                   >
                     <View
-                      accessibilityLabel="Credentials.IssuedBy faber.agent,  Credential"
+                      accessibilityLabel="Credentials.IssuedBy faber.agent,  Credential Credentials.Credential.,"
                       accessible={true}
                       style={
                         Object {
@@ -2086,7 +2086,7 @@ exports[`displays a credential offer screen declining a credential 1`] = `
                     testID="com.ariesbifold:id/CredentialCard"
                   >
                     <View
-                      accessibilityLabel="Credentials.IssuedBy faber.agent,  Credential"
+                      accessibilityLabel="Credentials.IssuedBy faber.agent,  Credential Credentials.Credential.,"
                       accessible={true}
                       style={
                         Object {
@@ -3834,7 +3834,7 @@ exports[`displays a credential offer screen renders correctly 1`] = `
                     testID="com.ariesbifold:id/CredentialCard"
                   >
                     <View
-                      accessibilityLabel="Credentials.IssuedBy faber.agent,  Credential"
+                      accessibilityLabel="Credentials.IssuedBy faber.agent,  Credential Credentials.Credential.,"
                       accessible={true}
                       style={
                         Object {


### PR DESCRIPTION
# Summary of Changes

Previously the proof requests were not accessible, to read what a verifier was requesting a user would have to go through the card element by element. Now upon clicking a proof request card, all of the attribute labels and values are read out


https://github.com/hyperledger/aries-mobile-agent-react-native/assets/36937407/a16cdebf-465d-443e-a3bb-feb2986ec4fc



# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
