### PR TITLE
fix: update a11y label and use proper icon color

### DIFF
--- a/packages/legacy/core/App/components/misc/ConnectionAlert.tsx
+++ b/packages/legacy/core/App/components/misc/ConnectionAlert.tsx
@@ -82,7 +82,7 @@ const ConnectionAlert: React.FC<ConnectionAlertProps> = ({ connectionID }) => {
         <Text style={styles.notifyTitle}>{t('ConnectionAlert.AddedContacts')}</Text>
         <TouchableOpacity
           testID={t('Global.Info')}
-          accessibilityLabel={t('Global.Info')}
+          accessibilityLabel={t('ConnectionAlert.WhatAreContacts')}
           accessibilityRole={'button'}
           onPress={toggleInfoCard}
           hitSlop={hitSlop}

--- a/packages/legacy/core/App/components/misc/ConnectionAlert.tsx
+++ b/packages/legacy/core/App/components/misc/ConnectionAlert.tsx
@@ -64,7 +64,7 @@ const ConnectionAlert: React.FC<ConnectionAlertProps> = ({ connectionID }) => {
       marginVertical: 6,
     },
     informationIcon: {
-      color: ColorPallet.brand.icon,
+      color: ColorPallet.notification.infoIcon,
       marginLeft: 10,
     },
   })

--- a/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
@@ -1029,7 +1029,7 @@ exports[`displays a credential offer screen accepting a credential 1`] = `
                   ConnectionAlert.AddedContacts
                 </Text>
                 <View
-                  accessibilityLabel="Global.Info"
+                  accessibilityLabel="ConnectionAlert.WhatAreContacts"
                   accessibilityRole="button"
                   accessible={true}
                   focusable={true}
@@ -2775,7 +2775,7 @@ exports[`displays a credential offer screen declining a credential 1`] = `
                   ConnectionAlert.AddedContacts
                 </Text>
                 <View
-                  accessibilityLabel="Global.Info"
+                  accessibilityLabel="ConnectionAlert.WhatAreContacts"
                   accessibilityRole="button"
                   accessible={true}
                   focusable={true}
@@ -4523,7 +4523,7 @@ exports[`displays a credential offer screen renders correctly 1`] = `
                   ConnectionAlert.AddedContacts
                 </Text>
                 <View
-                  accessibilityLabel="Global.Info"
+                  accessibilityLabel="ConnectionAlert.WhatAreContacts"
                   accessibilityRole="button"
                   accessible={true}
                   focusable={true}

--- a/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
@@ -1064,7 +1064,7 @@ exports[`displays a credential offer screen accepting a credential 1`] = `
                           "fontSize": 30,
                         },
                         Object {
-                          "color": "#FFFFFF",
+                          "color": "#0099FF",
                           "marginLeft": 10,
                         },
                         Object {
@@ -2810,7 +2810,7 @@ exports[`displays a credential offer screen declining a credential 1`] = `
                           "fontSize": 30,
                         },
                         Object {
-                          "color": "#FFFFFF",
+                          "color": "#0099FF",
                           "marginLeft": 10,
                         },
                         Object {
@@ -4558,7 +4558,7 @@ exports[`displays a credential offer screen renders correctly 1`] = `
                           "fontSize": 30,
                         },
                         Object {
-                          "color": "#FFFFFF",
+                          "color": "#0099FF",
                           "marginLeft": 10,
                         },
                         Object {


### PR DESCRIPTION
# Summary of Changes

The info icon on the connection alert wasn't using the proper infoIcon color and so wasn't showing up. It was also using the wrong accessibilityLabel.

Before (black outline coming from VoiceOver):
![IMG_0032](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/32586431/0fec702d-d4e8-4b51-bd88-a446cf19f010)

After (black outline coming from VoiceOver):
![IMG_0035](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/32586431/6d9cbfd0-7bab-45c4-a325-79bab1b02ad9)

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
