### PR TITLE
fix: no screen read settings icons

### DIFF
--- a/packages/legacy/core/App/components/listItems/NotificationListItem.tsx
+++ b/packages/legacy/core/App/components/listItems/NotificationListItem.tsx
@@ -354,7 +354,7 @@ const NotificationListItem: React.FC<NotificationListItemProps> = ({ notificatio
     <View style={[styles.container, styleConfig.containerStyle]} testID={testIdWithKey('NotificationListItem')}>
       <View style={styles.headerContainer}>
         <View style={styles.icon}>
-          <Icon name={styleConfig.iconName} size={iconSize} color={styleConfig.iconColor} />
+          <Icon accessible={false} name={styleConfig.iconName} size={iconSize} color={styleConfig.iconColor} />
         </View>
         <Text style={[styles.headerText, styleConfig.textStyle]} testID={testIdWithKey('HeaderText')}>
           {details.title}

--- a/packages/legacy/core/App/components/misc/InfoBox.tsx
+++ b/packages/legacy/core/App/components/misc/InfoBox.tsx
@@ -173,7 +173,7 @@ const InfoBox: React.FC<BifoldErrorProps> = ({
     <View style={styles.container}>
       <View style={styles.headerContainer}>
         <View style={[styles.icon]}>
-          <Icon name={iconName} size={iconSize} color={iconColor} />
+          <Icon accessible={false} name={iconName} size={iconSize} color={iconColor} />
         </View>
         <Text style={styles.headerText} testID={testIdWithKey('HeaderText')}>
           {title}

--- a/packages/legacy/core/App/screens/Settings.tsx
+++ b/packages/legacy/core/App/screens/Settings.tsx
@@ -224,8 +224,10 @@ const Settings: React.FC<SettingsProps> = ({ navigation }) => {
 
   const SectionHeader: React.FC<{ icon: string; title: string }> = ({ icon, title }) => (
     <View style={[styles.section, styles.sectionHeader]}>
-      <Icon name={icon} size={24} style={{ marginRight: 10, color: SettingsTheme.iconColor }} />
-      <Text style={[TextTheme.headingThree, { flexShrink: 1 }]}>{title}</Text>
+      <Icon accessible={false} name={icon} size={24} style={{ marginRight: 10, color: SettingsTheme.iconColor }} />
+      <Text accessibilityRole={'header'} style={[TextTheme.headingThree, { flexShrink: 1 }]}>
+        {title}
+      </Text>
     </View>
   )
 

--- a/packages/legacy/core/__tests__/components/__snapshots__/ErrorModal.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/ErrorModal.test.tsx.snap
@@ -51,6 +51,7 @@ exports[`ErrorModal Component Dismiss on demand 1`] = `
           }
         >
           <Text
+            accessible={false}
             allowFontScaling={false}
             style={
               Array [
@@ -224,6 +225,7 @@ exports[`ErrorModal Component Renders correctly 1`] = `
           }
         >
           <Text
+            accessible={false}
             allowFontScaling={false}
             style={
               Array [

--- a/packages/legacy/core/__tests__/components/__snapshots__/InfoBox.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/InfoBox.test.tsx.snap
@@ -33,6 +33,7 @@ exports[`ErrorModal Component Renders correctly as Error 1`] = `
       }
     >
       <Text
+        accessible={false}
         allowFontScaling={false}
         style={
           Array [
@@ -242,6 +243,7 @@ exports[`ErrorModal Component Renders correctly as Info 1`] = `
       }
     >
       <Text
+        accessible={false}
         allowFontScaling={false}
         style={
           Array [
@@ -451,6 +453,7 @@ exports[`ErrorModal Component Renders correctly as Success 1`] = `
       }
     >
       <Text
+        accessible={false}
         allowFontScaling={false}
         style={
           Array [
@@ -660,6 +663,7 @@ exports[`ErrorModal Component Renders correctly as Warning 1`] = `
       }
     >
       <Text
+        accessible={false}
         allowFontScaling={false}
         style={
           Array [


### PR DESCRIPTION
# Summary of Changes

Disable accessibility on the menu header icons in Settings and add accessibility role to better indicate what is being read.

# Related Issues

Fixed bcgov/bc-wallet-mobile#1094, bcgov/bc-wallet-mobile#1139


# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
