### PR TITLE
feat: non oca photo attribute

### DIFF
--- a/packages/legacy/core/App/components/record/RecordField.tsx
+++ b/packages/legacy/core/App/components/record/RecordField.tsx
@@ -31,6 +31,10 @@ interface AttributeValueParams {
   style?: Record<string, unknown>
 }
 
+const isDataUrl = (value: string | number | null) => {
+  return typeof value === 'string' && value.startsWith('data:image/')
+}
+
 export const AttributeValue: React.FC<AttributeValueParams> = ({ field, style, shown }) => {
   const { ListItems } = useTheme()
   const styles = StyleSheet.create({
@@ -38,8 +42,7 @@ export const AttributeValue: React.FC<AttributeValueParams> = ({ field, style, s
       ...ListItems.recordAttributeText,
     },
   })
-
-  if (field.encoding == validEncoding && field.format && validFormat.test(field.format)) {
+  if ((field.encoding == validEncoding && field.format && validFormat.test(field.format)) || isDataUrl(field.value)) {
     return <RecordBinaryField attributeValue={field.value as string} style={style} shown={shown} />
   }
   if (field.type == BaseType.DateInt) {


### PR DESCRIPTION
# Summary of Changes

Previously we would rely on OCA to mark an attribute as a photo attribute. I've added functionality to look for data urls and display them as a photo attribute if they start with `data:image/`

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
