### PR TITLE
fix: use common remove for with-credentials

### DIFF
--- a/packages/legacy/core/App/components/modals/CommonRemoveModal.tsx
+++ b/packages/legacy/core/App/components/modals/CommonRemoveModal.tsx
@@ -133,6 +133,10 @@ const CommonRemoveModal: React.FC<CommonRemoveModalProps> = ({ usage, visible, o
       return t('ContactDetails.RemoveContact')
     }
 
+    if (usage === ModalUsage.ContactRemoveWithCredentials) {
+      return t('ContactDetails.GoToCredentials')
+    }
+
     if (usage === ModalUsage.CredentialRemove) {
       return t('CredentialDetails.RemoveFromWallet')
     }
@@ -145,6 +149,10 @@ const CommonRemoveModal: React.FC<CommonRemoveModalProps> = ({ usage, visible, o
       return t('ContactDetails.RemoveContact')
     }
 
+    if (usage === ModalUsage.ContactRemoveWithCredentials) {
+      return t('ContactDetails.GoToCredentials')
+    }
+
     if (usage === ModalUsage.CredentialRemove) {
       return t('CredentialDetails.RemoveCredential')
     }
@@ -153,6 +161,10 @@ const CommonRemoveModal: React.FC<CommonRemoveModalProps> = ({ usage, visible, o
   }
 
   const testIdForConformationButton = (): string => {
+    if (usage === ModalUsage.ContactRemoveWithCredentials) {
+      return testIdWithKey('GoToCredentialsButton')
+    }
+
     if (usage === ModalUsage.ContactRemove || usage === ModalUsage.CredentialRemove) {
       return testIdWithKey('ConfirmRemoveButton')
     }
@@ -167,6 +179,10 @@ const CommonRemoveModal: React.FC<CommonRemoveModalProps> = ({ usage, visible, o
   const testIdForCancelButton = (): string => {
     if (usage === ModalUsage.ContactRemove || usage === ModalUsage.CredentialRemove) {
       return testIdWithKey('CancelRemoveButton')
+    }
+
+    if (usage === ModalUsage.ContactRemoveWithCredentials) {
+      return testIdWithKey('AbortGoToCredentialsButton')
     }
 
     if (usage === ModalUsage.CredentialOfferDecline || usage === ModalUsage.ProofRequestDecline) {
@@ -265,6 +281,19 @@ const CommonRemoveModal: React.FC<CommonRemoveModalProps> = ({ usage, visible, o
       )
     }
 
+    if (type === ModalUsage.ContactRemoveWithCredentials) {
+      return (
+        <View style={[{ marginBottom: 25 }]}>
+          <View style={[{ marginBottom: 25 }]}>
+            <Text style={[TextTheme.modalTitle]}>{t('ContactDetails.UnableToRemoveTitle')}</Text>
+          </View>
+          <View>
+            <Text style={[styles.bodyText]}>{t('ContactDetails.UnableToRemoveCaption')}</Text>
+          </View>
+        </View>
+      )
+    }
+
     return null
   }
 
@@ -301,7 +330,9 @@ const CommonRemoveModal: React.FC<CommonRemoveModalProps> = ({ usage, visible, o
               accessibilityLabel={titleForAccessibilityLabel()}
               testID={testIdForConformationButton()}
               onPress={onSubmit}
-              buttonType={ButtonType.ModalCritical}
+              buttonType={
+                usage === ModalUsage.ContactRemoveWithCredentials ? ButtonType.ModalPrimary : ButtonType.ModalCritical
+              }
             />
           </View>
           <View style={[{ paddingTop: 10 }]}>

--- a/packages/legacy/core/App/screens/ContactDetails.tsx
+++ b/packages/legacy/core/App/screens/ContactDetails.tsx
@@ -4,24 +4,20 @@ import { useNavigation } from '@react-navigation/core'
 import { StackNavigationProp, StackScreenProps } from '@react-navigation/stack'
 import React, { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { DeviceEventEmitter, Modal, Platform, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { DeviceEventEmitter } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Toast from 'react-native-toast-message'
 
-import Button, { ButtonType } from '../components/buttons/Button'
 import CommonRemoveModal from '../components/modals/CommonRemoveModal'
 import RecordRemove from '../components/record/RecordRemove'
 import { ToastType } from '../components/toast/BaseToast'
-import FauxNavigationBar from '../components/views/FauxNavigationBar'
 import { EventTypes } from '../constants'
 import { useConfiguration } from '../contexts/configuration'
-import { useTheme } from '../contexts/theme'
 import { BifoldError } from '../types/error'
 import { ContactStackParams, Screens, TabStacks } from '../types/navigators'
 import { Attribute } from '../types/record'
 import { ModalUsage } from '../types/remove'
 import { formatTime } from '../utils/helpers'
-import { testIdWithKey } from '../utils/testable'
 
 type ContactDetailsProps = StackScreenProps<ContactStackParams, Screens.ContactDetails>
 
@@ -39,23 +35,13 @@ const ContactDetails: React.FC<ContactDetailsProps> = ({ route }) => {
     ...useCredentialByState(CredentialState.Done),
   ].filter((credential) => credential.connectionId === connection?.id)
   const { record } = useConfiguration()
-  const { ColorPallet, TextTheme } = useTheme()
-
-  const styles = StyleSheet.create({
-    container: {
-      height: '100%',
-      backgroundColor: ColorPallet.brand.modalPrimaryBackground,
-      padding: 20,
-    },
-    controlsContainer: {
-      marginTop: 'auto',
-      marginHorizontal: 20,
-      marginBottom: Platform.OS === 'ios' ? 108 : 20,
-    },
-  })
 
   const handleOnRemove = () => {
-    setIsRemoveModalDisplayed(true)
+    if (connectionCredentials?.length) {
+      setIsCredentialsRemoveModalDisplayed(true)
+    } else {
+      setIsRemoveModalDisplayed(true)
+    }
   }
 
   const handleSubmitRemove = async () => {
@@ -64,16 +50,12 @@ const ContactDetails: React.FC<ContactDetailsProps> = ({ route }) => {
         return
       }
 
-      if (connectionCredentials?.length) {
-        setIsCredentialsRemoveModalDisplayed(true)
-      } else {
-        await agent.connections.deleteById(connection.id)
-        Toast.show({
-          type: ToastType.Success,
-          text1: t('ContactDetails.ContactRemoved'),
-        })
-        navigation.navigate(Screens.Contacts)
-      }
+      await agent.connections.deleteById(connection.id)
+      Toast.show({
+        type: ToastType.Success,
+        text1: t('ContactDetails.ContactRemoved'),
+      })
+      navigation.navigate(Screens.Contacts)
     } catch (err: unknown) {
       const error = new BifoldError(t('Error.Title1037'), t('Error.Message1037'), (err as Error).message, 1025)
 
@@ -99,49 +81,6 @@ const ContactDetails: React.FC<ContactDetailsProps> = ({ route }) => {
   const callGoToCredentials = useCallback(() => handleGoToCredentials(), [])
   const callCancelUnableToRemove = useCallback(() => handleCancelUnableRemove(), [])
 
-  const CredentialsRemoveModal = ({ visible = false }) => {
-    return (
-      <Modal visible={visible} animationType={'slide'}>
-        <FauxNavigationBar title={t('CredentialDetails.RemoveFromWallet')} />
-        <SafeAreaView
-          edges={['left', 'right', 'bottom']}
-          style={{ backgroundColor: ColorPallet.brand.modalPrimaryBackground }}
-        >
-          <ScrollView style={[styles.container]}>
-            <View>
-              <View style={[{ marginBottom: 25 }]}>
-                <Text style={[TextTheme.modalTitle]}>{t('ContactDetails.UnableToRemoveTitle')}</Text>
-              </View>
-              <View>
-                <Text style={[TextTheme.modalNormal]}>{t('ContactDetails.UnableToRemoveCaption')}</Text>
-              </View>
-            </View>
-          </ScrollView>
-          <View style={[styles.controlsContainer]}>
-            <View style={[{ paddingTop: 10 }]}>
-              <Button
-                title={t('ContactDetails.GoToCredentials')}
-                accessibilityLabel={t('ContactDetails.GoToCredentials')}
-                testID={testIdWithKey('GoToCredentialsButton')}
-                onPress={callGoToCredentials}
-                buttonType={ButtonType.ModalPrimary}
-              />
-            </View>
-            <View style={[{ paddingTop: 10 }]}>
-              <Button
-                title={t('Global.Cancel')}
-                accessibilityLabel={t('Global.Cancel')}
-                testID={testIdWithKey('AbortGoToCredentialsButton')}
-                onPress={callCancelUnableToRemove}
-                buttonType={ButtonType.ModalSecondary}
-              />
-            </View>
-          </View>
-        </SafeAreaView>
-      </Modal>
-    )
-  }
-
   return (
     <SafeAreaView style={{ flexGrow: 1 }} edges={['bottom', 'left', 'right']}>
       {record({
@@ -161,7 +100,12 @@ const ContactDetails: React.FC<ContactDetailsProps> = ({ route }) => {
         onSubmit={callSubmitRemove}
         onCancel={callCancelRemove}
       />
-      <CredentialsRemoveModal visible={isCredentialsRemoveModalDisplayed} />
+      <CommonRemoveModal
+        usage={ModalUsage.ContactRemoveWithCredentials}
+        visible={isCredentialsRemoveModalDisplayed}
+        onSubmit={callGoToCredentials}
+        onCancel={callCancelUnableToRemove}
+      />
     </SafeAreaView>
   )
 }

--- a/packages/legacy/core/App/types/remove.ts
+++ b/packages/legacy/core/App/types/remove.ts
@@ -1,6 +1,7 @@
 export enum ModalUsage {
   CredentialRemove = 1,
   ContactRemove,
+  ContactRemoveWithCredentials,
   CredentialOfferDecline,
   ProofRequestDecline,
   CustomNotificationDecline,

--- a/packages/legacy/core/__tests__/components/CommonRemoveModal.test.tsx
+++ b/packages/legacy/core/__tests__/components/CommonRemoveModal.test.tsx
@@ -35,6 +35,12 @@ describe('CommonRemoveModal Component', () => {
     expect(tree).toMatchSnapshot()
   })
 
+  test('Remove contact renders correctly', async () => {
+    const tree = render(<CommonRemoveModal visible={true} usage={ModalUsage.ContactRemoveWithCredentials} />)
+
+    expect(tree).toMatchSnapshot()
+  })
+
   test('Remove credential renders correctly', async () => {
     const tree = render(<CommonRemoveModal visible={true} usage={ModalUsage.CredentialRemove} />)
 

--- a/packages/legacy/core/__tests__/components/__snapshots__/CommonRemoveModal.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/CommonRemoveModal.test.tsx.snap
@@ -1853,6 +1853,395 @@ exports[`CommonRemoveModal Component Remove contact renders correctly 1`] = `
 </Modal>
 `;
 
+exports[`CommonRemoveModal Component Remove contact renders correctly 2`] = `
+<Modal
+  animationType="slide"
+  hardwareAccelerated={false}
+  transparent={true}
+  visible={true}
+>
+  <View
+    style={
+      Array [
+        Object {
+          "alignItems": "flex-end",
+          "backgroundColor": "#000000",
+          "borderTopLeftRadius": 10,
+          "borderTopRightRadius": 10,
+          "height": 55,
+          "marginTop": 65,
+          "paddingRight": 20,
+          "paddingTop": 10,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityLabel="Global.Close"
+      accessibilityRole="button"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 44,
+          "left": 44,
+          "right": 44,
+          "top": 44,
+        }
+      }
+      nativeID="animatedComponent"
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "opacity": 1,
+        }
+      }
+      testID="com.ariesbifold:id/Close"
+    >
+      <Text
+        allowFontScaling={false}
+        style={
+          Array [
+            Object {
+              "color": "#FFFFFF",
+              "fontSize": 42,
+            },
+            undefined,
+            Object {
+              "fontFamily": "Material Icons",
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {},
+          ]
+        }
+      >
+        
+      </Text>
+    </View>
+  </View>
+  <RNCSafeAreaView
+    edges={
+      Array [
+        "left",
+        "right",
+        "bottom",
+      ]
+    }
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#000000",
+        },
+      ]
+    }
+  >
+    <RCTScrollView
+      style={
+        Array [
+          Object {
+            "backgroundColor": "#000000",
+            "height": "100%",
+            "padding": 20,
+          },
+        ]
+      }
+    >
+      <View>
+        <View
+          style={
+            Object {
+              "flexDirection": "row",
+              "justifyContent": "center",
+            }
+          }
+        />
+        <View
+          style={
+            Array [
+              Object {
+                "marginBottom": 25,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "marginBottom": 25,
+                },
+              ]
+            }
+          >
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 24,
+                    "fontWeight": "bold",
+                  },
+                ]
+              }
+            >
+              ContactDetails.UnableToRemoveTitle
+            </Text>
+          </View>
+          <View>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "normal",
+                  },
+                ]
+              }
+            >
+              ContactDetails.UnableToRemoveCaption
+            </Text>
+          </View>
+        </View>
+      </View>
+    </RCTScrollView>
+    <View
+      style={
+        Array [
+          Object {
+            "marginBottom": 108,
+            "marginHorizontal": 20,
+            "marginTop": "auto",
+            "position": "relative",
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Object {
+            "height": 30,
+            "position": "absolute",
+            "top": -30,
+            "width": "100%",
+          }
+        }
+      >
+        <RNSVGSvgView
+          bbHeight="30"
+          bbWidth="100%"
+          focusable={false}
+          height="30"
+          style={
+            Array [
+              Object {
+                "backgroundColor": "transparent",
+                "borderWidth": 0,
+              },
+              Object {
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              Object {
+                "flex": 0,
+                "height": 30,
+                "width": "100%",
+              },
+            ]
+          }
+          width="100%"
+        >
+          <RNSVGGroup>
+            <RNSVGDefs>
+              <RNSVGLinearGradient
+                gradient={
+                  Array [
+                    0,
+                    0,
+                    1,
+                    -16777216,
+                  ]
+                }
+                gradientTransform={null}
+                gradientUnits={0}
+                name="gradient"
+                x1="0%"
+                x2="0%"
+                y1="0%"
+                y2="100%"
+              />
+            </RNSVGDefs>
+            <RNSVGRect
+              fill={
+                Array [
+                  1,
+                  "gradient",
+                ]
+              }
+              height="30"
+              propList={
+                Array [
+                  "fill",
+                ]
+              }
+              width="100%"
+              x={0}
+              y={0}
+            />
+          </RNSVGGroup>
+        </RNSVGSvgView>
+      </View>
+      <View
+        style={
+          Array [
+            Object {
+              "paddingTop": 10,
+            },
+          ]
+        }
+      >
+        <View
+          accessibilityLabel="ContactDetails.GoToCredentials"
+          accessibilityRole="button"
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={false}
+          nativeID="animatedComponent"
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "backgroundColor": "#42803E",
+              "borderRadius": 4,
+              "opacity": 1,
+              "padding": 16,
+            }
+          }
+          testID="com.ariesbifold:id/GoToCredentialsButton"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                    "textAlign": "center",
+                  },
+                  false,
+                  false,
+                  false,
+                ]
+              }
+            >
+              ContactDetails.GoToCredentials
+            </Text>
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          Array [
+            Object {
+              "paddingTop": 10,
+            },
+          ]
+        }
+      >
+        <View
+          accessibilityLabel="Global.Cancel"
+          accessibilityRole="button"
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={false}
+          nativeID="animatedComponent"
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "borderColor": "#42803E",
+              "borderRadius": 4,
+              "borderWidth": 2,
+              "opacity": 1,
+              "padding": 16,
+            }
+          }
+          testID="com.ariesbifold:id/AbortGoToCredentialsButton"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#42803E",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                    "textAlign": "center",
+                  },
+                  false,
+                  false,
+                  false,
+                ]
+              }
+            >
+              Global.Cancel
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </RNCSafeAreaView>
+</Modal>
+`;
+
 exports[`CommonRemoveModal Component Remove credential renders correctly 1`] = `
 <Modal
   animationType="slide"


### PR DESCRIPTION
# Summary of Changes

Previously if a user tried to delete a contact that had credentials in their wallet, it would show the regular remove modal and then only if they attempted to fully delete it, would they see the modal for not being able to delete a contact (and only after they dismissed the first modal.) I refactored the separate modals into just the one `CommonRemoveModal` and adjusted the logic so that they display appropriately. Also added test for the updated `CommonRemoveModal` option.

Here's what the contact remove flow looks like now:
![remove_contact_with_credentials](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/32586431/ac024072-9bd2-45a8-b420-98eb3a1d1df3)


# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
