### PR TITLE
fix: handled startCase() issue on some cred names

### DIFF
--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -12,7 +12,6 @@ import {
   GetFormatDataReturn,
 } from '@aries-framework/core/build/modules/proofs/models/ProofServiceOptions'
 import { useAgent, useConnectionById, useProofById, useCredentials } from '@aries-framework/react-hooks'
-import startCase from 'lodash.startcase'
 import React, { useState, useMemo, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { View, StyleSheet, Text, DeviceEventEmitter, FlatList } from 'react-native'
@@ -32,7 +31,6 @@ import { BifoldError } from '../types/error'
 import { NotificationStackParams, Screens } from '../types/navigators'
 import { ProofCredentialItems } from '../types/record'
 import { ModalUsage } from '../types/remove'
-import { parseCredDefFromId } from '../utils/cred-def'
 import { mergeAttributesAndPredicates, processProofAttributes, processProofPredicates } from '../utils/helpers'
 import { testIdWithKey } from '../utils/testable'
 
@@ -204,19 +202,17 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
 
   const toggleDeclineModalVisible = () => setDeclineModalVisible(!declineModalVisible)
 
-  const hasAvailableCredentials = (credName?: string): boolean => {
+  const hasAvailableCredentials = (credDefId?: string): boolean => {
     const fields: Fields = {
       ...retrievedCredentials?.requestedAttributes,
       ...retrievedCredentials?.requestedPredicates,
     }
 
-    if (credName) {
+    if (credDefId) {
       let credFound = false
       Object.keys(fields).forEach((proofKey) => {
-        const credNamesInAttrs = fields[proofKey].map((attr) =>
-          parseCredDefFromId(attr.credentialInfo?.credentialDefinitionId, attr.credentialInfo?.schemaId)
-        )
-        if (credNamesInAttrs.includes(startCase(credName)) || credNamesInAttrs.includes(credName)) {
+        const credDefsInAttrs = fields[proofKey].map((attr) => attr.credentialInfo?.credentialDefinitionId)
+        if (credDefsInAttrs.includes(credDefId)) {
           credFound = true
           return
         }
@@ -344,7 +340,6 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
       </View>
     )
   }
-
   return (
     <SafeAreaView style={styles.pageContainer} edges={['bottom', 'left', 'right']}>
       <View style={styles.pageContent}>
@@ -361,7 +356,7 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
                   schemaId={item.schemaId}
                   displayItems={[...(item.attributes ?? []), ...(item.predicates ?? [])]}
                   credName={item.credName}
-                  existsInWallet={hasAvailableCredentials(item.credName)}
+                  existsInWallet={hasAvailableCredentials(item.credDefId)}
                   proof
                 ></CredentialCard>
               </View>

--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -216,7 +216,7 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
         const credNamesInAttrs = fields[proofKey].map((attr) =>
           parseCredDefFromId(attr.credentialInfo?.credentialDefinitionId, attr.credentialInfo?.schemaId)
         )
-        if (credNamesInAttrs.includes(startCase(credName))) {
+        if (credNamesInAttrs.includes(startCase(credName)) || credNamesInAttrs.includes(credName)) {
           credFound = true
           return
         }


### PR DESCRIPTION
# Summary of Changes

Previously the wallet would show error branding on the credential `Demo (For Demo)` this is because the wallet performs a check to see if the requested credential exists in the wallet. It casts the credential name to `Start Case`: eg. `hello_world` => `Hello World`. In IOS the start case of `Demo (For Demo)` is `Demo For Demo` with the brackets removed so the wallet branding thinks it doesn't exist in the wallet. I've changed the logic to check for start case or plain text, this resolves the issue. 

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
