### PR TITLE
fix: fixed rev notification dismiss on cred details screen

### DIFF
--- a/packages/legacy/core/App/screens/CredentialDetails.tsx
+++ b/packages/legacy/core/App/screens/CredentialDetails.tsx
@@ -18,7 +18,7 @@ import { EventTypes } from '../constants'
 import { useConfiguration } from '../contexts/configuration'
 import { useTheme } from '../contexts/theme'
 import { BifoldError } from '../types/error'
-import { CredentialMetadata } from '../types/metadata'
+import { CredentialMetadata, customMetadata } from '../types/metadata'
 import { CredentialStackParams, Screens } from '../types/navigators'
 import { CardLayoutOverlay11, CardOverlayType, CredentialOverlay } from '../types/oca'
 import { ModalUsage } from '../types/remove'
@@ -52,7 +52,9 @@ const CredentialDetails: React.FC<CredentialDetailsProps> = ({ navigation, route
   const [revocationDate, setRevocationDate] = useState<string>('')
   const [preciseRevocationDate, setPreciseRevocationDate] = useState<string>('')
   const [isRemoveModalDisplayed, setIsRemoveModalDisplayed] = useState<boolean>(false)
-  const [isRevokedMessageHidden, setIsRevokedMessageHidden] = useState<boolean>(false)
+  const [isRevokedMessageHidden, setIsRevokedMessageHidden] = useState<boolean>(
+    (credential!.metadata.get(CredentialMetadata.customMetadata) as customMetadata)?.revoked_detail_dismissed ?? false
+  )
 
   const [overlay, setOverlay] = useState<CredentialOverlay<CardLayoutOverlay11>>({
     bundle: undefined,
@@ -150,7 +152,8 @@ const CredentialDetails: React.FC<CredentialDetailsProps> = ({ navigation, route
 
   useEffect(() => {
     if (credential?.revocationNotification) {
-      credential.metadata.set(CredentialMetadata.customMetadata, { revoked_seen: true })
+      const meta = credential!.metadata.get(CredentialMetadata.customMetadata)
+      credential.metadata.set(CredentialMetadata.customMetadata, { ...meta, revoked_seen: true })
       agent?.credentials.update(credential)
     }
   }, [isRevoked])
@@ -186,6 +189,9 @@ const CredentialDetails: React.FC<CredentialDetailsProps> = ({ navigation, route
 
   const handleDismissRevokedMessage = () => {
     setIsRevokedMessageHidden(true)
+    const meta = credential!.metadata.get(CredentialMetadata.customMetadata)
+    credential.metadata.set(CredentialMetadata.customMetadata, { ...meta, revoked_detail_dismissed: true })
+    agent?.credentials.update(credential)
   }
 
   const callOnRemove = useCallback(() => handleOnRemove(), [])

--- a/packages/legacy/core/App/types/metadata.ts
+++ b/packages/legacy/core/App/types/metadata.ts
@@ -4,4 +4,5 @@ export enum CredentialMetadata {
 
 export interface customMetadata {
   revoked_seen?: boolean
+  revoked_detail_dismissed?: boolean
 }


### PR DESCRIPTION
# Summary of Changes

Previously in the credential detail screen, if a credential was revoked, the dismiss modal would show up whenever a user opened the credential detail screen. I added custom meta data to track if the credential detail revocation notification has already been dismissed. That way it will not show up the next time the user goes to the credential detail screen. The metadata is also stored in the wallet so the state is saved across reboots. 

https://github.com/hyperledger/aries-mobile-agent-react-native/assets/36937407/33512824-3216-4a91-a316-2c0ba27fcd1d


# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
