### PR TITLE
fix: make onboarding more a11y friendly

### DIFF
--- a/packages/legacy/core/App/localization/en/index.ts
+++ b/packages/legacy/core/App/localization/en/index.ts
@@ -498,6 +498,9 @@ const translation = {
     "LedgerConnectivityIssueTitle": "Wallet Services",
     "LedgerConnectivityIssueMessage": "A firewall may be preventing you from connecting to wallet related services.",
   },
+  "Onboarding": {
+    "SkipA11y": "Skip introduction to Aries Bifold",
+  },
   "Chat": {
     "OpenItem": "Open",
     "UserYou": "You",

--- a/packages/legacy/core/App/localization/fr/index.ts
+++ b/packages/legacy/core/App/localization/fr/index.ts
@@ -488,6 +488,9 @@ const translation = {
         "LedgerConnectivityIssueTitle": "Services de portefeuille",
         "LedgerConnectivityIssueMessage": "Il se peut qu'un pare-feu vous empêche de vous connecter aux services liés au portefeuille.",
     },
+    "Onboarding": {
+        "SkipA11y": "Skip introduction to Aries Bifold (FR)",
+    },
     "Chat": {
         "OpenItem": "Ouvrir",
         "UserYou": "Vous avez",

--- a/packages/legacy/core/App/localization/pt-br/index.ts
+++ b/packages/legacy/core/App/localization/pt-br/index.ts
@@ -463,6 +463,9 @@ const translation = {
     "LedgerConnectivityIssueTitle": "Serviços de Carteira",
     "LedgerConnectivityIssueMessage": "Um firewall pode estar te impedindo de conectar-se a serviços relacionados a carteira.",
   },
+  "Onboarding": {
+    "SkipA11y": "Skip introduction to Aries Bifold (PT-BR)",
+  },
   "Chat": {
     "OpenItem": "Abrir",
     "UserYou": "Você",

--- a/packages/legacy/core/App/screens/Onboarding.tsx
+++ b/packages/legacy/core/App/screens/Onboarding.tsx
@@ -12,7 +12,6 @@ import { DispatchAction } from '../contexts/reducers/store'
 import { useStore } from '../contexts/store'
 import { AuthenticateStackParams, Screens } from '../types/navigators'
 import { testIdWithKey } from '../utils/testable'
-// import HeaderRight from 'components/buttons/HeaderRightSkip'
 
 const { width } = Dimensions.get('window')
 
@@ -106,11 +105,11 @@ const Onboarding: React.FC<OnboardingProps> = ({
         headerRight: () => (
           <HeaderButton
             buttonLocation={ButtonLocation.Right}
-            accessibilityLabel={t('Tour.Skip')}
+            accessibilityLabel={t('Onboarding.SkipA11y')}
             testID={testIdWithKey('Skip')}
             onPress={onSkipTouched}
             icon="chevron-right"
-            text={t('Tour.Skip')}
+            text={t('Global.Skip')}
           />
         ),
       })


### PR DESCRIPTION
# Summary of Changes

This PR makes it clear to screen reader users that the skip button on the onboarding screen skips the introduction to the app.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
