### PR TITLE
fix: make whatarecontacts scrollable, add test

### DIFF
--- a/packages/legacy/core/App/screens/WhatAreContacts.tsx
+++ b/packages/legacy/core/App/screens/WhatAreContacts.tsx
@@ -1,7 +1,7 @@
 import { NavigationProp, ParamListBase } from '@react-navigation/native'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { FlatList, SafeAreaView, StyleSheet, Text, View } from 'react-native'
+import { SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native'
 
 import { useTheme } from '../contexts/theme'
 import { Screens, Stacks } from '../types/navigators'
@@ -25,7 +25,8 @@ const WhatAreContacts: React.FC<WhatAreContactsProps> = ({ navigation }) => {
     },
     pageContent: {
       marginTop: 30,
-      marginHorizontal: 15,
+      paddingLeft: 25,
+      paddingRight: 25,
     },
     fakeLink: {
       color: ColorPallet.brand.link,
@@ -39,37 +40,38 @@ const WhatAreContacts: React.FC<WhatAreContactsProps> = ({ navigation }) => {
       ?.navigate(Stacks.ContactStack, { screen: Screens.Contacts, params: { navigation: navigation } })
   }
 
+  const bulletPoints = [
+    t('WhatAreContacts.ListItemDirectMessage'),
+    t('WhatAreContacts.ListItemNewCredentials'),
+    t('WhatAreContacts.ListItemNotifiedOfUpdates'),
+    t('WhatAreContacts.ListItemRequest'),
+  ].map((text, index) => {
+    return (
+      <View key={index} style={{ marginBottom: 10, flexDirection: 'row' }}>
+        <Text style={{ ...TextTheme.normal, paddingRight: 5 }}>{'\u2022'}</Text>
+        <Text style={[TextTheme.normal, { flexShrink: 1 }]}>{text}</Text>
+      </View>
+    )
+  })
+
   return (
     <SafeAreaView style={styles.container}>
-      <View style={styles.pageContent}>
+      <ScrollView
+        contentContainerStyle={styles.pageContent}
+        directionalLockEnabled
+        automaticallyAdjustContentInsets={false}
+        showsHorizontalScrollIndicator={false}
+      >
         <Text style={styles.title}>{t('WhatAreContacts.Title')}</Text>
         <Text style={TextTheme.normal}>{t('WhatAreContacts.Preamble')}</Text>
-        <FlatList
-          style={{ marginTop: 15, flexGrow: 0 }}
-          scrollEnabled={false}
-          data={[
-            { key: t('WhatAreContacts.ListItemDirectMessage') },
-            { key: t('WhatAreContacts.ListItemNewCredentials') },
-            { key: t('WhatAreContacts.ListItemNotifiedOfUpdates') },
-            { key: t('WhatAreContacts.ListItemRequest') },
-          ]}
-          renderItem={({ item }) => {
-            return (
-              <View style={{ marginBottom: 10, flexDirection: 'row' }}>
-                <Text style={{ ...TextTheme.normal, marginRight: 5 }}>{'\u2022'}</Text>
-                <Text style={[TextTheme.normal, { flexShrink: 1, flexWrap: 'wrap' }]}>{item.key}</Text>
-              </View>
-            )
-          }}
-        />
-        <View style={{ flexDirection: 'row', justifyContent: 'center' }}></View>
-        <Text style={TextTheme.normal}>
-          {t('WhatAreContacts.RemoveContacts') + ' '}
+        {bulletPoints}
+        <Text style={[TextTheme.normal, { marginBottom: 30 }]}>
+          {`${t('WhatAreContacts.RemoveContacts')} `}
           <Text onPress={goToContactList} style={[TextTheme.normal, styles.fakeLink]}>
             {t('WhatAreContacts.ContactsLink')}.
           </Text>
         </Text>
-      </View>
+      </ScrollView>
     </SafeAreaView>
   )
 }

--- a/packages/legacy/core/__tests__/screens/WhatAreContacts.test.tsx
+++ b/packages/legacy/core/__tests__/screens/WhatAreContacts.test.tsx
@@ -1,0 +1,23 @@
+import { useNavigation } from '@react-navigation/core'
+import { render } from '@testing-library/react-native'
+import React from 'react'
+
+import WhatAreContacts from '../../App/screens/WhatAreContacts'
+
+jest.mock('@react-navigation/core', () => {
+  return require('../../__mocks__/custom/@react-navigation/core')
+})
+jest.mock('@react-navigation/native', () => {
+  return require('../../__mocks__/custom/@react-navigation/native')
+})
+
+describe('WhatAreContacts Screen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('Renders correctly', async () => {
+    const tree = render(<WhatAreContacts navigation={useNavigation()} />)
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/packages/legacy/core/__tests__/screens/__snapshots__/WhatAreContacts.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/WhatAreContacts.test.tsx.snap
@@ -1,0 +1,236 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WhatAreContacts Screen Renders correctly 1`] = `
+<RCTSafeAreaView
+  emulateUnlessSupported={true}
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#000000",
+      "flex": 1,
+    }
+  }
+>
+  <RCTScrollView
+    automaticallyAdjustContentInsets={false}
+    contentContainerStyle={
+      Object {
+        "marginTop": 30,
+        "paddingLeft": 25,
+        "paddingRight": 25,
+      }
+    }
+    directionalLockEnabled={true}
+    showsHorizontalScrollIndicator={false}
+  >
+    <View>
+      <Text
+        style={
+          Object {
+            "color": "#FFFFFF",
+            "fontSize": 32,
+            "fontWeight": "bold",
+            "marginBottom": 15,
+          }
+        }
+      >
+        WhatAreContacts.Title
+      </Text>
+      <Text
+        style={
+          Object {
+            "color": "#FFFFFF",
+            "fontSize": 18,
+            "fontWeight": "normal",
+          }
+        }
+      >
+        WhatAreContacts.Preamble
+      </Text>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+            "marginBottom": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#FFFFFF",
+              "fontSize": 18,
+              "fontWeight": "normal",
+              "paddingRight": 5,
+            }
+          }
+        >
+          •
+        </Text>
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 18,
+                "fontWeight": "normal",
+              },
+              Object {
+                "flexShrink": 1,
+              },
+            ]
+          }
+        >
+          WhatAreContacts.ListItemDirectMessage
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+            "marginBottom": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#FFFFFF",
+              "fontSize": 18,
+              "fontWeight": "normal",
+              "paddingRight": 5,
+            }
+          }
+        >
+          •
+        </Text>
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 18,
+                "fontWeight": "normal",
+              },
+              Object {
+                "flexShrink": 1,
+              },
+            ]
+          }
+        >
+          WhatAreContacts.ListItemNewCredentials
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+            "marginBottom": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#FFFFFF",
+              "fontSize": 18,
+              "fontWeight": "normal",
+              "paddingRight": 5,
+            }
+          }
+        >
+          •
+        </Text>
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 18,
+                "fontWeight": "normal",
+              },
+              Object {
+                "flexShrink": 1,
+              },
+            ]
+          }
+        >
+          WhatAreContacts.ListItemNotifiedOfUpdates
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+            "marginBottom": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#FFFFFF",
+              "fontSize": 18,
+              "fontWeight": "normal",
+              "paddingRight": 5,
+            }
+          }
+        >
+          •
+        </Text>
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 18,
+                "fontWeight": "normal",
+              },
+              Object {
+                "flexShrink": 1,
+              },
+            ]
+          }
+        >
+          WhatAreContacts.ListItemRequest
+        </Text>
+      </View>
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "#FFFFFF",
+              "fontSize": 18,
+              "fontWeight": "normal",
+            },
+            Object {
+              "marginBottom": 30,
+            },
+          ]
+        }
+      >
+        WhatAreContacts.RemoveContacts 
+        <Text
+          onPress={[Function]}
+          style={
+            Array [
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 18,
+                "fontWeight": "normal",
+              },
+              Object {
+                "color": "#FFFFFF",
+                "textDecorationLine": "underline",
+              },
+            ]
+          }
+        >
+          WhatAreContacts.ContactsLink
+          .
+        </Text>
+      </Text>
+    </View>
+  </RCTScrollView>
+</RCTSafeAreaView>
+`;


### PR DESCRIPTION
# Summary of Changes

Make the WhatAreContacts screen scrollable and remove the Flatlist

Here's what it looks like with max zoom settings:
![what_are_contacts](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/32586431/cc13c038-0844-4a9d-9927-3b79bf69531f)

Here's what it looks like with normal zoom settings:
<img width="284" alt="WhatAreContacts" src="https://github.com/hyperledger/aries-mobile-agent-react-native/assets/32586431/d02719ca-6a04-4650-a728-021d778ecd5f">


# Related Issues

#822

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
