### PR TITLE
fix: make proof request decline navigate to home screen

### DIFF
--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -276,7 +276,7 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
     }
 
     toggleDeclineModalVisible()
-    navigation.goBack()
+    navigation.getParent()?.navigate(Screens.Home)
   }
 
   const proofPageHeader = () => {


### PR DESCRIPTION
# Summary of Changes

Previously, declining a proof request from the scan screen would navigate users to the connection screen, when it should have been navigating them to the home screen. This PR fixes that.

Here it is in action:
![proof_request_navigation](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/32586431/ddd0551f-f423-4535-af67-8af4b18fdc15)

# Related Issues

#821 

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
