### PR TITLE
fix: fixed back button disappearing from biom screen

### DIFF
--- a/packages/legacy/core/App/screens/UseBiometry.tsx
+++ b/packages/legacy/core/App/screens/UseBiometry.tsx
@@ -113,9 +113,8 @@ const UseBiometry: React.FC = () => {
     // If successfully authenticated the toggle may proceed.
     if (status) {
       setBiometryEnabled((previousState) => !previousState)
-      DeviceEventEmitter.emit(EventTypes.BIOMETRY_UPDATE, false)
     }
-
+    DeviceEventEmitter.emit(EventTypes.BIOMETRY_UPDATE, false)
     setCanSeeCheckPIN(false)
   }
 


### PR DESCRIPTION
# Summary of Changes

Previously in the biometrics screen accessed from the setting menu, when toggling biometrics on/off and entering the incorrect pin, the left header back button would disappear. These changes ensure that it does not disappear.

# Related Issues
Resolves: #823

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
