### PR TITLE
fix: only send problem report if connectionid

### DIFF
--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -263,7 +263,10 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
     try {
       if (agent && proof) {
         await agent.proofs.declineRequest(proof.id)
-        await agent.proofs.sendProblemReport(proof.id, t('ProofRequest.Declined')) // currently, fails for connectionless case
+        // sending a problem report fails if there is neither a connectionId nor a ~service decorator
+        if (proof.connectionId) {
+          await agent.proofs.sendProblemReport(proof.id, t('ProofRequest.Declined'))
+        }
       }
     } catch (err: unknown) {
       const error = new BifoldError(t('Error.Title1028'), t('Error.Message1028'), (err as Error).message, 1028)


### PR DESCRIPTION
# Summary of Changes

Previously declining a proof request would cause Bifold to attempt to send a problem report even if the proof request was connectionless, which caused an error. This PR conditionally sends problem reports only if there is a connection.

Here is the relevant code from AFJ core: https://github.com/hyperledger/aries-framework-javascript/blob/38a0578011896cfcf217713d34f285cd381ad72c/packages/core/src/modules/proofs/ProofsApi.ts#L561

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
