### PR TITLE
fix: make toasts appear after modal closes

### DIFF
--- a/packages/legacy/core/App/screens/ContactDetails.tsx
+++ b/packages/legacy/core/App/screens/ContactDetails.tsx
@@ -51,11 +51,16 @@ const ContactDetails: React.FC<ContactDetailsProps> = ({ route }) => {
       }
 
       await agent.connections.deleteById(connection.id)
+
+      navigation.navigate(Screens.Contacts)
+
+      // FIXME: This delay is a hack so that the toast doesn't appear until the modal is dismissed
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+
       Toast.show({
         type: ToastType.Success,
         text1: t('ContactDetails.ContactRemoved'),
       })
-      navigation.navigate(Screens.Contacts)
     } catch (err: unknown) {
       const error = new BifoldError(t('Error.Title1037'), t('Error.Message1037'), (err as Error).message, 1025)
 

--- a/packages/legacy/core/App/screens/CredentialDetails.tsx
+++ b/packages/legacy/core/App/screens/CredentialDetails.tsx
@@ -170,12 +170,15 @@ const CredentialDetails: React.FC<CredentialDetailsProps> = ({ navigation, route
 
       await agent.credentials.deleteById(credential.id)
 
+      navigation.pop()
+
+      // FIXME: This delay is a hack so that the toast doesn't appear until the modal is dismissed
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+
       Toast.show({
         type: ToastType.Success,
         text1: t('CredentialDetails.CredentialRemoved'),
       })
-
-      navigation.pop()
     } catch (err: unknown) {
       const error = new BifoldError(t('Error.Title1032'), t('Error.Message1032'), (err as Error).message, 1025)
 


### PR DESCRIPTION
# Summary of Changes

Previously the toasts that let the user know a credential or contact had been removed were being covered by the common remove modal. This PR addresses that. It's not a perfect fix but since we're looking at swapping toasts out entirely, it'll do for now.

Here's what it looks like:
![toast](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/32586431/a74fad74-2f41-4528-a9cf-154a1da5e92a)

# Related Issues

#835

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
