### PR TITLE
fix: modal status bar

### DIFF
--- a/packages/legacy/core/App/components/misc/IOSStatusBar.tsx
+++ b/packages/legacy/core/App/components/misc/IOSStatusBar.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Platform, View } from 'react-native'
+
+import { useTheme } from '../../contexts/theme'
+
+
+
+const IOSStatusBar: React.FC = ({ ...props }) => {
+    const { ColorPallet } = useTheme()
+    return (
+        <>
+            {Platform.OS === "ios" && <View style={{ height: 40, backgroundColor: ColorPallet.brand.primary }} {...props}></View>}
+        </>
+    )
+}
+
+export default IOSStatusBar

--- a/packages/legacy/core/App/components/misc/IOSStatusBar.tsx
+++ b/packages/legacy/core/App/components/misc/IOSStatusBar.tsx
@@ -3,15 +3,15 @@ import { Platform, View } from 'react-native'
 
 import { useTheme } from '../../contexts/theme'
 
-
-
 const IOSStatusBar: React.FC = ({ ...props }) => {
-    const { ColorPallet } = useTheme()
-    return (
-        <>
-            {Platform.OS === "ios" && <View style={{ height: 40, backgroundColor: ColorPallet.brand.primary }} {...props}></View>}
-        </>
-    )
+  const { ColorPallet } = useTheme()
+  return (
+    <>
+      {Platform.OS === 'ios' && (
+        <View style={{ height: 40, backgroundColor: ColorPallet.brand.primary }} {...props}></View>
+      )}
+    </>
+  )
 }
 
 export default IOSStatusBar

--- a/packages/legacy/core/App/components/modals/CameraDisclosureModal.tsx
+++ b/packages/legacy/core/App/components/modals/CameraDisclosureModal.tsx
@@ -2,7 +2,7 @@ import { useNavigation } from '@react-navigation/core'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Modal, ScrollView, StyleSheet, Text, View, Linking } from 'react-native'
+import { Modal, ScrollView, StyleSheet, Text, View, Linking, Platform } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import { useTheme } from '../../contexts/theme'
@@ -69,6 +69,7 @@ const CameraDisclosureModal: React.FC<CameraDisclosureModalProps> = ({ requestCa
 
   return (
     <Modal visible={modalVisible} animationType={'slide'} transparent>
+      {Platform.OS === "ios" && <View style={{ height: 40, backgroundColor: ColorPallet.brand.primary }}></View>}
       {showSettingsPopup && (
         <DismissiblePopupModal
           title={t('CameraDisclosure.AllowCameraUse')}

--- a/packages/legacy/core/App/components/modals/CameraDisclosureModal.tsx
+++ b/packages/legacy/core/App/components/modals/CameraDisclosureModal.tsx
@@ -11,6 +11,7 @@ import { testIdWithKey } from '../../utils/testable'
 import Button, { ButtonType } from '../buttons/Button'
 
 import DismissiblePopupModal from './DismissiblePopupModal'
+import IOSStatusBar from '../../components/misc/IOSStatusBar'
 
 interface CameraDisclosureModalProps {
   requestCameraUse: () => Promise<boolean>
@@ -69,7 +70,7 @@ const CameraDisclosureModal: React.FC<CameraDisclosureModalProps> = ({ requestCa
 
   return (
     <Modal visible={modalVisible} animationType={'slide'} transparent>
-      {Platform.OS === "ios" && <View style={{ height: 40, backgroundColor: ColorPallet.brand.primary }}></View>}
+      <IOSStatusBar></IOSStatusBar>
       {showSettingsPopup && (
         <DismissiblePopupModal
           title={t('CameraDisclosure.AllowCameraUse')}

--- a/packages/legacy/core/App/components/modals/CameraDisclosureModal.tsx
+++ b/packages/legacy/core/App/components/modals/CameraDisclosureModal.tsx
@@ -2,16 +2,16 @@ import { useNavigation } from '@react-navigation/core'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Modal, ScrollView, StyleSheet, Text, View, Linking, Platform } from 'react-native'
+import { Modal, ScrollView, StyleSheet, Text, View, Linking } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
+import IOSStatusBar from '../../components/misc/IOSStatusBar'
 import { useTheme } from '../../contexts/theme'
 import { Screens, HomeStackParams } from '../../types/navigators'
 import { testIdWithKey } from '../../utils/testable'
 import Button, { ButtonType } from '../buttons/Button'
 
 import DismissiblePopupModal from './DismissiblePopupModal'
-import IOSStatusBar from '../../components/misc/IOSStatusBar'
 
 interface CameraDisclosureModalProps {
   requestCameraUse: () => Promise<boolean>

--- a/packages/legacy/core/App/screens/PINEnter.tsx
+++ b/packages/legacy/core/App/screens/PINEnter.tsx
@@ -2,7 +2,7 @@ import { useNavigation } from '@react-navigation/core'
 import { CommonActions } from '@react-navigation/native'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StatusBar, Keyboard, StyleSheet, Text, Image, View, DeviceEventEmitter } from 'react-native'
+import { StatusBar, Keyboard, StyleSheet, Text, Image, View, DeviceEventEmitter, SafeAreaView } from 'react-native'
 
 import Button, { ButtonType } from '../components/buttons/Button'
 import PINInput from '../components/inputs/PINInput'
@@ -277,7 +277,6 @@ const PINEnter: React.FC<PINEnterProps> = ({ setAuthenticated, usage = PINEntryU
 
   return (
     <KeyboardView>
-      <StatusBar barStyle={StatusBarStyles.Light} />
       <View style={style.screenContainer}>
         <View style={style.contentContainer}>
           <Image

--- a/packages/legacy/core/App/screens/PINEnter.tsx
+++ b/packages/legacy/core/App/screens/PINEnter.tsx
@@ -2,7 +2,7 @@ import { useNavigation } from '@react-navigation/core'
 import { CommonActions } from '@react-navigation/native'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StatusBar, Keyboard, StyleSheet, Text, Image, View, DeviceEventEmitter, SafeAreaView } from 'react-native'
+import { Keyboard, StyleSheet, Text, Image, View, DeviceEventEmitter } from 'react-native'
 
 import Button, { ButtonType } from '../components/buttons/Button'
 import PINInput from '../components/inputs/PINInput'
@@ -17,7 +17,6 @@ import { useStore } from '../contexts/store'
 import { useTheme } from '../contexts/theme'
 import { Screens } from '../types/navigators'
 import { hashPIN } from '../utils/crypto'
-import { StatusBarStyles } from '../utils/luminance'
 import { testIdWithKey } from '../utils/testable'
 
 interface PINEnterProps {

--- a/packages/legacy/core/App/screens/UseBiometry.tsx
+++ b/packages/legacy/core/App/screens/UseBiometry.tsx
@@ -1,18 +1,10 @@
 import React, { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import {
-  StyleSheet,
-  Text,
-  View,
-  Modal,
-  Switch,
-  ScrollView,
-  Pressable,
-  DeviceEventEmitter,
-} from 'react-native'
+import { StyleSheet, Text, View, Modal, Switch, ScrollView, Pressable, DeviceEventEmitter } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import Button, { ButtonType } from '../components/buttons/Button'
+import IOSStatusBar from '../components/misc/IOSStatusBar'
 import { EventTypes } from '../constants'
 import { useAnimatedComponents } from '../contexts/animated-components'
 import { useAuth } from '../contexts/auth'
@@ -22,7 +14,6 @@ import { useTheme } from '../contexts/theme'
 import { testIdWithKey } from '../utils/testable'
 
 import PINEnter, { PINEntryUsage } from './PINEnter'
-import IOSStatusBar from '../components/misc/IOSStatusBar'
 
 enum UseBiometryUsage {
   InitialSetup,

--- a/packages/legacy/core/App/screens/UseBiometry.tsx
+++ b/packages/legacy/core/App/screens/UseBiometry.tsx
@@ -120,9 +120,6 @@ const UseBiometry: React.FC = () => {
 
   return (
     <SafeAreaView edges={['left', 'right', 'bottom']}>
-      <StatusBar
-        barStyle={Platform.OS === 'android' ? StatusBarStyles.Light : statusBarStyleForColor(ColorPallet.brand.primary)}
-      />
       <ScrollView style={styles.container}>
         <View style={{ alignItems: 'center' }}>
           <Assets.svg.biometrics style={[styles.image]} />
@@ -191,6 +188,7 @@ const UseBiometry: React.FC = () => {
         transparent={false}
         animationType={'slide'}
       >
+        {Platform.OS === "ios" && <View style={{ height: 40, backgroundColor: ColorPallet.brand.primary }}></View>}
         <PINEnter usage={PINEntryUsage.PINCheck} setAuthenticated={onAuthenticationComplete} />
       </Modal>
     </SafeAreaView>

--- a/packages/legacy/core/App/screens/UseBiometry.tsx
+++ b/packages/legacy/core/App/screens/UseBiometry.tsx
@@ -6,8 +6,6 @@ import {
   View,
   Modal,
   Switch,
-  StatusBar,
-  Platform,
   ScrollView,
   Pressable,
   DeviceEventEmitter,
@@ -21,10 +19,10 @@ import { useAuth } from '../contexts/auth'
 import { DispatchAction } from '../contexts/reducers/store'
 import { useStore } from '../contexts/store'
 import { useTheme } from '../contexts/theme'
-import { statusBarStyleForColor, StatusBarStyles } from '../utils/luminance'
 import { testIdWithKey } from '../utils/testable'
 
 import PINEnter, { PINEntryUsage } from './PINEnter'
+import IOSStatusBar from '../components/misc/IOSStatusBar'
 
 enum UseBiometryUsage {
   InitialSetup,
@@ -188,7 +186,7 @@ const UseBiometry: React.FC = () => {
         transparent={false}
         animationType={'slide'}
       >
-        {Platform.OS === "ios" && <View style={{ height: 40, backgroundColor: ColorPallet.brand.primary }}></View>}
+        <IOSStatusBar></IOSStatusBar>
         <PINEnter usage={PINEntryUsage.PINCheck} setAuthenticated={onAuthenticationComplete} />
       </Modal>
     </SafeAreaView>

--- a/packages/legacy/core/__tests__/components/__snapshots__/CameraDisclosureModal.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/CameraDisclosureModal.test.tsx.snap
@@ -7,6 +7,14 @@ exports[`CameraDisclosureModal Component Renders correctly 1`] = `
   transparent={true}
   visible={true}
 >
+  <View
+    style={
+      Object {
+        "backgroundColor": "#42803E",
+        "height": 40,
+      }
+    }
+  />
   <RNCSafeAreaView
     style={
       Object {

--- a/packages/legacy/core/__tests__/screens/__snapshots__/UseBiometry.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/UseBiometry.test.tsx.snap
@@ -246,6 +246,14 @@ exports[`UseBiometry Screen Renders correctly when biometry available 1`] = `
     transparent={false}
     visible={false}
   >
+    <View
+      style={
+        Object {
+          "backgroundColor": "#42803E",
+          "height": 40,
+        }
+      }
+    />
     <RNCSafeAreaView
       edges={
         Array [
@@ -916,6 +924,14 @@ exports[`UseBiometry Screen Renders correctly when biometry not available 1`] = 
     transparent={false}
     visible={false}
   >
+    <View
+      style={
+        Object {
+          "backgroundColor": "#42803E",
+          "height": 40,
+        }
+      }
+    />
     <RNCSafeAreaView
       edges={
         Array [
@@ -1644,6 +1660,14 @@ exports[`UseBiometry Screen Toggles use biometrics ok 1`] = `
     transparent={false}
     visible={false}
   >
+    <View
+      style={
+        Object {
+          "backgroundColor": "#42803E",
+          "height": 40,
+        }
+      }
+    />
     <RNCSafeAreaView
       edges={
         Array [


### PR DESCRIPTION
# Summary of Changes

Added status bar background to IOS. IOS doesn't really have a notion of status bar background colour, the IOS status bar is always transparent. I added a simple view at the top of the modal to give the effect of a coloured status bar. I added the component to the usebiometry in the settings as well as the camera disclosure modal
![Screen Shot 2023-06-20 at 10 39 33 AM](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/36937407/6beb6dfc-4cf6-410b-8503-9e9ea5006ca9)


# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
