### PR TITLE
fix: make a11y label for show hide all button rspsv

### DIFF
--- a/packages/legacy/core/App/components/record/Record.tsx
+++ b/packages/legacy/core/App/components/record/Record.tsx
@@ -87,7 +87,7 @@ const Record: React.FC<RecordProps> = ({ header, footer, fields, hideFieldValues
                   onPress={() => resetShown()}
                   testID={testIdWithKey('HideAll')}
                   accessible={true}
-                  accessibilityLabel={t('Record.HideAll')}
+                  accessibilityLabel={showAll ? t('Record.ShowAll') : t('Record.HideAll')}
                 >
                   <Text style={ListItems.recordLink}>{showAll ? t('Record.ShowAll') : t('Record.HideAll')}</Text>
                 </TouchableOpacity>


### PR DESCRIPTION
# Summary of Changes

Previously this label would always read 'Hide all' even when it was to show all. Here is a couple screenshots of Voice Control on iOS showing the new labels:
![hide_all](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/32586431/b1078d2c-a1c0-4613-a5e4-79c518c328e5)
![show_all](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/32586431/4bb0fd5d-9e8d-41ac-b270-389a4c2ab8a0)

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
