### PR TITLE
fix: OCA translation for proof request labels

### DIFF
--- a/packages/legacy/core/App/components/misc/CredentialCard11.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard11.tsx
@@ -254,6 +254,8 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
   }
 
   const AttributeLabel: React.FC<{ label: string }> = ({ label }) => {
+    const ylabel = overlay.bundle?.labelOverlay?.attributeLabels[label] ?? startCase(label)
+
     return (
       <Text
         style={[
@@ -266,7 +268,7 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
         ]}
         testID={testIdWithKey('AttributeName')}
       >
-        {label}
+        {ylabel}
       </Text>
     )
   }
@@ -296,7 +298,7 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
   }
 
   const parseAttribute = (item: (Attribute & Predicate) | undefined) => {
-    return { label: item?.label ?? startCase(item?.name ?? ''), value: item?.value || `${item?.pType} ${item?.pValue}` }
+    return { label: item?.label ?? item?.name ?? '', value: item?.value || `${item?.pType} ${item?.pValue}` }
   }
 
   const renderCardAttribute = (item: Attribute & Predicate) => {


### PR DESCRIPTION
# Summary of Changes

Apply OCA on labels during Proof request

In the `Credential details` everything work fine with the OCA bundle:
![image](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/24842909/067f9231-28f7-4c60-a299-8b3ee7fa2127)

but, in the proof request the OCA bundle is not apply on the labels (only `startCase()`): 
![image](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/24842909/1167fe37-01f1-4c49-bf7e-3f05399f9596)

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
