### PR TITLE
fix: make sure walletName is not undefined when fetching from ls

### DIFF
--- a/packages/legacy/core/App/contexts/reducers/store.ts
+++ b/packages/legacy/core/App/contexts/reducers/store.ts
@@ -11,6 +11,7 @@ import {
   Migration as MigrationState,
   State,
 } from '../../types/state'
+import { generateRandomWalletName } from '../../utils/helpers'
 
 enum OnboardingDispatchAction {
   ONBOARDING_UPDATED = 'onboarding/onboardingStateLoaded',
@@ -149,6 +150,11 @@ export const reducer = <S extends State>(state: S, action: ReducerAction<Dispatc
     }
     case PreferencesDispatchAction.PREFERENCES_UPDATED: {
       const preferences: PreferencesState = (action?.payload || []).pop()
+      // For older wallets that haven't explicitly named their wallet yet
+      if (!preferences.walletName) {
+        preferences.walletName = generateRandomWalletName()
+      }
+
       return {
         ...state,
         preferences,

--- a/packages/legacy/core/App/screens/Splash.tsx
+++ b/packages/legacy/core/App/screens/Splash.tsx
@@ -30,14 +30,8 @@ import {
 import { getAgentModules, createLinkSecretIfRequired } from '../utils/agent'
 import { migrateToAskar, didMigrateToAskar } from '../utils/migration'
 
-const onboardingComplete = (state: StoreOnboardingState, enableWalletNaming: boolean | undefined): boolean => {
-  return (
-    state.didCompleteTutorial &&
-    state.didAgreeToTerms &&
-    state.didCreatePIN &&
-    (state.didNameWallet || !enableWalletNaming) &&
-    state.didConsiderBiometry
-  )
+const onboardingComplete = (state: StoreOnboardingState): boolean => {
+  return state.didCompleteTutorial && state.didAgreeToTerms && state.didCreatePIN && state.didConsiderBiometry
 }
 
 const resumeOnboardingAt = (state: StoreOnboardingState, enableWalletNaming: boolean | undefined): Screens => {
@@ -155,7 +149,7 @@ const Splash: React.FC = () => {
         if (data) {
           const onboardingState = JSON.parse(data) as StoreOnboardingState
           dispatch({ type: DispatchAction.ONBOARDING_UPDATED, payload: [onboardingState] })
-          if (onboardingComplete(onboardingState, enableWalletNaming) && !attemptData?.lockoutDate) {
+          if (onboardingComplete(onboardingState) && !attemptData?.lockoutDate) {
             navigation.dispatch(
               CommonActions.reset({
                 index: 0,
@@ -163,7 +157,7 @@ const Splash: React.FC = () => {
               })
             )
             return
-          } else if (onboardingComplete(onboardingState, enableWalletNaming) && attemptData?.lockoutDate) {
+          } else if (onboardingComplete(onboardingState) && attemptData?.lockoutDate) {
             // return to lockout screen if lockout date is set
             navigation.dispatch(
               CommonActions.reset({
@@ -214,7 +208,7 @@ const Splash: React.FC = () => {
 
         const newAgent = new Agent({
           config: {
-            label: store.preferences.walletName,
+            label: store.preferences.walletName || 'Aries Bifold',
             walletConfig: {
               id: credentials.id,
               key: credentials.key,


### PR DESCRIPTION
# Summary of Changes

Previously, if an older instance of the wallet that had already gone through onboarding was initialized it would have an undefined walletName in preferences, which would then overwrite the default value. This caused errors in connections because the label was missing. This fix is two-pronged, first it will convert undefined `walletName` values in localstorage to `generateRandomWalletName` when preferences are loaded, then it will use a backup value of `Aries Bifold` if `walletName` is still somehow undefined.

EDIT: I also removed the check for the wallet being named from the onboarding completeness check, so that older already-initialized wallets don't end up having to go back to onboarding. (Something I did for BC Wallet already but not for Bifold)

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
