### PR TITLE
fix: mob ver proof notif

### DIFF
--- a/packages/legacy/core/App/hooks/notifications.ts
+++ b/packages/legacy/core/App/hooks/notifications.ts
@@ -17,14 +17,6 @@ interface Notifications {
 export const useNotifications = (): Notifications => {
   const offers = useCredentialByState(CredentialState.OfferReceived)
   const proofsRequested = useProofByState(ProofState.RequestReceived)
-  const proofsDone = useProofByState([ProofState.Done, ProofState.PresentationReceived]).filter(
-    (proof: ProofExchangeRecord) => {
-      if (proof.isVerified === undefined) return false
-
-      const metadata = proof.metadata.get(ProofMetadata.customMetadata) as ProofCustomMetadata
-      return !metadata?.details_seen
-    }
-  )
   const revoked = useCredentialByState(CredentialState.Done).filter((cred: CredentialRecord) => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const metadata = cred!.metadata.get(CredentialMetadata.customMetadata) as customMetadata
@@ -33,7 +25,7 @@ export const useNotifications = (): Notifications => {
     }
   })
 
-  const notifications = [...offers, ...proofsRequested, ...proofsDone, ...revoked].sort(
+  const notifications = [...offers, ...proofsRequested, ...revoked].sort(
     (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
   )
 

--- a/packages/legacy/core/App/hooks/notifications.ts
+++ b/packages/legacy/core/App/hooks/notifications.ts
@@ -6,7 +6,6 @@ import {
 } from '@aries-framework/core'
 import { useCredentialByState, useProofByState } from '@aries-framework/react-hooks'
 
-import { ProofCustomMetadata, ProofMetadata } from '../../verifier'
 import { CredentialMetadata, customMetadata } from '../types/metadata'
 
 interface Notifications {


### PR DESCRIPTION
# Summary of Changes

Previously the notification functionality was listing any proof record that was in the done state. This doesn't really make sense since the notification list is supposed to contain proofs and credential offers that haven't been completed yet. The functionality to list completed proof requests in the notification list has been removed

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
