### PR TITLE
fix: verifier notifications

### DIFF
--- a/packages/legacy/core/App/hooks/notifications.ts
+++ b/packages/legacy/core/App/hooks/notifications.ts
@@ -6,6 +6,7 @@ import {
 } from '@aries-framework/core'
 import { useCredentialByState, useProofByState } from '@aries-framework/react-hooks'
 
+import { ProofCustomMetadata, ProofMetadata } from '../../verifier'
 import { CredentialMetadata, customMetadata } from '../types/metadata'
 
 interface Notifications {
@@ -16,6 +17,13 @@ interface Notifications {
 export const useNotifications = (): Notifications => {
   const offers = useCredentialByState(CredentialState.OfferReceived)
   const proofsRequested = useProofByState(ProofState.RequestReceived)
+  const proofsDone = useProofByState([ProofState.Done, ProofState.PresentationReceived]).filter(
+    (proof: ProofExchangeRecord) => {
+      if (proof.isVerified === undefined) return false
+      const metadata = proof.metadata.get(ProofMetadata.customMetadata) as ProofCustomMetadata
+      return !metadata?.details_seen
+    }
+  )
   const revoked = useCredentialByState(CredentialState.Done).filter((cred: CredentialRecord) => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const metadata = cred!.metadata.get(CredentialMetadata.customMetadata) as customMetadata
@@ -24,7 +32,7 @@ export const useNotifications = (): Notifications => {
     }
   })
 
-  const notifications = [...offers, ...proofsRequested, ...revoked].sort(
+  const notifications = [...offers, ...proofsRequested, ...proofsDone, ...revoked].sort(
     (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
   )
 

--- a/packages/legacy/core/App/screens/ProofDetails.tsx
+++ b/packages/legacy/core/App/screens/ProofDetails.tsx
@@ -102,7 +102,7 @@ const VerifiedProof: React.FC<VerifiedProofProps> = ({ record, navigation, isHis
 
   const onGenerateNew = useCallback(() => {
     const metadata = record.metadata.get(ProofMetadata.customMetadata) as ProofCustomMetadata
-    if (metadata.proof_request_template_id) {
+    if (metadata?.proof_request_template_id) {
       navigation.navigate(Screens.ProofRequesting, { templateId: metadata.proof_request_template_id })
     } else {
       navigation.navigate(Screens.ProofRequests, {})
@@ -232,8 +232,10 @@ const ProofDetails: React.FC<ProofDetailsProps> = ({ route, navigation }) => {
   const { agent } = useAgent()
 
   useEffect(() => {
-    if (agent && record) markProofAsViewed(agent, record)
-  }, [])
+    if (agent && record && !record.metadata?.data?.customMetadata?.details_seen) {
+      markProofAsViewed(agent, record)
+    }
+  }, [record])
 
   useFocusEffect(
     useCallback(() => {

--- a/packages/legacy/core/__tests__/screens/Home.test.tsx
+++ b/packages/legacy/core/__tests__/screens/Home.test.tsx
@@ -72,6 +72,11 @@ describe('with a notifications module, when an issuer sends a credential offer',
       state: ProofState.RequestReceived,
       protocolVersion: 'v1',
     }),
+    new ProofExchangeRecord({
+      threadId: '3',
+      state: ProofState.Done,
+      protocolVersion: 'v1',
+    }),
   ]
 
   beforeEach(() => {
@@ -96,7 +101,7 @@ describe('with a notifications module, when an issuer sends a credential offer',
         <Home route={{} as any} navigation={useNavigation()} />
       </ConfigurationContext.Provider>
     )
-    const notificationLabel = await findByText('Home.Notifications (2)')
+    const notificationLabel = await findByText('Home.Notifications (3)')
 
     expect(notificationLabel).toBeTruthy()
   })
@@ -134,7 +139,7 @@ describe('with a notifications module, when an issuer sends a credential offer',
 
     const flatListInstance = await findAllByTestId(testIdWithKey('NotificationListItem'))
 
-    expect(flatListInstance).toHaveLength(2)
+    expect(flatListInstance).toHaveLength(3)
   })
 
   /**
@@ -189,9 +194,40 @@ describe('with a notifications module, when an issuer sends a credential offer',
     })
 
     expect(navigation.navigate).toHaveBeenCalledTimes(1)
+
     expect(navigation.navigate).toHaveBeenCalledWith('Notifications Stack', {
       screen: 'Proof Request',
       params: { proofId: testProofRecords[0].id },
+    })
+
+  })
+
+  /**
+   * Scenario: Holder selects a proof request
+   * Given the holder has received a proof request from a connected verifier
+   * When the holder selects the proof request
+   * When the holder is taken to the proof request screen/flow
+   */
+  test('touch notification triggers navigation correctly III', async () => {
+    const { findByTestId } = render(
+      <ConfigurationContext.Provider value={configurationContext}>
+        <Home route={{} as any} navigation={useNavigation()} />
+      </ConfigurationContext.Provider>
+    )
+
+    const button = await findByTestId(testIdWithKey('ViewProofRecordReceived'))
+    const navigation = useNavigation()
+
+    expect(button).toBeDefined()
+
+    act(() => {
+      fireEvent(button, 'press')
+    })
+
+    expect(navigation.navigate).toHaveBeenCalledTimes(1)
+    expect(navigation.navigate).toHaveBeenCalledWith('Contacts Stack', {
+      screen: 'Proof Details',
+      params: { recordId: testProofRecords[1].id, isHistory: true },
     })
   })
 })


### PR DESCRIPTION
# Summary of Changes

Previously I removed mobile verifier notifications in the home screen. This change adds them back in as well as fixes bugs while viewing or deleting the notification.
<img width="389" alt="image" src="https://github.com/hyperledger/aries-mobile-agent-react-native/assets/36937407/6a43b5b7-6d9d-471c-98a4-a2e69ab95cff">
<img width="389" alt="image" src="https://github.com/hyperledger/aries-mobile-agent-react-native/assets/36937407/7cd2e0ef-20f1-4c4f-ae21-15b178e6e136">

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
