### PR TITLE
fix:fixing problem with the amount of attributes in the proof request

### DIFF
--- a/packages/legacy/core/App/components/misc/CredentialCard11.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard11.tsx
@@ -379,6 +379,7 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
           <FlatList
             data={cardData}
             scrollEnabled={false}
+            initialNumToRender={cardData?.length}
             renderItem={({ item }) => {
               return renderCardAttribute(item as Attribute & Predicate)
             }}

--- a/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
@@ -512,6 +512,7 @@ exports[`displays a credential offer screen accepting a credential 1`] = `
                             }
                             getItem={[Function]}
                             getItemCount={[Function]}
+                            initialNumToRender={2}
                             keyExtractor={[Function]}
                             onContentSizeChange={[Function]}
                             onLayout={[Function]}
@@ -2328,6 +2329,7 @@ exports[`displays a credential offer screen declining a credential 1`] = `
                             }
                             getItem={[Function]}
                             getItemCount={[Function]}
+                            initialNumToRender={2}
                             keyExtractor={[Function]}
                             onContentSizeChange={[Function]}
                             onLayout={[Function]}
@@ -4146,6 +4148,7 @@ exports[`displays a credential offer screen renders correctly 1`] = `
                             }
                             getItem={[Function]}
                             getItemCount={[Function]}
+                            initialNumToRender={2}
                             keyExtractor={[Function]}
                             onContentSizeChange={[Function]}
                             onLayout={[Function]}


### PR DESCRIPTION
# Summary of Changes

When the proof request contains more than ten attributes, the card keep blinking. This happens because the `initialNumToRender` variable has a default value of ten.

Before

https://github.com/hyperledger/aries-mobile-agent-react-native/assets/97122568/d834cb28-d15a-43ba-bf62-f846b805dccf

Now

https://github.com/hyperledger/aries-mobile-agent-react-native/assets/97122568/9bff3a04-3eab-4cea-bd8f-031b638730b8

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [X] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [X] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [X] Updated documentation as needed for changed code and new or modified features;
- [X] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._