### PR TITLE
feat: dev only templates

### DIFF
--- a/packages/legacy/core/App/contexts/reducers/store.ts
+++ b/packages/legacy/core/App/contexts/reducers/store.ts
@@ -40,6 +40,7 @@ enum PreferencesDispatchAction {
   PREFERENCES_UPDATED = 'preferences/preferencesStateLoaded',
   USE_VERIFIER_CAPABILITY = 'preferences/useVerifierCapability',
   USE_CONNECTION_INVITER_CAPABILITY = 'preferences/useConnectionInviterCapability',
+  USE_DEV_VERIFIER_TEMPLATES = 'preferences/useDevVerifierTemplates',
   UPDATE_WALLET_NAME = 'preferences/updateWalletName',
 }
 
@@ -138,6 +139,21 @@ export const reducer = <S extends State>(state: S, action: ReducerAction<Dispatc
       const preferences = {
         ...state.preferences,
         useConnectionInviterCapability: choice,
+      }
+      const newState = {
+        ...state,
+        preferences,
+      }
+
+      AsyncStorage.setItem(LocalStorageKeys.Preferences, JSON.stringify(preferences))
+
+      return newState
+    }
+    case PreferencesDispatchAction.USE_DEV_VERIFIER_TEMPLATES: {
+      const choice = (action?.payload ?? []).pop() ?? false
+      const preferences = {
+        ...state.preferences,
+        useDevVerifierTemplates: choice,
       }
       const newState = {
         ...state,

--- a/packages/legacy/core/App/contexts/store.tsx
+++ b/packages/legacy/core/App/contexts/store.tsx
@@ -41,6 +41,7 @@ export const defaultState: State = {
     useBiometry: false,
     useVerifierCapability: false,
     useConnectionInviterCapability: false,
+    useDevVerifierTemplates:false,
     walletName: generateRandomWalletName(),
   },
   tours: {

--- a/packages/legacy/core/App/contexts/store.tsx
+++ b/packages/legacy/core/App/contexts/store.tsx
@@ -41,7 +41,7 @@ export const defaultState: State = {
     useBiometry: false,
     useVerifierCapability: false,
     useConnectionInviterCapability: false,
-    useDevVerifierTemplates:false,
+    useDevVerifierTemplates: false,
     walletName: generateRandomWalletName(),
   },
   tours: {

--- a/packages/legacy/core/App/localization/en/index.ts
+++ b/packages/legacy/core/App/localization/en/index.ts
@@ -408,7 +408,7 @@ const translation = {
     "ShareFollowingInformation_other": "is sharing the following information from {{count}} credentials.",
     "DeclineBulletPoint1": "Organizations and services require that you prove you're eligible to continue with their service or access.",
     "DeclineBulletPoint2": "In order to receive the proof request again, you will need to restart the process with the service.",
-    "DeclineBulletPoint3": "Are you sure you want to decline this proof request?",  
+    "DeclineBulletPoint3": "Are you sure you want to decline this proof request?",
   },
   "Settings": {
     "Version": "Version",
@@ -481,7 +481,7 @@ const translation = {
     "ConnectionInvitation": "Connection Invitation",
     "CreateConnectionInvitation": "Create a connection invitation",
     "AttemptLockout": "Temporarily Locked",
-    "OnTheWay":'On The Way',
+    "OnTheWay": 'On The Way',
     "Declined": 'Declined',
     "UseBiometry": 'Use Biometry',
     "RecreatePIN": 'Change PIN',
@@ -527,7 +527,9 @@ const translation = {
   },
   "Verifier": {
     "UseVerifierCapability": "Use Verifier capability?",
+    "UseDevVerifierTemplates": "Use development verifier templates?",
     "Toggle": "Toggle Verifier Capability",
+    "ToggleDevTemplates": "Toggle Verifier Development Templates",
     "ProcessingProof": "Just a moment...",
     "ZeroKnowledgeProof": "Zero-knowledge proof",
     "Parameterizable": "Parameterizable",

--- a/packages/legacy/core/App/localization/fr/index.ts
+++ b/packages/legacy/core/App/localization/fr/index.ts
@@ -517,7 +517,9 @@ const translation = {
     },
     "Verifier": {
         "UseVerifierCapability": "Utiliser la fonctionnalité Verifier?",
+        "UseDevVerifierTemplates": "Use development verifier templates? (FR)",
         "Toggle": "Basculer la capacité de vérification",
+        "ToggleDevTemplates": "Toggle Verifier Development Templates (FR)",
         "ProcessingProof": "Juste un moment...",
         "ZeroKnowledgeProof": "Preuve zéro connaissance",
         "Parameterizable": "Paramétrable",

--- a/packages/legacy/core/App/localization/pt-br/index.ts
+++ b/packages/legacy/core/App/localization/pt-br/index.ts
@@ -492,7 +492,9 @@ const translation = {
   },
   "Verifier": {
     "UseVerifierCapability": "Usar o recurso Verificador?",
+    "UseDevVerifierTemplates": "Use development verifier templates? (PB)",
     "Toggle": "Alternar capacidade do verificador",
+    "ToggleDevTemplates": "Toggle Verifier Development Templates (PB)",
     "ProcessingProof": "Um momento...",
     "ZeroKnowledgeProof": "Prova de conhecimento Zero",
     "Parameterizable": "Parametrizável",

--- a/packages/legacy/core/App/screens/Developer.tsx
+++ b/packages/legacy/core/App/screens/Developer.tsx
@@ -45,6 +45,14 @@ const Developer: React.FC = () => {
   })
 
   const toggleVerifierCapabilitySwitch = () => {
+    // if verifier feature is switched off then also turn off the dev templates
+    if(useVerifierCapability){
+      dispatch({
+        type: DispatchAction.USE_DEV_VERIFIER_TEMPLATES,
+        payload: [false]
+      })
+      setDevVerifierTemplates(false)
+    }
     dispatch({
       type: DispatchAction.USE_VERIFIER_CAPABILITY,
       payload: [!useVerifierCapability],
@@ -59,13 +67,21 @@ const Developer: React.FC = () => {
     })
     setConnectionInviterCapability((previousState) => !previousState)
   }
-  
-  const toggleDevVerifierTemplatesSwitch = () =>{
+
+  const toggleDevVerifierTemplatesSwitch = () => {
+    // if we switch on dev templates we can assume the user also wants to enable the verifier capability
+    if (!useDevVerifierTemplates) {
+      dispatch({
+        type: DispatchAction.USE_VERIFIER_CAPABILITY,
+        payload: [true],
+      })
+      setUseVerifierCapability(true)
+    }
     dispatch({
-      type:DispatchAction.USE_DEV_VERIFIER_TEMPLATES,
+      type: DispatchAction.USE_DEV_VERIFIER_TEMPLATES,
       payload: [!useDevVerifierTemplates]
     })
-    setDevVerifierTemplates((previousState)=> !previousState)
+    setDevVerifierTemplates((previousState) => !previousState)
   }
 
   return (

--- a/packages/legacy/core/App/screens/Developer.tsx
+++ b/packages/legacy/core/App/screens/Developer.tsx
@@ -46,10 +46,10 @@ const Developer: React.FC = () => {
 
   const toggleVerifierCapabilitySwitch = () => {
     // if verifier feature is switched off then also turn off the dev templates
-    if(useVerifierCapability){
+    if (useVerifierCapability) {
       dispatch({
         type: DispatchAction.USE_DEV_VERIFIER_TEMPLATES,
-        payload: [false]
+        payload: [false],
       })
       setDevVerifierTemplates(false)
     }
@@ -79,7 +79,7 @@ const Developer: React.FC = () => {
     }
     dispatch({
       type: DispatchAction.USE_DEV_VERIFIER_TEMPLATES,
-      payload: [!useDevVerifierTemplates]
+      payload: [!useDevVerifierTemplates],
     })
     setDevVerifierTemplates((previousState) => !previousState)
   }

--- a/packages/legacy/core/App/screens/Developer.tsx
+++ b/packages/legacy/core/App/screens/Developer.tsx
@@ -16,6 +16,8 @@ const Developer: React.FC = () => {
     !!store.preferences.useConnectionInviterCapability
   )
 
+  const [useDevVerifierTemplates, setDevVerifierTemplates] = useState(!!store.preferences.useDevVerifierTemplates)
+
   const styles = StyleSheet.create({
     container: {
       marginTop: 50,
@@ -56,6 +58,14 @@ const Developer: React.FC = () => {
       payload: [!useConnectionInviterCapability],
     })
     setConnectionInviterCapability((previousState) => !previousState)
+  }
+  
+  const toggleDevVerifierTemplatesSwitch = () =>{
+    dispatch({
+      type:DispatchAction.USE_DEV_VERIFIER_TEMPLATES,
+      payload: [!useDevVerifierTemplates]
+    })
+    setDevVerifierTemplates((previousState)=> !previousState)
   }
 
   return (
@@ -100,6 +110,25 @@ const Developer: React.FC = () => {
             ios_backgroundColor={ColorPallet.grayscale.lightGrey}
             onValueChange={toggleConnectionInviterCapabilitySwitch}
             value={useConnectionInviterCapability}
+          />
+        </Pressable>
+      </View>
+      <View style={styles.settingContainer}>
+        <View style={{ flex: 1 }}>
+          <Text style={styles.settingLabelText}>{t('Verifier.UseDevVerifierTemplates')}</Text>
+        </View>
+        <Pressable
+          style={styles.settingSwitchContainer}
+          accessibilityLabel={t('Verifier.ToggleDevTemplates')}
+          accessibilityRole={'switch'}
+          testID={testIdWithKey('ToggleDevVerifierTemplatesSwitch')}
+        >
+          <Switch
+            trackColor={{ false: ColorPallet.grayscale.lightGrey, true: ColorPallet.brand.primaryDisabled }}
+            thumbColor={useDevVerifierTemplates ? ColorPallet.brand.primary : ColorPallet.grayscale.mediumGrey}
+            ios_backgroundColor={ColorPallet.grayscale.lightGrey}
+            onValueChange={toggleDevVerifierTemplatesSwitch}
+            value={useDevVerifierTemplates}
           />
         </Pressable>
       </View>

--- a/packages/legacy/core/App/screens/ListProofRequests.tsx
+++ b/packages/legacy/core/App/screens/ListProofRequests.tsx
@@ -8,12 +8,12 @@ import Icon from 'react-native-vector-icons/MaterialIcons'
 import { ProofRequestTemplate, hasPredicates, isParameterizable } from '../../verifier'
 import EmptyList from '../components/misc/EmptyList'
 import { useConfiguration } from '../contexts/configuration'
+import { useStore } from '../contexts/store'
 import { useTheme } from '../contexts/theme'
 import { useTemplates } from '../hooks/proof-request-templates'
 import { ProofRequestsStackParams, Screens } from '../types/navigators'
 import { MetaOverlay, OverlayType } from '../types/oca'
 import { testIdWithKey } from '../utils/testable'
-import { useStore } from '../contexts/store'
 
 interface ProofRequestsCardProps {
   navigation: StackNavigationProp<ProofRequestsStackParams>
@@ -118,7 +118,9 @@ const ListProofRequests: React.FC<ListProofRequestsProps> = ({ navigation, route
   const { connectionId } = route?.params
 
   // if useDevVerifierTemplates not set then exclude dev templates
-  const proofRequestTemplates = useTemplates().filter(tem => store.preferences.useDevVerifierTemplates || !tem.devOnly)
+  const proofRequestTemplates = useTemplates().filter(
+    (tem) => store.preferences.useDevVerifierTemplates || !tem.devOnly
+  )
 
   return (
     <SafeAreaView style={style.container} edges={['left', 'right']}>

--- a/packages/legacy/core/App/screens/ListProofRequests.tsx
+++ b/packages/legacy/core/App/screens/ListProofRequests.tsx
@@ -13,6 +13,7 @@ import { useTemplates } from '../hooks/proof-request-templates'
 import { ProofRequestsStackParams, Screens } from '../types/navigators'
 import { MetaOverlay, OverlayType } from '../types/oca'
 import { testIdWithKey } from '../utils/testable'
+import { useStore } from '../contexts/store'
 
 interface ProofRequestsCardProps {
   navigation: StackNavigationProp<ProofRequestsStackParams>
@@ -104,6 +105,7 @@ type ListProofRequestsProps = StackScreenProps<ProofRequestsStackParams, Screens
 const ListProofRequests: React.FC<ListProofRequestsProps> = ({ navigation, route }) => {
   const { t } = useTranslation()
   const { ColorPallet } = useTheme()
+  const [store] = useStore()
 
   const style = StyleSheet.create({
     container: {
@@ -115,7 +117,8 @@ const ListProofRequests: React.FC<ListProofRequestsProps> = ({ navigation, route
 
   const { connectionId } = route?.params
 
-  const proofRequestTemplates = useTemplates()
+  // if useDevVerifierTemplates not set then exclude dev templates
+  const proofRequestTemplates = useTemplates().filter(tem => store.preferences.useDevVerifierTemplates || !tem.devOnly)
 
   return (
     <SafeAreaView style={style.container} edges={['left', 'right']}>

--- a/packages/legacy/core/App/types/state.ts
+++ b/packages/legacy/core/App/types/state.ts
@@ -16,6 +16,7 @@ export interface Preferences {
   developerModeEnabled: boolean
   useVerifierCapability?: boolean
   useConnectionInviterCapability?: boolean
+  useDevVerifierTemplates?: boolean
   walletName: string
 }
 

--- a/packages/legacy/core/__tests__/screens/Developer.test.tsx
+++ b/packages/legacy/core/__tests__/screens/Developer.test.tsx
@@ -28,8 +28,10 @@ describe('Developer screen', () => {
 
     const VerifierToggle = await findByTestId(testIdWithKey('ToggleVerifierCapability'))
     const ConnectionToggle = await findByTestId(testIdWithKey('ToggleConnectionInviterCapabilitySwitch'))
+    const DevVerifierToggle = await findByTestId(testIdWithKey('ToggleDevVerifierTemplatesSwitch'))
 
     expect(VerifierToggle).not.toBe(null)
     expect(ConnectionToggle).not.toBe(null)
+    expect(DevVerifierToggle).not.toBe(null)
   })
 })

--- a/packages/legacy/core/__tests__/screens/__snapshots__/Developer.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/Developer.test.tsx.snap
@@ -185,5 +185,83 @@ exports[`Developer screen screen renders correctly 1`] = `
       />
     </View>
   </View>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+        "marginHorizontal": 10,
+        "marginVertical": 10,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
+      <Text
+        style={
+          Object {
+            "color": "#FFFFFF",
+            "fontSize": 18,
+            "fontWeight": "bold",
+            "marginRight": 10,
+            "textAlign": "left",
+          }
+        }
+      >
+        Verifier.UseDevVerifierTemplates
+      </Text>
+    </View>
+    <View
+      accessibilityLabel="Verifier.ToggleDevTemplates"
+      accessibilityRole="switch"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "justifyContent": "center",
+        }
+      }
+      testID="com.ariesbifold:id/ToggleDevVerifierTemplatesSwitch"
+    >
+      <RCTSwitch
+        accessibilityRole="switch"
+        onChange={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        onTintColor="rgba(53, 130, 63, 0.35)"
+        style={
+          Array [
+            Object {
+              "height": 31,
+              "width": 51,
+            },
+            Object {
+              "backgroundColor": "#D3D3D3",
+              "borderRadius": 16,
+            },
+          ]
+        }
+        thumbTintColor="#606060"
+        tintColor="#D3D3D3"
+        value={false}
+      />
+    </View>
+  </View>
 </View>
 `;

--- a/packages/legacy/core/verifier/types/proof-reqeust-template.ts
+++ b/packages/legacy/core/verifier/types/proof-reqeust-template.ts
@@ -52,5 +52,6 @@ export interface ProofRequestTemplate {
   name: string
   description: string
   version: string
+  devOnly?: boolean
   payload: AnonCredsProofRequestTemplatePayload | DifProofRequestTemplatePayload
 }


### PR DESCRIPTION
# Summary of Changes

Sheldon asked for Unverified Person templates for ease of testing, Decided to make them development only templates so they don't end up in prod.
- Added extra toggle on developer menu to include development templates
- Bound inputs so that when the dev templates toggle is on, verifier feature must be enabled. Conversely when the verifier feature is turned off, dev template must also be turned off 

https://github.com/hyperledger/aries-mobile-agent-react-native/assets/36937407/d2910669-c842-4501-b2da-3d351cb80ed2


# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
