### PR TITLE
feat: restore verifier flow

### DIFF
--- a/packages/legacy/core/App/hooks/connections.ts
+++ b/packages/legacy/core/App/hooks/connections.ts
@@ -20,7 +20,7 @@ export const useOutOfBandById = (oobId: string): OutOfBandRecord | undefined => 
       }
     })
   }
-  return useMemo(() => oob, [oobId, oob])
+  return oob
 }
 
 export const useOutOfBandByConnectionId = (connectionId: string): OutOfBandRecord | undefined => {

--- a/packages/legacy/core/App/hooks/connections.ts
+++ b/packages/legacy/core/App/hooks/connections.ts
@@ -10,23 +10,20 @@ export const useConnectionByOutOfBandId = (outOfBandId: string): ConnectionRecor
   )
 }
 
-export const useOutOfBandByConnectionId = (connectionId: string): OutOfBandRecord | undefined => {
-  const connection = useConnectionById(connectionId)
-  return useOutOfBandById(connection?.outOfBandId ?? "")
-}
-
 export const useOutOfBandById = (oobId: string): OutOfBandRecord | undefined => {
   const { agent } = useAgent()
   const [oob, setOob] = useState<OutOfBandRecord | undefined>(undefined)
   if (!oob) {
-    agent?.oob.findById(oobId).then(res => {
+    agent?.oob.findById(oobId).then((res) => {
       if (res) {
         setOob(res)
       }
     })
   }
-  return useMemo(
-    () => oob,
-    [oobId, oob]
-  )
+  return useMemo(() => oob, [oobId, oob])
+}
+
+export const useOutOfBandByConnectionId = (connectionId: string): OutOfBandRecord | undefined => {
+  const connection = useConnectionById(connectionId)
+  return useOutOfBandById(connection?.outOfBandId ?? '')
 }

--- a/packages/legacy/core/App/hooks/connections.ts
+++ b/packages/legacy/core/App/hooks/connections.ts
@@ -1,11 +1,32 @@
-import { ConnectionRecord } from '@aries-framework/core'
-import { useConnections } from '@aries-framework/react-hooks'
-import { useMemo } from 'react'
+import { ConnectionRecord, OutOfBandRecord } from '@aries-framework/core'
+import { useAgent, useConnectionById, useConnections } from '@aries-framework/react-hooks'
+import { useMemo, useState } from 'react'
 
 export const useConnectionByOutOfBandId = (outOfBandId: string): ConnectionRecord | undefined => {
   const { records: connections } = useConnections()
   return useMemo(
     () => connections.find((connection: ConnectionRecord) => connection.outOfBandId === outOfBandId),
     [connections, outOfBandId]
+  )
+}
+
+export const useOutOfBandByConnectionId = (connectionId: string): OutOfBandRecord | undefined => {
+  const connection = useConnectionById(connectionId)
+  return useOutOfBandById(connection?.outOfBandId ?? "")
+}
+
+export const useOutOfBandById = (oobId: string): OutOfBandRecord | undefined => {
+  const { agent } = useAgent()
+  const [oob, setOob] = useState<OutOfBandRecord | undefined>(undefined)
+  if (!oob) {
+    agent?.oob.findById(oobId).then(res => {
+      if (res) {
+        setOob(res)
+      }
+    })
+  }
+  return useMemo(
+    () => oob,
+    [oobId, oob]
   )
 }

--- a/packages/legacy/core/App/screens/Connection.tsx
+++ b/packages/legacy/core/App/screens/Connection.tsx
@@ -1,9 +1,8 @@
-import { DidExchangeState } from '@aries-framework/core'
-import { useConnectionById, useAgent } from '@aries-framework/react-hooks'
+import { useConnectionById } from '@aries-framework/react-hooks'
 import { StackScreenProps } from '@react-navigation/stack'
-import React, { useEffect, useReducer } from 'react'
+import React, { useCallback, useEffect, useMemo, useReducer, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Modal, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { AccessibilityInfo, Modal, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import Button, { ButtonType } from '../components/buttons/Button'
@@ -12,6 +11,9 @@ import { useTheme } from '../contexts/theme'
 import { useNotifications } from '../hooks/notifications'
 import { Screens, TabStacks, DeliveryStackParams } from '../types/navigators'
 import { testIdWithKey } from '../utils/testable'
+import { useConfiguration } from '../contexts/configuration'
+import { useOutOfBandByConnectionId } from '../hooks/connections'
+import { useFocusEffect } from '@react-navigation/native'
 
 type ConnectionProps = StackScreenProps<DeliveryStackParams, Screens.Connection>
 
@@ -20,6 +22,7 @@ type MergeFunction = (current: LocalState, next: Partial<LocalState>) => LocalSt
 type LocalState = {
   isVisible: boolean
   isInitialized: boolean
+  notificationRecord?: any
   shouldShowDelayMessage: boolean
   connectionIsActive: boolean
 }
@@ -28,21 +31,22 @@ const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
   // TODO(jl): When implementing goal codes the `autoRedirectConnectionToHome`
   // logic should be: if this property is set, rather than showing the
   // delay message, the user should be redirected to the home screen.
-  // const { connectionTimerDelay } = useConfiguration()
-  // const connTimerDelay = connectionTimerDelay ?? 10000 // in ms
+  const { connectionTimerDelay } = useConfiguration()
+  const connTimerDelay = connectionTimerDelay ?? 10000 // in ms
 
   if (!navigation || !route) {
     throw new Error('Connection route props were not set properly')
   }
 
-  const { connectionId } = route.params
-  // const timerRef = useRef<NodeJS.Timeout | null>(null)
+  const { connectionId, threadId } = route.params
+  const timerRef = useRef<NodeJS.Timeout | null>(null)
   const connection = connectionId ? useConnectionById(connectionId) : undefined
-  const { agent } = useAgent()
   const { t } = useTranslation()
   const { notifications } = useNotifications()
   const { ColorPallet, TextTheme } = useTheme()
   const { ConnectionLoading } = useAnimatedComponents()
+  const oobRecord = useOutOfBandByConnectionId(connectionId ?? "")
+  const goalCode = oobRecord?.outOfBandInvitation.goalCode
   const styles = StyleSheet.create({
     container: {
       height: '100%',
@@ -77,23 +81,23 @@ const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
     connectionIsActive: false,
   })
 
-  // const startTimer = () => {
-  //   if (!state.isInitialized) {
-  //     timerRef.current = setTimeout(() => {
-  //       dispatch({ shouldShowDelayMessage: true })
-  //       timerRef.current = null
-  //     }, connTimerDelay)
+  const startTimer = () => {
+    if (!state.isInitialized) {
+      timerRef.current = setTimeout(() => {
+        dispatch({ shouldShowDelayMessage: true })
+        timerRef.current = null
+      }, connTimerDelay)
 
-  //     dispatch({ isInitialized: true })
-  //   }
-  // }
+      dispatch({ isInitialized: true })
+    }
+  }
 
-  // const abortTimer = () => {
-  //   if (timerRef.current) {
-  //     clearTimeout(timerRef.current)
-  //     timerRef.current = null
-  //   }
-  // }
+  const abortTimer = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }
 
   const onDismissModalTouched = () => {
     dispatch({ shouldShowDelayMessage: false, isVisible: false })
@@ -101,41 +105,51 @@ const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
   }
 
   useEffect(() => {
-    // Wait for OOB proof notification to arrive.
-    if (!connection || !connectionId) {
-      return
+    if (state.shouldShowDelayMessage && !state.notificationRecord) {
+      AccessibilityInfo.announceForAccessibility(t('Connection.TakingTooLong'))
     }
+  }, [state.shouldShowDelayMessage])
 
-    // Note: V1 connections are not required to enter the `Completed` state and may
-    // remain at `RequestSent` indefinitely. This is a known issue that is addressed
-    // in higher protocol versions.
-    if (connection.state === DidExchangeState.Completed || connection.state === DidExchangeState.RequestSent) {
-      dispatch({ connectionIsActive: true })
-      agent?.mediationRecipient.initiateMessagePickup()
-
+  useEffect(() => {
+    if (connectionId && oobRecord && (!goalCode || (!goalCode.startsWith("aries.vc.verify") && !goalCode.startsWith("aries.vc.issue")))) {
       // No goal code, we don't know what to expect next,
       // navigate to the chat screen.
       navigation.navigate(Screens.Chat, { connectionId })
       dispatch({ isVisible: false })
     }
-  }, [connection])
+    if (state.notificationRecord && goalCode) {
+      if (goalCode.startsWith("aries.vc.issue")) {
+        navigation.navigate(Screens.CredentialOffer, { credentialId: state.notificationRecord.id })
+      } else if (goalCode.startsWith("aries.vc.verify")) {
+        navigation.navigate(Screens.ProofRequest, { proofId: state.notificationRecord.id })
+      } else {
+        throw new Error('Unhandled notification type')
+      }
+    }
+  }, [connection, goalCode, state.notificationRecord])
 
-  // useMemo(() => {
-  //   startTimer()
-  //   return () => abortTimer
-  // }, [])
+  useMemo(() => {
+    startTimer()
+    return () => abortTimer
+  }, [])
 
-  // useFocusEffect(
-  //   useCallback(() => {
-  //     console.log('************* FOCUS *************')
-  //     startTimer()
-  //     return () => abortTimer
-  //   }, [])
-  // )
+  useFocusEffect(
+    useCallback(() => {
+      console.log('************* FOCUS *************')
+      startTimer()
+      return () => abortTimer
+    }, [])
+  )
 
   useEffect(() => {
     if (state.isVisible) {
       for (const notification of notifications) {
+        if (!state.notificationRecord && ((connectionId && notification.connectionId === connectionId) ||
+          (threadId && notification.threadId == threadId))
+        ) {
+          dispatch({ notificationRecord: notification, isVisible: false })
+          break
+        }
         if (!connection && notification.state === 'request-received') {
           navigation.navigate(Screens.ProofRequest, { proofId: notification.id })
           dispatch({ isVisible: false })

--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -22,6 +22,7 @@ import { EventTypes } from '../constants'
 import { useAnimatedComponents } from '../contexts/animated-components'
 import { useNetwork } from '../contexts/network'
 import { useTheme } from '../contexts/theme'
+import { useOutOfBandByConnectionId } from '../hooks/connections'
 import { BifoldError } from '../types/error'
 import { NotificationStackParams, Screens, TabStacks } from '../types/navigators'
 import { ProofCredentialItems } from '../types/record'
@@ -31,7 +32,6 @@ import { mergeAttributesAndPredicates, processProofAttributes, processProofPredi
 import { testIdWithKey } from '../utils/testable'
 
 import ProofRequestAccept from './ProofRequestAccept'
-import { useOutOfBandByConnectionId } from '../hooks/connections'
 
 type ProofRequestProps = StackScreenProps<NotificationStackParams, Screens.ProofRequest>
 type Fields = Record<string, AnonCredsRequestedAttributeMatch[] | AnonCredsRequestedPredicateMatch[]>
@@ -57,7 +57,7 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
   const { ColorPallet, ListItems, TextTheme } = useTheme()
   const { RecordLoading } = useAnimatedComponents()
 
-  const goalCode = useOutOfBandByConnectionId(proof?.connectionId ?? "")?.outOfBandInvitation.goalCode
+  const goalCode = useOutOfBandByConnectionId(proof?.connectionId ?? '')?.outOfBandInvitation.goalCode
 
   const styles = StyleSheet.create({
     pageContainer: {
@@ -144,26 +144,26 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
             // We should ignore the key, if the value is undefined. For now this is a workaround.
             ...(hasIndy
               ? {
-                indy: {
-                  // Setting `filterByNonRevocationRequirements` to `false` returns all
-                  // credentials even if they are revokable (and revoked). We need this to
-                  // be able to show why a proof cannot be satisfied. Otherwise we can only
-                  // show failure.
-                  filterByNonRevocationRequirements: false,
-                },
-              }
+                  indy: {
+                    // Setting `filterByNonRevocationRequirements` to `false` returns all
+                    // credentials even if they are revokable (and revoked). We need this to
+                    // be able to show why a proof cannot be satisfied. Otherwise we can only
+                    // show failure.
+                    filterByNonRevocationRequirements: false,
+                  },
+                }
               : {}),
 
             ...(hasAnonCreds
               ? {
-                anoncreds: {
-                  // Setting `filterByNonRevocationRequirements` to `false` returns all
-                  // credentials even if they are revokable (and revoked). We need this to
-                  // be able to show why a proof cannot be satisfied. Otherwise we can only
-                  // show failure.
-                  filterByNonRevocationRequirements: false,
-                },
-              }
+                  anoncreds: {
+                    // Setting `filterByNonRevocationRequirements` to `false` returns all
+                    // credentials even if they are revokable (and revoked). We need this to
+                    // be able to show why a proof cannot be satisfied. Otherwise we can only
+                    // show failure.
+                    filterByNonRevocationRequirements: false,
+                  },
+                }
               : {}),
           },
         })

--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -31,6 +31,7 @@ import { mergeAttributesAndPredicates, processProofAttributes, processProofPredi
 import { testIdWithKey } from '../utils/testable'
 
 import ProofRequestAccept from './ProofRequestAccept'
+import { useOutOfBandByConnectionId } from '../hooks/connections'
 
 type ProofRequestProps = StackScreenProps<NotificationStackParams, Screens.ProofRequest>
 type Fields = Record<string, AnonCredsRequestedAttributeMatch[] | AnonCredsRequestedPredicateMatch[]>
@@ -55,13 +56,8 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
   const [declineModalVisible, setDeclineModalVisible] = useState(false)
   const { ColorPallet, ListItems, TextTheme } = useTheme()
   const { RecordLoading } = useAnimatedComponents()
-  const [goalCode, setGoalCode] = useState<string>()
 
-  const oobRecord = connection?.outOfBandId ? agent?.oob.findById(connection.outOfBandId) : undefined
-
-  oobRecord?.then((rec) => {
-    setGoalCode(rec?.outOfBandInvitation.goalCode)
-  })
+  const goalCode = useOutOfBandByConnectionId(proof?.connectionId ?? "")?.outOfBandInvitation.goalCode
 
   const styles = StyleSheet.create({
     pageContainer: {
@@ -148,26 +144,26 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
             // We should ignore the key, if the value is undefined. For now this is a workaround.
             ...(hasIndy
               ? {
-                  indy: {
-                    // Setting `filterByNonRevocationRequirements` to `false` returns all
-                    // credentials even if they are revokable (and revoked). We need this to
-                    // be able to show why a proof cannot be satisfied. Otherwise we can only
-                    // show failure.
-                    filterByNonRevocationRequirements: false,
-                  },
-                }
+                indy: {
+                  // Setting `filterByNonRevocationRequirements` to `false` returns all
+                  // credentials even if they are revokable (and revoked). We need this to
+                  // be able to show why a proof cannot be satisfied. Otherwise we can only
+                  // show failure.
+                  filterByNonRevocationRequirements: false,
+                },
+              }
               : {}),
 
             ...(hasAnonCreds
               ? {
-                  anoncreds: {
-                    // Setting `filterByNonRevocationRequirements` to `false` returns all
-                    // credentials even if they are revokable (and revoked). We need this to
-                    // be able to show why a proof cannot be satisfied. Otherwise we can only
-                    // show failure.
-                    filterByNonRevocationRequirements: false,
-                  },
-                }
+                anoncreds: {
+                  // Setting `filterByNonRevocationRequirements` to `false` returns all
+                  // credentials even if they are revokable (and revoked). We need this to
+                  // be able to show why a proof cannot be satisfied. Otherwise we can only
+                  // show failure.
+                  filterByNonRevocationRequirements: false,
+                },
+              }
               : {}),
           },
         })
@@ -268,7 +264,6 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
         proofRecordId: proof.id,
         proofFormats: automaticRequestedCreds.proofFormats,
       })
-
       if (proof.connectionId && goalCode && goalCode.endsWith('verify.once')) {
         agent.connections.deleteById(proof.connectionId)
       }

--- a/packages/legacy/core/App/screens/ProofRequesting.tsx
+++ b/packages/legacy/core/App/screens/ProofRequesting.tsx
@@ -15,7 +15,7 @@ import Button, { ButtonType } from '../components/buttons/Button'
 import QRRenderer from '../components/misc/QRRenderer'
 import { EventTypes } from '../constants'
 import { useTheme } from '../contexts/theme'
-import { useConnectionByOutOfBandId } from '../hooks/connections'
+import { useConnectionByOutOfBandId, useOutOfBandByConnectionId } from '../hooks/connections'
 import { useTemplate } from '../hooks/proof-request-templates'
 import { BifoldError } from '../types/error'
 import { ProofRequestsStackParams, Screens } from '../types/navigators'
@@ -51,13 +51,8 @@ const ProofRequesting: React.FC<ProofRequestingProps> = ({ route, navigation }) 
   const record = useConnectionByOutOfBandId(connectionRecordId ?? '')
   const proofRecord = useProofById(proofRecordId ?? '')
   const template = useTemplate(templateId)
-  const [goalCode, setGoalCode] = useState<string>()
 
-  const oobRecord = connectionRecordId ? agent?.oob.findById(connectionRecordId) : undefined
-
-  oobRecord?.then((rec) => {
-    setGoalCode(rec?.outOfBandInvitation.goalCode)
-  })
+  const goalCode = useOutOfBandByConnectionId(record?.id ?? "")?.outOfBandInvitation.goalCode
 
   const styles = StyleSheet.create({
     container: {

--- a/packages/legacy/core/App/screens/ProofRequesting.tsx
+++ b/packages/legacy/core/App/screens/ProofRequesting.tsx
@@ -52,7 +52,7 @@ const ProofRequesting: React.FC<ProofRequestingProps> = ({ route, navigation }) 
   const proofRecord = useProofById(proofRecordId ?? '')
   const template = useTemplate(templateId)
 
-  const goalCode = useOutOfBandByConnectionId(record?.id ?? "")?.outOfBandInvitation.goalCode
+  const goalCode = useOutOfBandByConnectionId(record?.id ?? '')?.outOfBandInvitation.goalCode
 
   const styles = StyleSheet.create({
     container: {

--- a/packages/legacy/core/__mocks__/@aries-framework/react-hooks.ts
+++ b/packages/legacy/core/__mocks__/@aries-framework/react-hooks.ts
@@ -31,12 +31,15 @@ const mockProofModule = {
 const mockMediationRecipient = {
   initiateMessagePickup: jest.fn(),
 }
-
+const mockOobModule = {
+  findById: jest.fn().mockReturnValue(Promise.resolve(null))
+}
 const useAgent = () => ({
   agent: {
     credentials: mockCredentialModule,
     proofs: mockProofModule,
     mediationRecipient: mockMediationRecipient,
+    oob: mockOobModule
   },
 })
 const useCredentialById = jest.fn()

--- a/packages/legacy/core/__tests__/screens/Connection.test.tsx
+++ b/packages/legacy/core/__tests__/screens/Connection.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useConnectionById } from '@aries-framework/react-hooks'
-import { render } from '@testing-library/react-native'
+import { render, waitFor } from '@testing-library/react-native'
 import fs from 'fs'
 import path from 'path'
 import React from 'react'
@@ -10,6 +10,7 @@ import { useNotifications } from '../../App/hooks/notifications'
 import ConnectionModal from '../../App/screens/Connection'
 import configurationContext from '../contexts/configuration'
 import navigationContext from '../contexts/navigation'
+import timeTravel from '../helpers/timetravel'
 
 const proofNotifPath = path.join(__dirname, '../fixtures/proof-notif.json')
 const proofNotif = JSON.parse(fs.readFileSync(proofNotifPath, 'utf8'))
@@ -50,7 +51,7 @@ describe('ConnectionModal Component', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('Navigate to chat when connection present', async () => {
+  test('Updates after delay', async () => {
     // @ts-ignore-next-line
     useConnectionById.mockReturnValueOnce(connection)
     const element = (
@@ -59,13 +60,16 @@ describe('ConnectionModal Component', () => {
       </ConfigurationContext.Provider>
     )
 
-    render(element)
+    const tree = render(element)
 
-    expect(navigationContext.getParent()?.navigate).toBeCalledTimes(1)
-    expect(navigationContext.getParent()?.navigate).toBeCalledWith('Chat', { connectionId: '123' })
+    await waitFor(() => {
+      timeTravel(10000)
+    })
+
+    expect(tree).toMatchSnapshot()
   })
 
-  test('Navigate to Proof when OOB connection', async () => {
+  test('Dismiss on demand', async () => {
     // @ts-ignore-next-line
     useNotifications.mockReturnValueOnce({ total: 1, notifications: [proofNotif] })
     const element = (
@@ -74,11 +78,12 @@ describe('ConnectionModal Component', () => {
       </ConfigurationContext.Provider>
     )
 
-    render(element)
+    const tree = render(element)
 
-    expect(navigationContext.navigate).toBeCalledTimes(1)
-    expect(navigationContext.navigate).toBeCalledWith('Proof Request', {
-      proofId: 'bcd2af54-6021-4389-bb5f-3cc8bbedfb50',
+    await waitFor(() => {
+      timeTravel(10000)
     })
+
+    expect(tree).toMatchSnapshot()
   })
 })

--- a/packages/legacy/core/__tests__/screens/__snapshots__/Connection.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/Connection.test.tsx.snap
@@ -1,5 +1,198 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ConnectionModal Component Dismiss on demand 1`] = `
+<Modal
+  animationType="slide"
+  hardwareAccelerated={false}
+  onRequestClose={[Function]}
+  transparent={true}
+  visible={true}
+>
+  <RNCSafeAreaView
+    style={
+      Object {
+        "backgroundColor": "#000000",
+      }
+    }
+  >
+    <RCTScrollView
+      style={
+        Array [
+          Object {
+            "backgroundColor": "#000000",
+            "height": "100%",
+            "padding": 20,
+          },
+        ]
+      }
+    >
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+              },
+            ]
+          }
+        >
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 26,
+                  "fontWeight": "bold",
+                },
+                Object {
+                  "fontWeight": "normal",
+                  "marginTop": 30,
+                  "textAlign": "center",
+                },
+              ]
+            }
+            testID="com.ariesbifold:id/CredentialOnTheWay"
+          >
+            Connection.JustAMoment
+          </Text>
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "marginTop": 20,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <
+              fill="#FFFFFF"
+              height={130}
+              style={
+                Object {
+                  "position": "absolute",
+                }
+              }
+              width={130}
+            />
+            <View
+              style={
+                Object {
+                  "transform": Array [
+                    Object {
+                      "rotate": "360deg",
+                    },
+                  ],
+                }
+              }
+            >
+              <
+                fill="#FFFFFF"
+                height={250}
+                width={250}
+              />
+            </View>
+          </View>
+        </View>
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 18,
+                "fontWeight": "normal",
+              },
+              Object {
+                "marginTop": 20,
+                "textAlign": "center",
+              },
+            ]
+          }
+          testID="com.ariesbifold:id/TakingTooLong"
+        >
+          Connection.TakingTooLong
+        </Text>
+      </View>
+    </RCTScrollView>
+    <View
+      style={
+        Array [
+          Object {
+            "margin": 20,
+            "marginTop": "auto",
+          },
+        ]
+      }
+    >
+      <View
+        accessibilityLabel="Loading.BackToHome"
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "disabled": false,
+          }
+        }
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "borderColor": "#42803E",
+            "borderRadius": 4,
+            "borderWidth": 2,
+            "opacity": 1,
+            "padding": 16,
+          }
+        }
+        testID="com.ariesbifold:id/BackToHome"
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#42803E",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                  "textAlign": "center",
+                },
+                false,
+                false,
+                false,
+              ]
+            }
+          >
+            Loading.BackToHome
+          </Text>
+        </View>
+      </View>
+    </View>
+  </RNCSafeAreaView>
+</Modal>
+`;
+
 exports[`ConnectionModal Component Renders correctly 1`] = `
 <Modal
   animationType="slide"
@@ -128,6 +321,199 @@ exports[`ConnectionModal Component Renders correctly 1`] = `
         collapsable={false}
         focusable={true}
         nativeID="animatedComponent"
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "borderColor": "#42803E",
+            "borderRadius": 4,
+            "borderWidth": 2,
+            "opacity": 1,
+            "padding": 16,
+          }
+        }
+        testID="com.ariesbifold:id/BackToHome"
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#42803E",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                  "textAlign": "center",
+                },
+                false,
+                false,
+                false,
+              ]
+            }
+          >
+            Loading.BackToHome
+          </Text>
+        </View>
+      </View>
+    </View>
+  </RNCSafeAreaView>
+</Modal>
+`;
+
+exports[`ConnectionModal Component Updates after delay 1`] = `
+<Modal
+  animationType="slide"
+  hardwareAccelerated={false}
+  onRequestClose={[Function]}
+  transparent={true}
+  visible={true}
+>
+  <RNCSafeAreaView
+    style={
+      Object {
+        "backgroundColor": "#000000",
+      }
+    }
+  >
+    <RCTScrollView
+      style={
+        Array [
+          Object {
+            "backgroundColor": "#000000",
+            "height": "100%",
+            "padding": 20,
+          },
+        ]
+      }
+    >
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+              },
+            ]
+          }
+        >
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 26,
+                  "fontWeight": "bold",
+                },
+                Object {
+                  "fontWeight": "normal",
+                  "marginTop": 30,
+                  "textAlign": "center",
+                },
+              ]
+            }
+            testID="com.ariesbifold:id/CredentialOnTheWay"
+          >
+            Connection.JustAMoment
+          </Text>
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "marginTop": 20,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <
+              fill="#FFFFFF"
+              height={130}
+              style={
+                Object {
+                  "position": "absolute",
+                }
+              }
+              width={130}
+            />
+            <View
+              style={
+                Object {
+                  "transform": Array [
+                    Object {
+                      "rotate": "360deg",
+                    },
+                  ],
+                }
+              }
+            >
+              <
+                fill="#FFFFFF"
+                height={250}
+                width={250}
+              />
+            </View>
+          </View>
+        </View>
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 18,
+                "fontWeight": "normal",
+              },
+              Object {
+                "marginTop": 20,
+                "textAlign": "center",
+              },
+            ]
+          }
+          testID="com.ariesbifold:id/TakingTooLong"
+        >
+          Connection.TakingTooLong
+        </Text>
+      </View>
+    </RCTScrollView>
+    <View
+      style={
+        Array [
+          Object {
+            "margin": 20,
+            "marginTop": "auto",
+          },
+        ]
+      }
+    >
+      <View
+        accessibilityLabel="Loading.BackToHome"
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "disabled": false,
+          }
+        }
+        accessible={true}
+        focusable={true}
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}


### PR DESCRIPTION
# Summary of Changes

becuase we didn't have goal codes set up before, when Jason implemented the changes to the connection flow, he had to remove the loading screen functionality in the mobile verifier flow. This PR restores the origional flow and adds a hook to fetch the oob record from a conneciton ID which gives you the goal code. 

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
