### PR TITLE
fix: add iPad and iOS simulator support

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,12 @@
+comment:
+  layout: "header"
+  behavior: "default"
+  max_warnings: 0
+# coverage:
+#   precision: 2
+#   round: down
+#   range: "70...100"
+#   status:
+#     project:
+#       default:
+#         new_uncovered: 80

--- a/packages/legacy/app/ios/ariesbifold.xcodeproj/project.pbxproj
+++ b/packages/legacy/app/ios/ariesbifold.xcodeproj/project.pbxproj
@@ -242,7 +242,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "ariesbifold" */;
+			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "AriesBifold" */;
 			compatibilityVersion = "Xcode 12.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -520,10 +520,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = G9667JTP83;
 				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Pods/Frameworks",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AriesBifold/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -540,8 +537,12 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.reactjs.native.example.AriesBifold;
 				PRODUCT_NAME = AriesBifold;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -555,10 +556,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = G9667JTP83;
 				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Pods/Frameworks",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AriesBifold/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -575,7 +573,11 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.reactjs.native.example.AriesBifold;
 				PRODUCT_NAME = AriesBifold;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;
@@ -636,7 +638,6 @@
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
-					"\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -694,7 +695,6 @@
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
-					"\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
 				MTL_ENABLE_DEBUG_INFO = NO;
@@ -724,7 +724,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "ariesbifold" */ = {
+		83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "AriesBifold" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				83CBBA201A601CBA00E9B192 /* Debug */,

--- a/packages/legacy/core/App/navigators/TabStack.tsx
+++ b/packages/legacy/core/App/navigators/TabStack.tsx
@@ -1,7 +1,7 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Text, useWindowDimensions, View } from 'react-native'
+import { Text, useWindowDimensions, View, StyleSheet } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
@@ -23,8 +23,12 @@ const TabStack: React.FC = () => {
   const { assertConnectedNetwork } = useNetwork()
   const { ColorPallet, TabTheme } = useTheme()
   const { fontScale } = useWindowDimensions()
-
   const showLabels = fontScale * TabTheme.tabBarTextStyle.fontSize < 18
+  const styles = StyleSheet.create({
+    tabBarIcon: {
+      flex: 1,
+    },
+  })
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: ColorPallet.brand.primary }}>
@@ -43,6 +47,7 @@ const TabStack: React.FC = () => {
           name={TabStacks.HomeStack}
           component={HomeStack}
           options={{
+            tabBarIconStyle: styles.tabBarIcon,
             tabBarIcon: ({ color, focused }) => (
               <View style={{ ...TabTheme.tabBarContainerStyle, justifyContent: showLabels ? 'flex-end' : 'center' }}>
                 <Icon name={focused ? 'home' : 'home-outline'} color={color} size={30} />
@@ -70,6 +75,7 @@ const TabStack: React.FC = () => {
         <Tab.Screen
           name={TabStacks.ConnectStack}
           options={{
+            tabBarIconStyle: styles.tabBarIcon,
             tabBarIcon: ({ focused }) => (
               <View
                 style={{
@@ -138,6 +144,7 @@ const TabStack: React.FC = () => {
           name={TabStacks.CredentialStack}
           component={CredentialStack}
           options={{
+            tabBarIconStyle: styles.tabBarIcon,
             tabBarIcon: ({ color, focused }) => (
               <AttachTourStep index={2}>
                 <View style={{ ...TabTheme.tabBarContainerStyle, justifyContent: showLabels ? 'flex-end' : 'center' }}>

--- a/packages/legacy/core/App/screens/ProofRequesting.tsx
+++ b/packages/legacy/core/App/screens/ProofRequesting.tsx
@@ -24,9 +24,10 @@ import { testIdWithKey } from '../utils/testable'
 
 type ProofRequestingProps = StackScreenProps<ProofRequestsStackParams, Screens.ProofRequesting>
 
-const windowDimensions = Dimensions.get('window')
-
-const qrContainerSize = windowDimensions.width - 20
+const { width, height } = Dimensions.get('window')
+const aspectRatio = height / width
+const isTablet = aspectRatio < 1.6 // assume 4:3 for tablets
+const qrContainerSize = isTablet ? width - width * 0.3 : width - 20
 const qrSize = qrContainerSize - 20
 
 const ProofRequesting: React.FC<ProofRequestingProps> = ({ route, navigation }) => {
@@ -95,7 +96,6 @@ const ProofRequesting: React.FC<ProofRequestingProps> = ({ route, navigation }) 
       color: ColorPallet.brand.primary,
     },
     qrContainer: {
-      width: qrContainerSize,
       height: qrContainerSize,
       alignItems: 'center',
       justifyContent: 'center',

--- a/packages/legacy/core/__tests__/screens/__snapshots__/ProofRequesting.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/ProofRequesting.test.tsx.snap
@@ -25,7 +25,6 @@ exports[`ProofRequesting Component generate new qr works correctly 1`] = `
             "justifyContent": "center",
             "marginHorizontal": 10,
             "marginTop": 15,
-            "width": 730,
           }
         }
       >
@@ -219,7 +218,6 @@ exports[`ProofRequesting Component renders correctly 1`] = `
             "justifyContent": "center",
             "marginHorizontal": 10,
             "marginTop": 15,
-            "width": 730,
           }
         }
       >
@@ -413,7 +411,6 @@ exports[`ProofRequesting Component renders correctly 2`] = `
             "justifyContent": "center",
             "marginHorizontal": 10,
             "marginTop": 15,
-            "width": 730,
           }
         }
       />


### PR DESCRIPTION
# Summary of Changes

This PR addresses a few changes around adding support for the iOS tablets (iPads) to better alight with the supported Android devices (Android supports tables by default). Changes include:

- enable iPad support for iOS;
- enable iOS simulator support (iPad and iPhone);
- fix the tab button layout on tablets;
- fix the QR size on tablets (somewhat smaller on tablets).



# Related Issues

Please reference here any issue #'s that are relevant to this PR, or simply enter "N/A" if this PR does not relate to any existing issues.

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
