### PR TITLE
Enable references to bundles in oca-bundle.json

### DIFF
--- a/packages/oca/src/legacy/resolver/oca.ts
+++ b/packages/oca/src/legacy/resolver/oca.ts
@@ -188,10 +188,30 @@ export class DefaultOCABundleResolver implements OCABundleResolverType {
   protected bundles: Record<string, OverlayBundle> = {}
   protected options: OCABundleResolverOptions
 
-  public constructor(bundlesData: Record<string, IOverlayBundleData> = {}, options?: OCABundleResolverOptions) {
+  public constructor(
+    bundlesData: Record<string, IOverlayBundleData | string> = {},
+    options?: OCABundleResolverOptions
+  ) {
+    // getting the bundles
     for (const cid in bundlesData) {
       try {
-        this.bundles[cid] = new OverlayBundle(cid, bundlesData[cid])
+        if (typeof bundlesData[cid] !== 'string') {
+          this.bundles[cid] = new OverlayBundle(cid, bundlesData[cid] as IOverlayBundleData)
+        }
+      } catch (error) {
+        // might get an error trying to parse javascript's default value
+      }
+    }
+
+    // getting the bundles from its key
+    for (const cid in bundlesData) {
+      try {
+        if (typeof bundlesData[cid] === 'string') {
+          const tmpBundle: OverlayBundle = this.bundles[bundlesData[cid] as string]
+          if (tmpBundle) {
+            this.bundles[cid] = tmpBundle
+          }
+        }
       } catch (error) {
         // might get an error trying to parse javascript's default value
       }

--- a/packages/oca/src/legacy/resolver/oca.ts
+++ b/packages/oca/src/legacy/resolver/oca.ts
@@ -185,32 +185,19 @@ export class OCABundle implements OCABundleType {
 }
 
 export class DefaultOCABundleResolver implements OCABundleResolverType {
-  protected bundles: Record<string, OverlayBundle> = {}
+  protected bundles: Record<string, OverlayBundle | string> = {}
   protected options: OCABundleResolverOptions
 
   public constructor(
     bundlesData: Record<string, IOverlayBundleData | string> = {},
     options?: OCABundleResolverOptions
   ) {
-    // getting the bundles
     for (const cid in bundlesData) {
       try {
         if (typeof bundlesData[cid] !== 'string') {
           this.bundles[cid] = new OverlayBundle(cid, bundlesData[cid] as IOverlayBundleData)
-        }
-      } catch (error) {
-        // might get an error trying to parse javascript's default value
-      }
-    }
-
-    // getting the bundles from its key
-    for (const cid in bundlesData) {
-      try {
-        if (typeof bundlesData[cid] === 'string') {
-          const tmpBundle: OverlayBundle = this.bundles[bundlesData[cid] as string]
-          if (tmpBundle) {
-            this.bundles[cid] = tmpBundle
-          }
+        } else {
+          this.bundles[cid] = bundlesData[cid] as string
         }
       } catch (error) {
         // might get an error trying to parse javascript's default value
@@ -306,7 +293,9 @@ export class DefaultOCABundleResolver implements OCABundleResolverType {
         if (typeof bundle === 'string') {
           bundle = this.bundles[bundle]
         }
-        return Promise.resolve(new OCABundle(bundle, { ...this.options, language: language ?? this.options.language }))
+        return Promise.resolve(
+          new OCABundle(bundle as OverlayBundle, { ...this.options, language: language ?? this.options.language })
+        )
       }
     }
     return Promise.resolve(undefined)

--- a/packages/oca/src/legacy/resolver/remote-oca.ts
+++ b/packages/oca/src/legacy/resolver/remote-oca.ts
@@ -41,7 +41,7 @@ export class RemoteOCABundleResolver extends DefaultOCABundleResolver {
 
     if (this.bundles[identifier]) {
       return Promise.resolve(
-        new OCABundle(this.bundles[identifier], {
+        new OCABundle(this.bundles[identifier] as OverlayBundle, {
           ...this.options,
           language: language ?? this.options.language,
         })


### PR DESCRIPTION
# Summary of Changes

Add the feature of loading bundle references in bundles json. In oca-bundles.json asset, if the value is a string, it is a reference for another bundle. 

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [X] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [X] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [X] Updated documentation as needed for changed code and new or modified features;
- [X] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
