### PR TITLE
fix: OCA Resolver default branding overlay config fix

### DIFF
--- a/packages/oca/src/legacy/resolver/oca.ts
+++ b/packages/oca/src/legacy/resolver/oca.ts
@@ -205,13 +205,13 @@ export class DefaultOCABundleResolver implements OCABundleResolverType {
     }
 
     this.options = {
-      brandingOverlayType: options?.brandingOverlayType ?? BrandingOverlayType.Branding01,
+      brandingOverlayType: options?.brandingOverlayType ?? BrandingOverlayType.Branding10,
       language: options?.language ?? 'en',
     }
   }
 
   public getBrandingOverlayType(): BrandingOverlayType {
-    return this.options.brandingOverlayType ?? BrandingOverlayType.Branding01
+    return this.options.brandingOverlayType ?? BrandingOverlayType.Branding10
   }
 
   private getDefaultBundle(params: { language?: string; identifiers?: Identifiers; meta?: Meta }) {


### PR DESCRIPTION
# Summary of Changes

Setting the default OCA resolver branding overlay configuration to use the new branding overlay instead of the legacy one.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [X] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [X] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [X] Updated documentation as needed for changed code and new or modified features;
- [X] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
