### PR TITLE
feat: make settings fade in consistent for ios and android

### DIFF
--- a/packages/legacy/core/App/navigators/RootStack.tsx
+++ b/packages/legacy/core/App/navigators/RootStack.tsx
@@ -1,6 +1,6 @@
 import { useAgent } from '@aries-framework/react-hooks'
 import { useNavigation } from '@react-navigation/core'
-import { createStackNavigator, StackNavigationProp } from '@react-navigation/stack'
+import { createStackNavigator, StackCardStyleInterpolator, StackNavigationProp } from '@react-navigation/stack'
 import React, { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { AppState } from 'react-native'
@@ -167,6 +167,13 @@ const RootStack: React.FC = () => {
   const mainStack = () => {
     const Stack = createStackNavigator()
 
+    // This function is to make the fade in behavior of both iOS and Android consistent for the settings menu
+    const forFade: StackCardStyleInterpolator = ({ current }) => ({
+      cardStyle: {
+        opacity: current.progress,
+      },
+    })
+
     return (
       <Stack.Navigator initialRouteName={Screens.Splash} screenOptions={{ ...defaultStackOptions, headerShown: false }}>
         <Stack.Screen name={Screens.Splash} component={splash} />
@@ -177,7 +184,13 @@ const RootStack: React.FC = () => {
           // below is part of the temporary gating of the new scan screen tabs feature
           options={{ presentation: state.preferences.useConnectionInviterCapability ? 'card' : 'modal' }}
         />
-        <Stack.Screen name={Stacks.SettingStack} component={SettingStack} />
+        <Stack.Screen
+          name={Stacks.SettingStack}
+          component={SettingStack}
+          options={{
+            cardStyleInterpolator: forFade,
+          }}
+        />
         <Stack.Screen name={Stacks.ContactStack} component={ContactStack} />
         <Stack.Screen name={Stacks.NotificationStack} component={NotificationStack} />
         <Stack.Screen name={Stacks.ConnectionStack} component={DeliveryStack} />


### PR DESCRIPTION
# Summary of Changes

This PR makes the fade in behaviour of the settings menu consistent for both iOS and Android. Previously only Android faded in and iOS slid from the right.

Here's what it looks like:
![fade_in](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/32586431/75b697b2-f024-4d27-bb1f-4d21b14def68)

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
