### PR TITLE
chore: fixing the export of oca OverlayType and CaptureBaseAttributeType

### DIFF
--- a/packages/oca/src/legacy/resolver/oca.ts
+++ b/packages/oca/src/legacy/resolver/oca.ts
@@ -9,7 +9,7 @@ import {
 } from '../../interfaces'
 import {
   BaseOverlay,
-  BaseOverlayType,
+  OverlayType,
   BrandingOverlay,
   CaptureBase,
   CharacterEncodingOverlay,
@@ -25,8 +25,8 @@ import { parseCredDefFromId } from '../../utils/credential-definition'
 import { Field } from './record'
 
 export enum BrandingOverlayType {
-  Branding01 = BaseOverlayType.Branding01,
-  Branding10 = BaseOverlayType.Branding10,
+  Branding01 = OverlayType.Branding01,
+  Branding10 = OverlayType.Branding10,
 }
 
 export interface CredentialOverlay<T> {
@@ -113,19 +113,19 @@ export class OCABundle implements OCABundleType {
   }
 
   public get characterEncodingOverlay(): CharacterEncodingOverlay | undefined {
-    return this.getOverlay<CharacterEncodingOverlay>(BaseOverlayType.CharacterEncoding10)
+    return this.getOverlay<CharacterEncodingOverlay>(OverlayType.CharacterEncoding10)
   }
 
   public get formatOverlay(): FormatOverlay | undefined {
-    return this.getOverlay<FormatOverlay>(BaseOverlayType.Format10)
+    return this.getOverlay<FormatOverlay>(OverlayType.Format10)
   }
 
   public get labelOverlay(): LabelOverlay | undefined {
-    return this.getOverlay<LabelOverlay>(BaseOverlayType.Label10, this.options.language)
+    return this.getOverlay<LabelOverlay>(OverlayType.Label10, this.options.language)
   }
 
   public get metaOverlay(): MetaOverlay | undefined {
-    return this.getOverlay<MetaOverlay>(BaseOverlayType.Meta10, this.options.language)
+    return this.getOverlay<MetaOverlay>(OverlayType.Meta10, this.options.language)
   }
 
   public get brandingOverlay(): BrandingOverlay | LegacyBrandingOverlay | undefined {
@@ -135,7 +135,7 @@ export class OCABundle implements OCABundleType {
   public buildOverlay(name: string, language: string): MetaOverlay {
     return new MetaOverlay({
       capture_base: '',
-      type: BaseOverlayType.Meta10,
+      type: OverlayType.Meta10,
       name,
       language,
       description: '',
@@ -148,7 +148,7 @@ export class OCABundle implements OCABundleType {
   }
 
   private getOverlay<T extends BaseOverlay>(type: string, language?: string): T | undefined {
-    if (type === BaseOverlayType.CaptureBase10) {
+    if (type === OverlayType.CaptureBase10) {
       return this.bundle.captureBase as unknown as T
     }
     if (language !== undefined) {
@@ -203,7 +203,7 @@ export class DefaultOCABundleResolver implements OCABundleResolverType {
 
     const metaOverlay: IMetaOverlayData = {
       capture_base: '',
-      type: BaseOverlayType.Meta10,
+      type: OverlayType.Meta10,
       name: startCase(
         params.meta?.credName ??
           parseCredDefFromId(params.identifiers?.credentialDefinitionId, params.identifiers?.schemaId)
@@ -226,13 +226,13 @@ export class DefaultOCABundleResolver implements OCABundleResolverType {
 
     const brandingoOverlay01: ILegacyBrandingOverlayData = {
       capture_base: '',
-      type: BaseOverlayType.Branding01,
+      type: OverlayType.Branding01,
       background_color: generateColor(colorHash),
     }
 
     const brandingoOverlay10: IBrandingOverlayData = {
       capture_base: '',
-      type: BaseOverlayType.Branding10,
+      type: OverlayType.Branding10,
       primary_background_color: generateColor(colorHash),
     }
 
@@ -240,7 +240,7 @@ export class DefaultOCABundleResolver implements OCABundleResolverType {
       capture_base: {
         attributes: {},
         classification: '',
-        type: BaseOverlayType.CaptureBase10,
+        type: OverlayType.CaptureBase10,
         flagged_attributes: [],
       },
       overlays: [

--- a/packages/oca/src/types/index.ts
+++ b/packages/oca/src/types/index.ts
@@ -13,8 +13,8 @@ import MetaOverlay from './semantic/MetaOverlay'
 import StandardOverlay from './semantic/StandardOverlay'
 
 export {
-  OverlayType as BaseOverlayType,
-  CaptureBaseAttributeType as BaseType,
+  OverlayType,
+  CaptureBaseAttributeType,
   BaseOverlay,
   CaptureBase,
   OverlayBundle,


### PR DESCRIPTION
# Summary of Changes

Fixing the aries-oca package exports to export `OverlayType` and `CaptureBaseAttributeType` instead of  `BaseOverlayType` and `BaseType`.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [X] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [X] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [X] Updated documentation as needed for changed code and new or modified features;
- [X] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
