### PR TITLE
feat: enable wallet naming via onboarding dev mode

### DIFF
--- a/packages/legacy/core/App/contexts/configuration.tsx
+++ b/packages/legacy/core/App/contexts/configuration.tsx
@@ -42,7 +42,6 @@ export interface ConfigurationContext {
   autoRedirectConnectionToHome?: boolean
   proofRequestTemplates?: Array<ProofRequestTemplate>
   enableTours?: boolean
-  enableWalletNaming?: boolean
 }
 
 export const ConfigurationContext = createContext<ConfigurationContext>(null as unknown as ConfigurationContext)

--- a/packages/legacy/core/App/contexts/reducers/store.ts
+++ b/packages/legacy/core/App/contexts/reducers/store.ts
@@ -41,6 +41,7 @@ enum PreferencesDispatchAction {
   USE_VERIFIER_CAPABILITY = 'preferences/useVerifierCapability',
   USE_CONNECTION_INVITER_CAPABILITY = 'preferences/useConnectionInviterCapability',
   USE_DEV_VERIFIER_TEMPLATES = 'preferences/useDevVerifierTemplates',
+  ENABLE_WALLET_NAMING = 'preferences/enableWalletNaming',
   UPDATE_WALLET_NAME = 'preferences/updateWalletName',
 }
 
@@ -173,6 +174,17 @@ export const reducer = <S extends State>(state: S, action: ReducerAction<Dispatc
       if (!preferences.walletName) {
         preferences.walletName = generateRandomWalletName()
       }
+
+      return {
+        ...state,
+        preferences,
+      }
+    }
+    case PreferencesDispatchAction.ENABLE_WALLET_NAMING: {
+      const choice = (action?.payload ?? []).pop() ?? false
+      const preferences = { ...state.preferences, enableWalletNaming: choice }
+
+      AsyncStorage.setItem(LocalStorageKeys.Preferences, JSON.stringify(preferences))
 
       return {
         ...state,

--- a/packages/legacy/core/App/contexts/store.tsx
+++ b/packages/legacy/core/App/contexts/store.tsx
@@ -42,6 +42,7 @@ export const defaultState: State = {
     useVerifierCapability: false,
     useConnectionInviterCapability: false,
     useDevVerifierTemplates: false,
+    enableWalletNaming: false,
     walletName: generateRandomWalletName(),
   },
   tours: {

--- a/packages/legacy/core/App/defaultConfiguration.ts
+++ b/packages/legacy/core/App/defaultConfiguration.ts
@@ -47,5 +47,4 @@ export const defaultConfiguration: ConfigurationContext = {
   useCustomNotifications: useNotifications,
   proofRequestTemplates: defaultProofRequestTemplates,
   enableTours: false,
-  enableWalletNaming: false,
 }

--- a/packages/legacy/core/App/localization/en/index.ts
+++ b/packages/legacy/core/App/localization/en/index.ts
@@ -517,6 +517,8 @@ const translation = {
     "BackToHome": "Go back to home"
   },
   "NameWallet": {
+    "EnableWalletNaming": "Enable wallet naming?",
+    "ToggleWalletNaming": "Toggle wallet naming",
     "NameYourWallet": "Name your wallet",
     "ThisIsTheName": "This is the name people see when connecting with you.",
     "CharCountTitle": "Character count exceeded",

--- a/packages/legacy/core/App/localization/fr/index.ts
+++ b/packages/legacy/core/App/localization/fr/index.ts
@@ -506,6 +506,8 @@ const translation = {
         "BackToHome": "Retour à l'accueil"
     },
     "NameWallet": {
+        "EnableWalletNaming": "Enable wallet naming? (FR)",
+        "ToggleWalletNaming": "Toggle wallet naming (FR)",
         "NameYourWallet": "Name your wallet (FR)",
         "ThisIsTheName": "This is the name people see when connecting with you. (FR)",
         "CharCountTitle": "Character count exceeded (FR)",

--- a/packages/legacy/core/App/localization/pt-br/index.ts
+++ b/packages/legacy/core/App/localization/pt-br/index.ts
@@ -482,6 +482,8 @@ const translation = {
     "BackToHome": "Voltar para a home"
   },
   "NameWallet": {
+    "EnableWalletNaming": "Enable wallet naming? (PT-BR)",
+    "ToggleWalletNaming": "Toggle wallet naming (PT-BR)",
     "NameYourWallet": "Nome da sua carteira",
     "ThisIsTheName": "Este é o nome que as pessoas verão quando se conectar a você.",
     "CharCountTitle": "Número de caracteres excedido",

--- a/packages/legacy/core/App/navigators/RootStack.tsx
+++ b/packages/legacy/core/App/navigators/RootStack.tsx
@@ -45,7 +45,7 @@ const RootStack: React.FC = () => {
   const theme = useTheme()
   const defaultStackOptions = createDefaultStackOptions(theme)
   const OnboardingTheme = theme.OnboardingTheme
-  const { pages, terms, splash, useBiometry, enableWalletNaming } = useConfiguration()
+  const { pages, terms, splash, useBiometry } = useConfiguration()
   useDeepLinks()
 
   const lockoutUser = async () => {
@@ -284,7 +284,7 @@ const RootStack: React.FC = () => {
     state.onboarding.didAgreeToTerms &&
     state.onboarding.didCompleteTutorial &&
     state.onboarding.didCreatePIN &&
-    (!enableWalletNaming || state.onboarding.didNameWallet) &&
+    (!state.preferences.enableWalletNaming || state.onboarding.didNameWallet) &&
     state.onboarding.didConsiderBiometry
   ) {
     return state.authentication.didAuthenticate ? mainStack() : authStack()

--- a/packages/legacy/core/App/screens/Developer.tsx
+++ b/packages/legacy/core/App/screens/Developer.tsx
@@ -17,6 +17,7 @@ const Developer: React.FC = () => {
   )
 
   const [useDevVerifierTemplates, setDevVerifierTemplates] = useState(!!store.preferences.useDevVerifierTemplates)
+  const [enableWalletNaming, setEnableWalletNaming] = useState(!!store.preferences.enableWalletNaming)
 
   const styles = StyleSheet.create({
     container: {
@@ -84,6 +85,14 @@ const Developer: React.FC = () => {
     setDevVerifierTemplates((previousState) => !previousState)
   }
 
+  const toggleWalletNamingSwitch = () => {
+    dispatch({
+      type: DispatchAction.ENABLE_WALLET_NAMING,
+      payload: [!enableWalletNaming],
+    })
+    setEnableWalletNaming((previousState) => !previousState)
+  }
+
   return (
     <View style={styles.container}>
       <Text style={[TextTheme.normal, { margin: 10 }]}>
@@ -148,6 +157,27 @@ const Developer: React.FC = () => {
           />
         </Pressable>
       </View>
+      {!store.onboarding.didCreatePIN && (
+        <View style={styles.settingContainer}>
+          <View style={{ flex: 1 }}>
+            <Text style={styles.settingLabelText}>{t('NameWallet.EnableWalletNaming')}</Text>
+          </View>
+          <Pressable
+            style={styles.settingSwitchContainer}
+            accessibilityLabel={t('NameWallet.ToggleWalletNaming')}
+            accessibilityRole={'switch'}
+            testID={testIdWithKey('EnableWalletNamingSwitch')}
+          >
+            <Switch
+              trackColor={{ false: ColorPallet.grayscale.lightGrey, true: ColorPallet.brand.primaryDisabled }}
+              thumbColor={enableWalletNaming ? ColorPallet.brand.primary : ColorPallet.grayscale.mediumGrey}
+              ios_backgroundColor={ColorPallet.grayscale.lightGrey}
+              onValueChange={toggleWalletNamingSwitch}
+              value={enableWalletNaming}
+            />
+          </Pressable>
+        </View>
+      )}
     </View>
   )
 }

--- a/packages/legacy/core/App/screens/PINCreate.tsx
+++ b/packages/legacy/core/App/screens/PINCreate.tsx
@@ -60,7 +60,7 @@ const PINCreate: React.FC<PINCreateProps> = ({ setAuthenticated, route }) => {
   const navigation = useNavigation<StackNavigationProp<AuthenticateStackParams>>()
   const [store, dispatch] = useStore()
   const { t } = useTranslation()
-  const { PINSecurity, enableWalletNaming } = useConfiguration()
+  const { PINSecurity } = useConfiguration()
 
   const [PINOneValidations, setPINOneValidations] = useState<PINValidationsType[]>(
     PINCreationValidations(PIN, PINSecurity.rules)
@@ -98,7 +98,7 @@ const PINCreate: React.FC<PINCreateProps> = ({ setAuthenticated, route }) => {
       })
 
       // TODO: Navigate back if in settings
-      if (enableWalletNaming) {
+      if (store.preferences.enableWalletNaming) {
         navigation.dispatch(
           CommonActions.reset({
             index: 0,

--- a/packages/legacy/core/App/screens/Splash.tsx
+++ b/packages/legacy/core/App/screens/Splash.tsx
@@ -72,7 +72,7 @@ const resumeOnboardingAt = (state: StoreOnboardingState, enableWalletNaming: boo
  * of this view.
  */
 const Splash: React.FC = () => {
-  const { indyLedgers, enableWalletNaming } = useConfiguration()
+  const { indyLedgers } = useConfiguration()
   const { setAgent } = useAgent()
   const { t } = useTranslation()
   const [store, dispatch] = useStore()
@@ -149,29 +149,35 @@ const Splash: React.FC = () => {
         if (data) {
           const onboardingState = JSON.parse(data) as StoreOnboardingState
           dispatch({ type: DispatchAction.ONBOARDING_UPDATED, payload: [onboardingState] })
-          if (onboardingComplete(onboardingState) && !attemptData?.lockoutDate) {
-            navigation.dispatch(
-              CommonActions.reset({
-                index: 0,
-                routes: [{ name: Screens.EnterPIN }],
-              })
-            )
-            return
-          } else if (onboardingComplete(onboardingState) && attemptData?.lockoutDate) {
-            // return to lockout screen if lockout date is set
-            navigation.dispatch(
-              CommonActions.reset({
-                index: 0,
-                routes: [{ name: Screens.AttemptLockout }],
-              })
-            )
+          if (onboardingComplete(onboardingState)) {
+            // if they previously completed onboarding before wallet naming was enabled, mark complete
+            if (!store.onboarding.didNameWallet) {
+              dispatch({ type: DispatchAction.DID_NAME_WALLET, payload: [true] })
+            }
+
+            if (!attemptData?.lockoutDate) {
+              navigation.dispatch(
+                CommonActions.reset({
+                  index: 0,
+                  routes: [{ name: Screens.EnterPIN }],
+                })
+              )
+            } else {
+              // return to lockout screen if lockout date is set
+              navigation.dispatch(
+                CommonActions.reset({
+                  index: 0,
+                  routes: [{ name: Screens.AttemptLockout }],
+                })
+              )
+            }
             return
           } else {
             // If onboarding was interrupted we need to pickup from where we left off.
             navigation.dispatch(
               CommonActions.reset({
                 index: 0,
-                routes: [{ name: resumeOnboardingAt(onboardingState, enableWalletNaming) }],
+                routes: [{ name: resumeOnboardingAt(onboardingState, store.preferences.enableWalletNaming) }],
               })
             )
           }

--- a/packages/legacy/core/App/types/state.ts
+++ b/packages/legacy/core/App/types/state.ts
@@ -17,6 +17,7 @@ export interface Preferences {
   useVerifierCapability?: boolean
   useConnectionInviterCapability?: boolean
   useDevVerifierTemplates?: boolean
+  enableWalletNaming: boolean
   walletName: string
 }
 

--- a/packages/legacy/core/__mocks__/@react-native-async-storage/async-storage.js
+++ b/packages/legacy/core/__mocks__/@react-native-async-storage/async-storage.js
@@ -4,4 +4,8 @@ AsyncStorage.getItem = () => {
   return null
 }
 
+AsyncStorage.setItem = () => {
+  return null
+}
+
 export default AsyncStorage

--- a/packages/legacy/core/__mocks__/custom/@react-navigation/core.ts
+++ b/packages/legacy/core/__mocks__/custom/@react-navigation/core.ts
@@ -13,6 +13,7 @@ const navigation = {
   pop: jest.fn(),
   reset: jest.fn(),
   isFocused: () => true,
+  dispatch: jest.fn(),
 }
 
 const useNavigation = () => {

--- a/packages/legacy/core/__tests__/components/NewQRView.test.tsx
+++ b/packages/legacy/core/__tests__/components/NewQRView.test.tsx
@@ -37,12 +37,7 @@ describe('NewQRView Component', () => {
         initialState={{
           ...defaultState,
           preferences: {
-            developerModeEnabled: false,
-            biometryPreferencesUpdated: false,
-            useBiometry: false,
-            useVerifierCapability: false,
-            useConnectionInviterCapability: false,
-            useDevVerifierTemplates: false,
+            ...defaultState.preferences,
             walletName: 'My Wallet - 1234',
           },
         }}

--- a/packages/legacy/core/__tests__/screens/PINChange.test.tsx
+++ b/packages/legacy/core/__tests__/screens/PINChange.test.tsx
@@ -1,13 +1,13 @@
 import { render } from '@testing-library/react-native'
 import React from 'react'
 
-import { AuthContext } from '../../App/contexts/auth'
-import PINCreate from '../../App/screens/PINCreate'
-import authContext from '../contexts/auth'
 import { PINRules } from '../../App/constants'
-import { StoreProvider, defaultState } from '../../App/contexts/store'
+import { AuthContext } from '../../App/contexts/auth'
 import { useConfiguration } from '../../App/contexts/configuration'
+import { StoreProvider, defaultState } from '../../App/contexts/store'
+import PINCreate from '../../App/screens/PINCreate'
 import { testIdWithKey } from '../../App/utils/testable'
+import authContext from '../contexts/auth'
 
 jest.mock('@react-navigation/core', () => {
   return require('../../__mocks__/custom/@react-navigation/core')
@@ -26,15 +26,15 @@ jest.mock('../../App/contexts/configuration', () => ({
 describe('displays a PIN change screen', () => {
   beforeEach(() => {
     // @ts-ignore-next-line
-    useConfiguration.mockReturnValue({ PINSecurity: { rules: PINRules, displayHelper: false }, enableWalletNaming: false })
+    useConfiguration.mockReturnValue({ PINSecurity: { rules: PINRules, displayHelper: false } })
     jest.clearAllMocks()
   })
 
   test('PIN change renders correctly', async () => {
     const route = {
       params: {
-        updatePin: true
-      }
+        updatePin: true,
+      },
     } as any
     const tree = render(
       <StoreProvider

--- a/packages/legacy/core/__tests__/screens/PINCreate.test.tsx
+++ b/packages/legacy/core/__tests__/screens/PINCreate.test.tsx
@@ -1,13 +1,13 @@
 import { render } from '@testing-library/react-native'
 import React from 'react'
 
-import { AuthContext } from '../../App/contexts/auth'
-import PINCreate from '../../App/screens/PINCreate'
-import authContext from '../contexts/auth'
 import { PINRules } from '../../App/constants'
-import { StoreProvider, defaultState } from '../../App/contexts/store'
+import { AuthContext } from '../../App/contexts/auth'
 import { useConfiguration } from '../../App/contexts/configuration'
+import { StoreProvider, defaultState } from '../../App/contexts/store'
+import PINCreate from '../../App/screens/PINCreate'
 import { testIdWithKey } from '../../App/utils/testable'
+import authContext from '../contexts/auth'
 
 jest.mock('@react-navigation/core', () => {
   return require('../../__mocks__/custom/@react-navigation/core')
@@ -26,7 +26,7 @@ jest.mock('../../App/contexts/configuration', () => ({
 describe('displays a PIN create screen', () => {
   beforeEach(() => {
     // @ts-ignore-next-line
-    useConfiguration.mockReturnValue({ PINSecurity: { rules: PINRules, displayHelper: false }, enableWalletNaming: false })
+    useConfiguration.mockReturnValue({ PINSecurity: { rules: PINRules, displayHelper: false } })
     jest.clearAllMocks()
   })
   test('PIN create renders correctly', async () => {

--- a/packages/legacy/core/__tests__/screens/Splash.test.tsx
+++ b/packages/legacy/core/__tests__/screens/Splash.test.tsx
@@ -1,25 +1,32 @@
 import { render } from '@testing-library/react-native'
 import React from 'react'
 
+import { LocalStorageKeys } from '../../App/constants'
 import { AuthContext } from '../../App/contexts/auth'
 import { ConfigurationContext } from '../../App/contexts/configuration'
+import { StoreProvider, defaultState } from '../../App/contexts/store'
 import Splash from '../../App/screens/Splash'
+import AsyncStorage from '../../__mocks__/@react-native-async-storage/async-storage'
 import authContext from '../contexts/auth'
 import configurationContext from '../contexts/configuration'
 
-jest.mock('@react-navigation/core', () => {
-  return require('../../__mocks__/custom/@react-navigation/core')
-})
-jest.mock('@react-navigation/native', () => {
-  return require('../../__mocks__/custom/@react-navigation/native')
-})
 jest.mock('@hyperledger/aries-askar-react-native', () => ({}))
 jest.mock('@hyperledger/anoncreds-react-native', () => ({}))
 jest.mock('@hyperledger/indy-vdr-react-native', () => ({}))
 jest.mock('react-native-fs', () => ({}))
+const mockedDispatch = jest.fn()
+jest.mock('@react-navigation/core', () => {
+  const actualNav = jest.requireActual('@react-navigation/core')
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      dispatch: mockedDispatch,
+    }),
+  }
+})
 
 describe('Splash Screen', () => {
-  test('Renders correctly', () => {
+  test('Renders default correctly', () => {
     const tree = render(
       <ConfigurationContext.Provider value={configurationContext}>
         <AuthContext.Provider value={authContext}>
@@ -29,6 +36,66 @@ describe('Splash Screen', () => {
     )
 
     expect(tree).toMatchSnapshot()
-    expect(true).toBe(true)
+  })
+
+  test('Starts onboarding correctly', async () => {
+    AsyncStorage.getItem = jest.fn().mockImplementation((key: string) => {
+      console.log('getItem called with:', key)
+      switch (key) {
+        case LocalStorageKeys.LoginAttempts:
+          return JSON.stringify({
+            servedPenalty: true,
+            loginAttempts: 0,
+          })
+        case LocalStorageKeys.Preferences:
+          return JSON.stringify({
+            useBiometry: false,
+            biometryPreferencesUpdated: false,
+            developerModeEnabled: false,
+            useVerifierCapability: false,
+            useConnectionInviterCapability: false,
+            useDevVerifierTemplates: false,
+            enableWalletNaming: true,
+            walletName: 'My Wallet 1234',
+          })
+        case LocalStorageKeys.Migration:
+          return JSON.stringify({
+            didMigrateToAskar: true,
+          })
+        case LocalStorageKeys.Onboarding:
+          return JSON.stringify({
+            didCompleteTutorial: false,
+            didAgreeToTerms: false,
+            didCreatePIN: false,
+            didConsiderBiometry: false,
+            didNameWallet: false,
+          })
+        case LocalStorageKeys.Tours:
+          return JSON.stringify({
+            seenToursPrompt: false,
+            enableTours: false,
+            seenHomeTour: false,
+            seenCredentialsTour: false,
+            seenCredentialOfferTour: false,
+            seenProofRequestTour: false,
+          })
+      }
+    })
+
+    render(
+      <StoreProvider
+        initialState={{
+          ...defaultState,
+        }}
+      >
+        <ConfigurationContext.Provider value={configurationContext}>
+          <AuthContext.Provider value={authContext}>
+            <Splash />
+          </AuthContext.Provider>
+        </ConfigurationContext.Provider>
+      </StoreProvider>
+    )
+
+    expect(mockedDispatch).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/legacy/core/__tests__/screens/Splash.test.tsx
+++ b/packages/legacy/core/__tests__/screens/Splash.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react-native'
+import { render, waitFor } from '@testing-library/react-native'
 import React from 'react'
 
 import { LocalStorageKeys } from '../../App/constants'
@@ -40,7 +40,6 @@ describe('Splash Screen', () => {
 
   test('Starts onboarding correctly', async () => {
     AsyncStorage.getItem = jest.fn().mockImplementation((key: string) => {
-      console.log('getItem called with:', key)
       switch (key) {
         case LocalStorageKeys.LoginAttempts:
           return JSON.stringify({
@@ -81,21 +80,22 @@ describe('Splash Screen', () => {
           })
       }
     })
+    await waitFor(() => {
+      render(
+        <StoreProvider
+          initialState={{
+            ...defaultState,
+          }}
+        >
+          <ConfigurationContext.Provider value={configurationContext}>
+            <AuthContext.Provider value={authContext}>
+              <Splash />
+            </AuthContext.Provider>
+          </ConfigurationContext.Provider>
+        </StoreProvider>
+      )
+    })
 
-    render(
-      <StoreProvider
-        initialState={{
-          ...defaultState,
-        }}
-      >
-        <ConfigurationContext.Provider value={configurationContext}>
-          <AuthContext.Provider value={authContext}>
-            <Splash />
-          </AuthContext.Provider>
-        </ConfigurationContext.Provider>
-      </StoreProvider>
-    )
-
-    expect(mockedDispatch).toHaveBeenCalledTimes(1)
+    expect(mockedDispatch).toHaveBeenCalled()
   })
 })

--- a/packages/legacy/core/__tests__/screens/__snapshots__/Developer.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/Developer.test.tsx.snap
@@ -263,5 +263,83 @@ exports[`Developer screen screen renders correctly 1`] = `
       />
     </View>
   </View>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+        "marginHorizontal": 10,
+        "marginVertical": 10,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
+      <Text
+        style={
+          Object {
+            "color": "#FFFFFF",
+            "fontSize": 18,
+            "fontWeight": "bold",
+            "marginRight": 10,
+            "textAlign": "left",
+          }
+        }
+      >
+        NameWallet.EnableWalletNaming
+      </Text>
+    </View>
+    <View
+      accessibilityLabel="NameWallet.ToggleWalletNaming"
+      accessibilityRole="switch"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "justifyContent": "center",
+        }
+      }
+      testID="com.ariesbifold:id/EnableWalletNamingSwitch"
+    >
+      <RCTSwitch
+        accessibilityRole="switch"
+        onChange={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        onTintColor="rgba(53, 130, 63, 0.35)"
+        style={
+          Array [
+            Object {
+              "height": 31,
+              "width": 51,
+            },
+            Object {
+              "backgroundColor": "#D3D3D3",
+              "borderRadius": 16,
+            },
+          ]
+        }
+        thumbTintColor="#606060"
+        tintColor="#D3D3D3"
+        value={false}
+      />
+    </View>
+  </View>
 </View>
 `;

--- a/packages/legacy/core/__tests__/screens/__snapshots__/Splash.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/Splash.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Splash Screen Renders correctly 1`] = `
+exports[`Splash Screen Renders default correctly 1`] = `
 <RNCSafeAreaView
   style={
     Object {


### PR DESCRIPTION
# Summary of Changes

Allow wallet naming to be enabled from the onboarding developer settings

Here's what it looks like:
![wallet_naming_onboarding](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/32586431/66e95555-102c-4081-9fe9-346864333b34)

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
