### PR TITLE
feat: dev option to toggle accepting dev credentials

### DIFF
--- a/packages/legacy/core/App/contexts/configuration.tsx
+++ b/packages/legacy/core/App/contexts/configuration.tsx
@@ -40,7 +40,7 @@ export interface ConfigurationContext {
   useCustomNotifications: () => { total: number; notifications: any }
   connectionTimerDelay?: number
   autoRedirectConnectionToHome?: boolean
-  proofRequestTemplates?: Array<ProofRequestTemplate>
+  proofRequestTemplates?: (useDevTemplates: boolean) => Array<ProofRequestTemplate>
   enableTours?: boolean
   enableWalletNaming?: boolean
 }

--- a/packages/legacy/core/App/contexts/reducers/store.ts
+++ b/packages/legacy/core/App/contexts/reducers/store.ts
@@ -42,6 +42,7 @@ enum PreferencesDispatchAction {
   USE_CONNECTION_INVITER_CAPABILITY = 'preferences/useConnectionInviterCapability',
   USE_DEV_VERIFIER_TEMPLATES = 'preferences/useDevVerifierTemplates',
   UPDATE_WALLET_NAME = 'preferences/updateWalletName',
+  ACCEPT_DEV_CREDENTIALS = 'preferences/acceptDevCredentials',
 }
 
 enum ToursDispatchAction {
@@ -157,6 +158,21 @@ export const reducer = <S extends State>(state: S, action: ReducerAction<Dispatc
       const preferences = {
         ...state.preferences,
         useDevVerifierTemplates: choice,
+      }
+      const newState = {
+        ...state,
+        preferences,
+      }
+
+      AsyncStorage.setItem(LocalStorageKeys.Preferences, JSON.stringify(preferences))
+
+      return newState
+    }
+    case PreferencesDispatchAction.ACCEPT_DEV_CREDENTIALS: {
+      const choice = (action?.payload ?? []).pop() ?? false
+      const preferences = {
+        ...state.preferences,
+        acceptDevCredentials: choice,
       }
       const newState = {
         ...state,

--- a/packages/legacy/core/App/contexts/store.tsx
+++ b/packages/legacy/core/App/contexts/store.tsx
@@ -42,6 +42,7 @@ export const defaultState: State = {
     useVerifierCapability: false,
     useConnectionInviterCapability: false,
     useDevVerifierTemplates: false,
+    acceptDevCredentials: false,
     walletName: generateRandomWalletName(),
   },
   tours: {

--- a/packages/legacy/core/App/defaultConfiguration.ts
+++ b/packages/legacy/core/App/defaultConfiguration.ts
@@ -1,5 +1,5 @@
 import defaultIndyLedgers from '../configs/ledgers/indy'
-import { defaultProofRequestTemplates } from '../verifier'
+import { useProofRequestTemplates } from '../verifier'
 
 import * as bundle from './assets/oca-bundles.json'
 import EmptyList from './components/misc/EmptyList'
@@ -45,7 +45,7 @@ export const defaultConfiguration: ConfigurationContext = {
     pageTitle: '',
   },
   useCustomNotifications: useNotifications,
-  proofRequestTemplates: defaultProofRequestTemplates,
+  proofRequestTemplates: useProofRequestTemplates,
   enableTours: false,
   enableWalletNaming: false,
 }

--- a/packages/legacy/core/App/hooks/proof-request-templates.ts
+++ b/packages/legacy/core/App/hooks/proof-request-templates.ts
@@ -2,13 +2,21 @@ import { useMemo } from 'react'
 
 import { ProofRequestTemplate } from '../../verifier'
 import { useConfiguration } from '../contexts/configuration'
+import { useStore } from '../contexts/store'
 
 export const useTemplates = (): Array<ProofRequestTemplate> => {
+  const [store] = useStore()
   const { proofRequestTemplates } = useConfiguration()
-  return proofRequestTemplates || []
+  return (proofRequestTemplates && proofRequestTemplates(store.preferences.acceptDevCredentials)) || []
 }
 
 export const useTemplate = (templateId: string): ProofRequestTemplate | undefined => {
   const { proofRequestTemplates } = useConfiguration()
-  return useMemo(() => proofRequestTemplates?.find((template) => template.id === templateId), [templateId])
+  const [store] = useStore()
+  return useMemo(
+    () =>
+      proofRequestTemplates &&
+      proofRequestTemplates(store.preferences.acceptDevCredentials).find((template) => template.id === templateId),
+    [templateId]
+  )
 }

--- a/packages/legacy/core/App/localization/en/index.ts
+++ b/packages/legacy/core/App/localization/en/index.ts
@@ -554,6 +554,7 @@ const translation = {
   },
   "Verifier": {
     "UseVerifierCapability": "Use Verifier capability?",
+    "AcceptDevCredentials": "Accept non-production credentials?",
     "UseDevVerifierTemplates": "Use development verifier templates?",
     "Toggle": "Toggle Verifier Capability",
     "ToggleDevTemplates": "Toggle Verifier Development Templates",

--- a/packages/legacy/core/App/localization/fr/index.ts
+++ b/packages/legacy/core/App/localization/fr/index.ts
@@ -543,6 +543,7 @@ const translation = {
     },
     "Verifier": {
         "UseVerifierCapability": "Utiliser la fonctionnalité Verifier?",
+        "AcceptDevCredentials": "Accept non-production credentials? (FR)",
         "UseDevVerifierTemplates": "Use development verifier templates? (FR)",
         "Toggle": "Basculer la capacité de vérification",
         "ToggleDevTemplates": "Toggle Verifier Development Templates (FR)",

--- a/packages/legacy/core/App/localization/pt-br/index.ts
+++ b/packages/legacy/core/App/localization/pt-br/index.ts
@@ -519,6 +519,7 @@ const translation = {
   },
   "Verifier": {
     "UseVerifierCapability": "Usar o recurso Verificador?",
+    "AcceptDevCredentials": "Accept non-production credentials? (PB)",
     "UseDevVerifierTemplates": "Usar templates de verificador de desenvolvimento?",
     "Toggle": "Alternar capacidade do verificador",
     "ToggleDevTemplates": "Alternar Templates de Verificador de Desenvolvimento",

--- a/packages/legacy/core/App/screens/Developer.tsx
+++ b/packages/legacy/core/App/screens/Developer.tsx
@@ -15,6 +15,7 @@ const Developer: React.FC = () => {
   const [useConnectionInviterCapability, setConnectionInviterCapability] = useState(
     !!store.preferences.useConnectionInviterCapability
   )
+  const [acceptDevCredentials, setAcceptDevCredentials] = useState<boolean>(!!store.preferences.acceptDevCredentials)
 
   const [useDevVerifierTemplates, setDevVerifierTemplates] = useState(!!store.preferences.useDevVerifierTemplates)
 
@@ -58,6 +59,14 @@ const Developer: React.FC = () => {
       payload: [!useVerifierCapability],
     })
     setUseVerifierCapability((previousState) => !previousState)
+  }
+
+  const toggleAcceptDevCredentialsSwitch = () => {
+    dispatch({
+      type: DispatchAction.ACCEPT_DEV_CREDENTIALS,
+      payload: [!acceptDevCredentials],
+    })
+    setAcceptDevCredentials((previousState) => !previousState)
   }
 
   const toggleConnectionInviterCapabilitySwitch = () => {
@@ -107,6 +116,27 @@ const Developer: React.FC = () => {
             ios_backgroundColor={ColorPallet.grayscale.lightGrey}
             onValueChange={toggleVerifierCapabilitySwitch}
             value={useVerifierCapability}
+          />
+        </Pressable>
+      </View>
+      <View style={styles.settingContainer}>
+        <View style={{ flex: 1 }}>
+          <Text accessible={false} style={styles.settingLabelText}>
+            {t('Verifier.AcceptDevCredentials')}
+          </Text>
+        </View>
+        <Pressable
+          style={styles.settingSwitchContainer}
+          accessibilityLabel={t('Verifier.Toggle')}
+          accessibilityRole={'switch'}
+          testID={testIdWithKey('ToggleAcceptDevCredentials')}
+        >
+          <Switch
+            trackColor={{ false: ColorPallet.grayscale.lightGrey, true: ColorPallet.brand.primaryDisabled }}
+            thumbColor={acceptDevCredentials ? ColorPallet.brand.primary : ColorPallet.grayscale.mediumGrey}
+            ios_backgroundColor={ColorPallet.grayscale.lightGrey}
+            onValueChange={toggleAcceptDevCredentialsSwitch}
+            value={acceptDevCredentials}
           />
         </Pressable>
       </View>

--- a/packages/legacy/core/App/types/state.ts
+++ b/packages/legacy/core/App/types/state.ts
@@ -18,6 +18,7 @@ export interface Preferences {
   useConnectionInviterCapability?: boolean
   useDevVerifierTemplates?: boolean
   walletName: string
+  acceptDevCredentials: boolean
 }
 
 export interface Tours {

--- a/packages/legacy/core/__tests__/components/NewQRView.test.tsx
+++ b/packages/legacy/core/__tests__/components/NewQRView.test.tsx
@@ -43,6 +43,7 @@ describe('NewQRView Component', () => {
             useVerifierCapability: false,
             useConnectionInviterCapability: false,
             useDevVerifierTemplates: false,
+            acceptDevCredentials:false,
             walletName: 'My Wallet - 1234',
           },
         }}

--- a/packages/legacy/core/__tests__/contexts/configuration.ts
+++ b/packages/legacy/core/__tests__/contexts/configuration.ts
@@ -2,7 +2,7 @@ import { ConfigurationContext } from '../../App'
 import Record from '../../App/components/record/Record'
 import { useNotifications } from '../../App/hooks/notifications'
 import { OCABundleResolver } from '../../App/types/oca'
-import { defaultProofRequestTemplates } from '../../verifier'
+import { useProofRequestTemplates } from '../../verifier/request-templates'
 
 const configurationContext: ConfigurationContext = {
   pages: () => [],
@@ -42,7 +42,7 @@ const configurationContext: ConfigurationContext = {
     pageTitle: '',
   },
   useCustomNotifications: useNotifications,
-  proofRequestTemplates: defaultProofRequestTemplates,
+  proofRequestTemplates: useProofRequestTemplates,
 }
 
 export default configurationContext

--- a/packages/legacy/core/__tests__/screens/ListProofRequests.test.tsx
+++ b/packages/legacy/core/__tests__/screens/ListProofRequests.test.tsx
@@ -7,7 +7,7 @@ import { ConfigurationContext } from '../../App/contexts/configuration'
 import { NetworkProvider } from '../../App/contexts/network'
 import configurationContext from '../contexts/configuration'
 import ListProofRequests from '../../App/screens/ListProofRequests'
-import { defaultProofRequestTemplates } from '../../verifier'
+import { useProofRequestTemplates } from '../../verifier/request-templates'
 
 jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter')
 jest.mock('@react-native-community/netinfo', () => mockRNCNetInfo)
@@ -60,7 +60,7 @@ describe('ListProofRequests Component', () => {
       fireEvent(templateItemInstance, 'press')
 
       expect(navigation.navigate).toBeCalledWith('Proof Request Details', {
-        templateId: defaultProofRequestTemplates[0].id,
+        templateId: useProofRequestTemplates(false)[0].id,
       })
     })
   })

--- a/packages/legacy/core/__tests__/screens/ProofRequestDetails.test.tsx
+++ b/packages/legacy/core/__tests__/screens/ProofRequestDetails.test.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 import { ConfigurationContext } from '../../App/contexts/configuration'
 import { NetworkProvider } from '../../App/contexts/network'
 import configurationContext from '../contexts/configuration'
-import { defaultProofRequestTemplates } from '../../verifier'
+import { useProofRequestTemplates } from '../../verifier/request-templates'
 import ProofRequestDetails from '../../App/screens/ProofRequestDetails'
 import { testIdWithKey } from '../../App'
 
@@ -28,8 +28,8 @@ jest.mock('react-native-device-info', () => () => jest.fn())
 
 jest.useFakeTimers('legacy')
 jest.spyOn(global, 'setTimeout')
-
-const templateId = defaultProofRequestTemplates[0].id
+const templates = useProofRequestTemplates(false)
+const templateId = templates[0].id
 const connectionId = 'test'
 const navigation = useNavigation()
 

--- a/packages/legacy/core/__tests__/screens/ProofRequesting.test.tsx
+++ b/packages/legacy/core/__tests__/screens/ProofRequesting.test.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from '@react-navigation/core'
 import { act, cleanup, render, fireEvent, waitFor } from '@testing-library/react-native'
 import React from 'react'
 
-import { defaultProofRequestTemplates } from '../../verifier'
+import { useProofRequestTemplates } from '../../verifier/request-templates'
 import { testIdWithKey } from '../../App'
 import ProofRequesting from '../../App/screens/ProofRequesting'
 import * as proofRequestUtils from '../../verifier/utils/proof-request'
@@ -39,7 +39,8 @@ jest.mock('react-native-device-info', () => () => jest.fn())
 jest.useFakeTimers('legacy')
 jest.spyOn(global, 'setTimeout')
 
-const template = defaultProofRequestTemplates[0]
+const templates = useProofRequestTemplates(true)
+const template = templates[0]
 const templateId = template.id
 
 const proof_request = {

--- a/packages/legacy/core/__tests__/screens/__snapshots__/Developer.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/Developer.test.tsx.snap
@@ -126,6 +126,85 @@ exports[`Developer screen screen renders correctly 1`] = `
       }
     >
       <Text
+        accessible={false}
+        style={
+          Object {
+            "color": "#FFFFFF",
+            "fontSize": 18,
+            "fontWeight": "bold",
+            "marginRight": 10,
+            "textAlign": "left",
+          }
+        }
+      >
+        Verifier.AcceptDevCredentials
+      </Text>
+    </View>
+    <View
+      accessibilityLabel="Verifier.Toggle"
+      accessibilityRole="switch"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "justifyContent": "center",
+        }
+      }
+      testID="com.ariesbifold:id/ToggleAcceptDevCredentials"
+    >
+      <RCTSwitch
+        accessibilityRole="switch"
+        onChange={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        onTintColor="rgba(53, 130, 63, 0.35)"
+        style={
+          Array [
+            Object {
+              "height": 31,
+              "width": 51,
+            },
+            Object {
+              "backgroundColor": "#D3D3D3",
+              "borderRadius": 16,
+            },
+          ]
+        }
+        thumbTintColor="#606060"
+        tintColor="#D3D3D3"
+        value={false}
+      />
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+        "marginHorizontal": 10,
+        "marginVertical": 10,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
+      <Text
         style={
           Object {
             "color": "#FFFFFF",

--- a/packages/legacy/core/verifier/__tests__/verifier/proof-request.test.ts
+++ b/packages/legacy/core/verifier/__tests__/verifier/proof-request.test.ts
@@ -1,4 +1,4 @@
-import { defaultProofRequestTemplates } from '../../request-templates'
+import { useProofRequestTemplates } from '../../request-templates'
 import { buildProofRequestDataForTemplate, hasPredicates } from '../../utils/proof-request'
 
 import SpyInstance = jest.SpyInstance
@@ -9,22 +9,23 @@ describe('Helpers', () => {
   beforeAll(() => {
     spy = jest.spyOn(Date, 'now').mockImplementation(() => 1677766511505)
   })
+  const templates = useProofRequestTemplates(false)
 
   test('Build anoncreds proof request from template containing two requested attributes', async () => {
-    const template = defaultProofRequestTemplates[0]
+    const template = templates[0]
     const proofRequest = buildProofRequestDataForTemplate(template)
     expect(proofRequest).toMatchSnapshot()
   })
 
   test('Build anoncreds proof request from template containing two requested attributes and predicate', async () => {
-    const template = defaultProofRequestTemplates[1]
+    const template = templates[1]
     const proofRequest = buildProofRequestDataForTemplate(template)
     expect(proofRequest).toMatchSnapshot()
   })
 
   test('Check if proof has predicates', async () => {
-    expect(hasPredicates(defaultProofRequestTemplates[0])).toBeFalsy()
-    expect(hasPredicates(defaultProofRequestTemplates[1])).toBeTruthy()
+    expect(hasPredicates(templates[0])).toBeFalsy()
+    expect(hasPredicates(templates[1])).toBeTruthy()
   })
 
   afterAll(() => {

--- a/packages/legacy/core/verifier/index.ts
+++ b/packages/legacy/core/verifier/index.ts
@@ -42,4 +42,4 @@ export {
   hasPredicates,
   isParameterizable,
 } from './utils/proof-request'
-export { defaultProofRequestTemplates } from './request-templates'
+export { useProofRequestTemplates } from './request-templates'

--- a/packages/legacy/core/verifier/request-templates.ts
+++ b/packages/legacy/core/verifier/request-templates.ts
@@ -1,56 +1,62 @@
 import { ProofRequestTemplate, ProofRequestType } from './types/proof-reqeust-template'
 
-export const defaultProofRequestTemplates: Array<ProofRequestTemplate> = [
-  {
-    id: 'Aries:5:StudentFullName:0.0.1:indy',
-    name: 'Student full name',
-    description: 'Verify the full name of a student',
-    version: '0.0.1',
-    payload: {
-      type: ProofRequestType.AnonCreds,
-      data: [
-        {
-          schema: 'XUxBrVSALWHLeycAUhrNr9:3:CL:26293:Student Card',
-          requestedAttributes: [
-            {
-              name: 'student_first_name',
-              restrictions: [{ cred_def_id: 'XUxBrVSALWHLeycAUhrNr9:3:CL:26293:student_card' }],
-            },
-            {
-              name: 'student_last_name',
-              restrictions: [{ cred_def_id: 'XUxBrVSALWHLeycAUhrNr9:3:CL:26293:student_card' }],
-            },
-          ],
-        },
-      ],
+export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
+  const studentRestrictions = [{ cred_def_id: 'XUxBrVSALWHLeycAUhrNr9:3:CL:26293:student_card' }]
+  const studentDevRestrictions = [{ schema_name: 'student_card' }]
+  const restrictions = useDevRestrictions ? studentDevRestrictions : studentRestrictions
+  const defaultProofRequestTemplates: Array<ProofRequestTemplate> = [
+    {
+      id: 'Aries:5:StudentFullName:0.0.1:indy',
+      name: 'Student full name',
+      description: 'Verify the full name of a student',
+      version: '0.0.1',
+      payload: {
+        type: ProofRequestType.AnonCreds,
+        data: [
+          {
+            schema: 'XUxBrVSALWHLeycAUhrNr9:3:CL:26293:Student Card',
+            requestedAttributes: [
+              {
+                name: 'student_first_name',
+                restrictions,
+              },
+              {
+                name: 'student_last_name',
+                restrictions,
+              },
+            ],
+          },
+        ],
+      },
     },
-  },
-  {
-    id: 'Aries:5:StudentFullNameAndExpirationDate:0.0.1:indy',
-    name: 'Student full name and expiration date',
-    description: 'Verify that full name of a student and that he/she has a not expired student card.',
-    version: '0.0.1',
-    payload: {
-      type: ProofRequestType.AnonCreds,
-      data: [
-        {
-          schema: 'XUxBrVSALWHLeycAUhrNr9:3:CL:26293:Student Card',
-          requestedAttributes: [
-            {
-              names: ['student_first_name', 'student_last_name'],
-              restrictions: [{ cred_def_id: 'XUxBrVSALWHLeycAUhrNr9:3:CL:26293:student_card' }],
-            },
-          ],
-          requestedPredicates: [
-            {
-              name: 'expiry_date',
-              predicateType: '>=',
-              predicateValue: 20240101,
-              restrictions: [{ cred_def_id: 'XUxBrVSALWHLeycAUhrNr9:3:CL:26293:student_card' }],
-            },
-          ],
-        },
-      ],
+    {
+      id: 'Aries:5:StudentFullNameAndExpirationDate:0.0.1:indy',
+      name: 'Student full name and expiration date',
+      description: 'Verify that full name of a student and that he/she has a not expired student card.',
+      version: '0.0.1',
+      payload: {
+        type: ProofRequestType.AnonCreds,
+        data: [
+          {
+            schema: 'XUxBrVSALWHLeycAUhrNr9:3:CL:26293:Student Card',
+            requestedAttributes: [
+              {
+                names: ['student_first_name', 'student_last_name'],
+                restrictions,
+              },
+            ],
+            requestedPredicates: [
+              {
+                name: 'expiry_date',
+                predicateType: '>=',
+                predicateValue: 20240101,
+                restrictions,
+              },
+            ],
+          },
+        ],
+      },
     },
-  },
-]
+  ]
+  return defaultProofRequestTemplates
+}

--- a/packages/legacy/core/verifier/types/proof-reqeust-template.ts
+++ b/packages/legacy/core/verifier/types/proof-reqeust-template.ts
@@ -10,6 +10,7 @@ export interface AnonCredsRequestedPredicate {
   predicateType: AnonCredsPredicateType
   predicateValue: number
   restrictions?: AnonCredsProofRequestRestriction[]
+  devRestrictions?: AnonCredsProofRequestRestriction[]
   nonRevoked?: AnonCredsNonRevokedInterval
   parameterizable?: boolean
 }
@@ -19,6 +20,7 @@ export interface AnonCredsRequestedAttribute {
   name?: string
   names?: Array<string>
   restrictions?: AnonCredsProofRequestRestriction[]
+  devRestrictions?: AnonCredsProofRequestRestriction[]
   revealed?: boolean
   nonRevoked?: AnonCredsNonRevokedInterval
 }


### PR DESCRIPTION
# Summary of Changes

Added a developer option to toggle accepting development credentials on and off in the mobile verifier. This allows us to test with credentials from the showcase without the security concerns of accepting development credentials in a production environment.

Refactored request templates to make them work with react hooks (from the react store)

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
