### PR TITLE
feat: added button to request decline screen

### DIFF
--- a/packages/legacy/core/App/screens/ProofDetails.tsx
+++ b/packages/legacy/core/App/screens/ProofDetails.tsx
@@ -221,7 +221,7 @@ const UnverifiedProof: React.FC<UnverifiedProofProps> = ({ record, navigation })
     },
     footerButton: {
       margin: 20,
-      marginTop:'auto',
+      marginTop: 'auto',
     },
   })
   const onGenerateNew = useCallback(() => {
@@ -234,28 +234,28 @@ const UnverifiedProof: React.FC<UnverifiedProofProps> = ({ record, navigation })
   }, [navigation])
 
   return (
-      <ScrollView contentContainerStyle={{ flexGrow: 1 }} testID={testIdWithKey('UnverifiedProofView')}>
-        <View style={styles.header}>
-          <View style={styles.headerTitleContainer}>
-            <Icon name="bookmark-remove" size={45} color={'white'} />
-            {record.state === ProofState.Abandoned && (
-              <Text style={styles.headerTitle}>{t('Verifier.PresentationDeclined')}</Text>
-            )}
-            {record.isVerified === false && (
-              <Text style={styles.headerTitle}>{t('Verifier.ProofVerificationFailed')}</Text>
-            )}
-          </View>
+    <ScrollView contentContainerStyle={{ flexGrow: 1 }} testID={testIdWithKey('UnverifiedProofView')}>
+      <View style={styles.header}>
+        <View style={styles.headerTitleContainer}>
+          <Icon name="bookmark-remove" size={45} color={'white'} />
+          {record.state === ProofState.Abandoned && (
+            <Text style={styles.headerTitle}>{t('Verifier.PresentationDeclined')}</Text>
+          )}
+          {record.isVerified === false && (
+            <Text style={styles.headerTitle}>{t('Verifier.ProofVerificationFailed')}</Text>
+          )}
         </View>
-        <View style={styles.footerButton}>
-          <Button
-            title={t('Verifier.GenerateNewQR')}
-            accessibilityLabel={t('Verifier.GenerateNewQR')}
-            testID={testIdWithKey('GenerateNewQR')}
-            buttonType={ButtonType.Primary}
-            onPress={onGenerateNew}
-          />
-        </View>
-      </ScrollView>
+      </View>
+      <View style={styles.footerButton}>
+        <Button
+          title={t('Verifier.GenerateNewQR')}
+          accessibilityLabel={t('Verifier.GenerateNewQR')}
+          testID={testIdWithKey('GenerateNewQR')}
+          buttonType={ButtonType.Primary}
+          onPress={onGenerateNew}
+        />
+      </View>
+    </ScrollView>
   )
 }
 

--- a/packages/legacy/core/App/screens/ProofDetails.tsx
+++ b/packages/legacy/core/App/screens/ProofDetails.tsx
@@ -30,6 +30,7 @@ interface VerifiedProofProps {
 
 interface UnverifiedProofProps {
   record: ProofExchangeRecord
+  navigation: StackNavigationProp<ProofRequestsStackParams, Screens.ProofDetails>
 }
 
 const VerifiedProof: React.FC<VerifiedProofProps> = ({
@@ -192,13 +193,12 @@ const VerifiedProof: React.FC<VerifiedProofProps> = ({
   )
 }
 
-const UnverifiedProof: React.FC<UnverifiedProofProps> = ({ record }) => {
+const UnverifiedProof: React.FC<UnverifiedProofProps> = ({ record, navigation }) => {
   const { t } = useTranslation()
   const { ColorPallet } = useTheme()
 
   const styles = StyleSheet.create({
     header: {
-      flexGrow: 1,
       backgroundColor: ColorPallet.semantic.error,
       paddingHorizontal: 30,
       paddingVertical: 20,
@@ -219,21 +219,43 @@ const UnverifiedProof: React.FC<UnverifiedProofProps> = ({ record }) => {
       marginVertical: 10,
       fontSize: 18,
     },
+    footerButton: {
+      margin: 20,
+      marginTop:'auto',
+    },
   })
+  const onGenerateNew = useCallback(() => {
+    const metadata = record.metadata.get(ProofMetadata.customMetadata) as ProofCustomMetadata
+    if (metadata?.proof_request_template_id) {
+      navigation.navigate(Screens.ProofRequesting, { templateId: metadata.proof_request_template_id })
+    } else {
+      navigation.navigate(Screens.ProofRequests, {})
+    }
+  }, [navigation])
+
   return (
-    <View testID={testIdWithKey('UnverifiedProofView')}>
-      <View style={styles.header}>
-        <View style={styles.headerTitleContainer}>
-          <Icon name="bookmark-remove" size={45} color={'white'} />
-          {record.state === ProofState.Abandoned && (
-            <Text style={styles.headerTitle}>{t('Verifier.PresentationDeclined')}</Text>
-          )}
-          {record.isVerified === false && (
-            <Text style={styles.headerTitle}>{t('Verifier.ProofVerificationFailed')}</Text>
-          )}
+      <ScrollView contentContainerStyle={{ flexGrow: 1 }} testID={testIdWithKey('UnverifiedProofView')}>
+        <View style={styles.header}>
+          <View style={styles.headerTitleContainer}>
+            <Icon name="bookmark-remove" size={45} color={'white'} />
+            {record.state === ProofState.Abandoned && (
+              <Text style={styles.headerTitle}>{t('Verifier.PresentationDeclined')}</Text>
+            )}
+            {record.isVerified === false && (
+              <Text style={styles.headerTitle}>{t('Verifier.ProofVerificationFailed')}</Text>
+            )}
+          </View>
         </View>
-      </View>
-    </View>
+        <View style={styles.footerButton}>
+          <Button
+            title={t('Verifier.GenerateNewQR')}
+            accessibilityLabel={t('Verifier.GenerateNewQR')}
+            testID={testIdWithKey('GenerateNewQR')}
+            buttonType={ButtonType.Primary}
+            onPress={onGenerateNew}
+          />
+        </View>
+      </ScrollView>
   )
 }
 
@@ -284,7 +306,7 @@ const ProofDetails: React.FC<ProofDetailsProps> = ({ route, navigation }) => {
       {(record.isVerified || senderReview) && (
         <VerifiedProof record={record} isHistory={isHistory} navigation={navigation} senderReview={senderReview} />
       )}
-      {!(record.isVerified || senderReview) && <UnverifiedProof record={record} />}
+      {!(record.isVerified || senderReview) && <UnverifiedProof record={record} navigation={navigation} />}
     </SafeAreaView>
   )
 }


### PR DESCRIPTION
# Summary of Changes

Added request another proof request button to mobile verifier decline screen:
<img width="395" alt="image" src="https://github.com/hyperledger/aries-mobile-agent-react-native/assets/36937407/938c1684-6966-4270-bafd-c1e35d77c6ed">


# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
