### PR TITLE
feat: added button to request decline screen

### DIFF
--- a/packages/legacy/core/App/screens/ProofDetails.tsx
+++ b/packages/legacy/core/App/screens/ProofDetails.tsx
@@ -221,7 +221,7 @@ const UnverifiedProof: React.FC<UnverifiedProofProps> = ({ record, navigation })
     },
     footerButton: {
       margin: 20,
-      marginTop:'auto',
+      marginTop: 'auto',
     },
   })
   const onGenerateNew = useCallback(() => {
@@ -234,28 +234,28 @@ const UnverifiedProof: React.FC<UnverifiedProofProps> = ({ record, navigation })
   }, [navigation])
 
   return (
-      <ScrollView contentContainerStyle={{ flexGrow: 1 }} testID={testIdWithKey('UnverifiedProofView')}>
-        <View style={styles.header}>
-          <View style={styles.headerTitleContainer}>
-            <Icon name="bookmark-remove" size={45} color={'white'} />
-            {record.state === ProofState.Abandoned && (
-              <Text style={styles.headerTitle}>{t('Verifier.PresentationDeclined')}</Text>
-            )}
-            {record.isVerified === false && (
-              <Text style={styles.headerTitle}>{t('Verifier.ProofVerificationFailed')}</Text>
-            )}
-          </View>
+    <ScrollView contentContainerStyle={{ flexGrow: 1 }} testID={testIdWithKey('UnverifiedProofView')}>
+      <View style={styles.header}>
+        <View style={styles.headerTitleContainer}>
+          <Icon name="bookmark-remove" size={45} color={'white'} />
+          {record.state === ProofState.Abandoned && (
+            <Text style={styles.headerTitle}>{t('Verifier.PresentationDeclined')}</Text>
+          )}
+          {record.isVerified === false && (
+            <Text style={styles.headerTitle}>{t('Verifier.ProofVerificationFailed')}</Text>
+          )}
         </View>
-        <View style={styles.footerButton}>
-          <Button
-            title={t('Verifier.GenerateNewQR')}
-            accessibilityLabel={t('Verifier.GenerateNewQR')}
-            testID={testIdWithKey('GenerateNewQR')}
-            buttonType={ButtonType.Primary}
-            onPress={onGenerateNew}
-          />
-        </View>
-      </ScrollView>
+      </View>
+      <View style={styles.footerButton}>
+        <Button
+          title={t('Verifier.GenerateNewQR')}
+          accessibilityLabel={t('Verifier.GenerateNewQR')}
+          testID={testIdWithKey('GenerateNewQR')}
+          buttonType={ButtonType.Primary}
+          onPress={onGenerateNew}
+        />
+      </View>
+    </ScrollView>
   )
 }
 

--- a/packages/legacy/core/App/screens/ProofDetails.tsx
+++ b/packages/legacy/core/App/screens/ProofDetails.tsx
@@ -224,6 +224,7 @@ const UnverifiedProof: React.FC<UnverifiedProofProps> = ({ record, navigation })
       marginTop: 'auto',
     },
   })
+
   const onGenerateNew = useCallback(() => {
     const metadata = record.metadata.get(ProofMetadata.customMetadata) as ProofCustomMetadata
     if (metadata?.proof_request_template_id) {
@@ -268,6 +269,7 @@ const ProofDetails: React.FC<ProofDetailsProps> = ({ route, navigation }) => {
   const record = useProofById(recordId)
   const { agent } = useAgent()
   const [store] = useStore()
+
   useEffect(() => {
     return () => {
       if (!store.preferences.useDataRetention) {

--- a/packages/legacy/core/App/screens/ProofDetails.tsx
+++ b/packages/legacy/core/App/screens/ProofDetails.tsx
@@ -30,6 +30,7 @@ interface VerifiedProofProps {
 
 interface UnverifiedProofProps {
   record: ProofExchangeRecord
+  navigation: StackNavigationProp<ProofRequestsStackParams, Screens.ProofDetails>
 }
 
 const VerifiedProof: React.FC<VerifiedProofProps> = ({
@@ -192,13 +193,12 @@ const VerifiedProof: React.FC<VerifiedProofProps> = ({
   )
 }
 
-const UnverifiedProof: React.FC<UnverifiedProofProps> = ({ record }) => {
+const UnverifiedProof: React.FC<UnverifiedProofProps> = ({ record, navigation }) => {
   const { t } = useTranslation()
   const { ColorPallet } = useTheme()
 
   const styles = StyleSheet.create({
     header: {
-      flexGrow: 1,
       backgroundColor: ColorPallet.semantic.error,
       paddingHorizontal: 30,
       paddingVertical: 20,
@@ -219,21 +219,43 @@ const UnverifiedProof: React.FC<UnverifiedProofProps> = ({ record }) => {
       marginVertical: 10,
       fontSize: 18,
     },
+    footerButton: {
+      margin: 20,
+      marginTop:'auto',
+    },
   })
+  const onGenerateNew = useCallback(() => {
+    const metadata = record.metadata.get(ProofMetadata.customMetadata) as ProofCustomMetadata
+    if (metadata?.proof_request_template_id) {
+      navigation.navigate(Screens.ProofRequesting, { templateId: metadata.proof_request_template_id })
+    } else {
+      navigation.navigate(Screens.ProofRequests, {})
+    }
+  }, [navigation])
+
   return (
-    <View testID={testIdWithKey('UnverifiedProofView')}>
-      <View style={styles.header}>
-        <View style={styles.headerTitleContainer}>
-          <Icon name="bookmark-remove" size={45} color={'white'} />
-          {record.state === ProofState.Abandoned && (
-            <Text style={styles.headerTitle}>{t('Verifier.PresentationDeclined')}</Text>
-          )}
-          {record.isVerified === false && (
-            <Text style={styles.headerTitle}>{t('Verifier.ProofVerificationFailed')}</Text>
-          )}
+      <ScrollView contentContainerStyle={{ flexGrow: 1 }} testID={testIdWithKey('UnverifiedProofView')}>
+        <View style={styles.header}>
+          <View style={styles.headerTitleContainer}>
+            <Icon name="bookmark-remove" size={45} color={'white'} />
+            {record.state === ProofState.Abandoned && (
+              <Text style={styles.headerTitle}>{t('Verifier.PresentationDeclined')}</Text>
+            )}
+            {record.isVerified === false && (
+              <Text style={styles.headerTitle}>{t('Verifier.ProofVerificationFailed')}</Text>
+            )}
+          </View>
         </View>
-      </View>
-    </View>
+        <View style={styles.footerButton}>
+          <Button
+            title={t('Verifier.GenerateNewQR')}
+            accessibilityLabel={t('Verifier.GenerateNewQR')}
+            testID={testIdWithKey('GenerateNewQR')}
+            buttonType={ButtonType.Primary}
+            onPress={onGenerateNew}
+          />
+        </View>
+      </ScrollView>
   )
 }
 
@@ -284,7 +306,7 @@ const ProofDetails: React.FC<ProofDetailsProps> = ({ route, navigation }) => {
       {(record.isVerified || senderReview) && (
         <VerifiedProof record={record} isHistory={isHistory} navigation={navigation} senderReview={senderReview} />
       )}
-      {!(record.isVerified || senderReview) && <UnverifiedProof record={record} />}
+      {!(record.isVerified || senderReview) && <UnverifiedProof record={record} navigation={navigation} />}
     </SafeAreaView>
   )
 }

--- a/packages/legacy/core/__tests__/screens/ProofDetails.test.tsx
+++ b/packages/legacy/core/__tests__/screens/ProofDetails.test.tsx
@@ -179,9 +179,22 @@ describe('ProofDetails Component', () => {
       await act(async () => null)
 
       const generateNewButton = tree.getByTestId(testIdWithKey('GenerateNewQR'))
-      expect(generateNewButton).not.toBeNull()
-
       fireEvent(generateNewButton, 'press')
+
+      expect(generateNewButton).not.toBeNull()
+      expect(navigation.navigate).toBeCalledWith('Proof Requests', {})
+    })
+
+    test('Done', async () => {
+      const navigation = useNavigation()
+      const { getByTestId } = renderView({ recordId: testVerifiedProofRequest.id, isHistory: false })
+
+      await act(async () => null)
+
+      const doneButton = getByTestId(testIdWithKey('Done'))
+      fireEvent(doneButton, 'press')
+
+      expect(doneButton).not.toBeNull()
       expect(navigation.navigate).toBeCalledWith('Proof Requests', {})
     })
   })

--- a/packages/legacy/core/__tests__/screens/ProofDetails.test.tsx
+++ b/packages/legacy/core/__tests__/screens/ProofDetails.test.tsx
@@ -116,15 +116,6 @@ describe('ProofDetails Component', () => {
   }
 
   describe('with a verified proof record', () => {
-    beforeEach(() => {
-      jest.clearAllMocks()
-
-      // @ts-ignore
-      useProofById.mockReturnValue(testVerifiedProofRequest)
-      // @ts-ignore
-      jest.spyOn(proofUtils, 'getProofData').mockReturnValue(Promise.resolve(data))
-    })
-
     const testVerifiedProofRequest = new ProofExchangeRecord({
       connectionId: undefined,
       threadId: requestPresentationMessage.id,
@@ -145,13 +136,21 @@ describe('ProofDetails Component', () => {
       expect(secondNameAttributeValue).not.toBe(null)
     }
 
+    beforeEach(() => {
+      jest.clearAllMocks()
+
+      // @ts-ignore
+      useProofById.mockReturnValue(testVerifiedProofRequest)
+      // @ts-ignore
+      jest.spyOn(proofUtils, 'getProofData').mockReturnValue(Promise.resolve(data))
+    })
+
     test('renders correctly when history is true', async () => {
       const tree = renderView({ recordId: testVerifiedProofRequest.id, isHistory: true })
 
-      await act(async () => null)
-      expect(tree).toMatchSnapshot()
-
       const proofDetailsHistoryView = await tree.findByTestId(testIdWithKey('ProofDetailsHistoryView'))
+
+      expect(tree).toMatchSnapshot()
       expect(proofDetailsHistoryView).not.toBe(null)
 
       await checkAttributes(tree)
@@ -160,12 +159,10 @@ describe('ProofDetails Component', () => {
     test('renders correctly when history is false', async () => {
       const tree = renderView({ recordId: testVerifiedProofRequest.id, isHistory: false })
 
-      await act(async () => null)
-      expect(tree).toMatchSnapshot()
-
       const proofDetailsView = await tree.findByTestId(testIdWithKey('ProofDetailsView'))
       const generateNewButton = await tree.findByTestId(testIdWithKey('GenerateNewQR'))
 
+      expect(tree).toMatchSnapshot()
       expect(proofDetailsView).not.toBe(null)
       expect(generateNewButton).not.toBe(null)
 
@@ -175,8 +172,6 @@ describe('ProofDetails Component', () => {
     test('Generate new QR code button should navigate correctly', async () => {
       const navigation = useNavigation()
       const tree = renderView({ recordId: testVerifiedProofRequest.id, isHistory: false })
-
-      await act(async () => null)
 
       const generateNewButton = tree.getByTestId(testIdWithKey('GenerateNewQR'))
       fireEvent(generateNewButton, 'press')
@@ -188,8 +183,6 @@ describe('ProofDetails Component', () => {
     test('Done', async () => {
       const navigation = useNavigation()
       const { getByTestId } = renderView({ recordId: testVerifiedProofRequest.id, isHistory: false })
-
-      await act(async () => null)
 
       const doneButton = getByTestId(testIdWithKey('Done'))
       fireEvent(doneButton, 'press')
@@ -218,10 +211,8 @@ describe('ProofDetails Component', () => {
     test('Unverified proof view should be rendered correctly', async () => {
       const tree = renderView({ recordId: testUnverifiedProofRequest.id, isHistory: false })
 
-      await act(async () => null)
-      expect(tree).toMatchSnapshot()
-
       const unverifiedView = await tree.getByTestId(testIdWithKey('UnverifiedProofView'))
+      expect(tree).toMatchSnapshot()
       expect(unverifiedView).not.toBeNull()
     })
   })

--- a/packages/legacy/core/__tests__/screens/__snapshots__/ProofDetails.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/ProofDetails.test.tsx.snap
@@ -14,63 +14,135 @@ exports[`ProofDetails Component renders correctly with an unverified proof Unver
     }
   }
 >
-  <View
+  <RCTScrollView
+    contentContainerStyle={
+      Object {
+        "flexGrow": 1,
+      }
+    }
     testID="com.ariesbifold:id/UnverifiedProofView"
   >
-    <View
-      style={
-        Object {
-          "backgroundColor": "#D8292F",
-          "flexGrow": 1,
-          "paddingHorizontal": 30,
-          "paddingVertical": 20,
-        }
-      }
-    >
+    <View>
       <View
         style={
           Object {
-            "alignItems": "center",
-            "flexDirection": "row",
-            "justifyContent": "flex-start",
+            "backgroundColor": "#D8292F",
+            "paddingHorizontal": 30,
+            "paddingVertical": 20,
           }
         }
       >
-        <Text
-          allowFontScaling={false}
-          style={
-            Array [
-              Object {
-                "color": "white",
-                "fontSize": 45,
-              },
-              undefined,
-              Object {
-                "fontFamily": "Material Design Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          󰃆
-        </Text>
-        <Text
+        <View
           style={
             Object {
-              "color": "#FFFFFF",
-              "fontSize": 34,
-              "fontWeight": "bold",
-              "marginHorizontal": 8,
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "flex-start",
             }
           }
         >
-          Verifier.ProofVerificationFailed
-        </Text>
+          <Text
+            allowFontScaling={false}
+            style={
+              Array [
+                Object {
+                  "color": "white",
+                  "fontSize": 45,
+                },
+                undefined,
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            󰃆
+          </Text>
+          <Text
+            style={
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 34,
+                "fontWeight": "bold",
+                "marginHorizontal": 8,
+              }
+            }
+          >
+            Verifier.ProofVerificationFailed
+          </Text>
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "margin": 20,
+            "marginTop": "auto",
+          }
+        }
+      >
+        <View
+          accessibilityLabel="Verifier.GenerateNewQR"
+          accessibilityRole="button"
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          nativeID="animatedComponent"
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "backgroundColor": "#42803E",
+              "borderRadius": 4,
+              "opacity": 1,
+              "padding": 16,
+            }
+          }
+          testID="com.ariesbifold:id/GenerateNewQR"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                    "textAlign": "center",
+                  },
+                  false,
+                  false,
+                  false,
+                ]
+              }
+            >
+              Verifier.GenerateNewQR
+            </Text>
+          </View>
+        </View>
       </View>
     </View>
-  </View>
+  </RCTScrollView>
 </RNCSafeAreaView>
 `;
 


### PR DESCRIPTION
# Summary of Changes


@wadeking98 is way for a week so I fixed the outdated snapshot in PR #938. I cannot push to his branch so I've created this one. As per his original comment: 

Added request another proof request button to mobile verifier decline screen:

<img width="395" alt="image" src="https://github.com/hyperledger/aries-mobile-agent-react-native/assets/36937407/938c1684-6966-4270-bafd-c1e35d77c6ed">


# Related Issues

Please reference here any issue #'s that are relevant to this PR, or simply enter "N/A" if this PR does not relate to any existing issues.

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
