### PR TITLE
fix: enabling Data Retention option only if Mobile Verifier is enabled

### DIFF
--- a/packages/legacy/core/App/localization/pt-br/index.ts
+++ b/packages/legacy/core/App/localization/pt-br/index.ts
@@ -417,7 +417,7 @@ const translation = {
     "AboutApp": "Sobre o App",
     "ChangePin": "Alterar o PIN",
     "Language": "Idioma",
-    "DataRetention": "Data retention (PB)",
+    "DataRetention": "Retenção de dados",
     "AppGuides": "Guia do app",
     "WhatAreContacts": "O que são Contatos?",
     "ScanMyQR": "Scanear meu QR code",
@@ -466,7 +466,7 @@ const translation = {
     "ProofDetails": "Detalhes da prova",
     "Settings": "Configurações",
     "Language": "Idioma",
-    "DataRetention": "Data retention (PB)",
+    "DataRetention": "Retenção de dados",
     "Tours": "Guias do app",
     "Contacts": "Contatos",
     "Decline": "Recusar",
@@ -486,8 +486,8 @@ const translation = {
     "BackToHome": "Voltar para a home"
   },
   "NameWallet": {
-    "EnableWalletNaming": "Enable wallet naming? (PT-BR)",
-    "ToggleWalletNaming": "Toggle wallet naming (PT-BR)",
+    "EnableWalletNaming": "Habilitar nome da carteira?",
+    "ToggleWalletNaming": "Alternar nome da carteira",
     "NameYourWallet": "Nome da sua carteira",
     "ThisIsTheName": "Este é o nome que as pessoas verão quando se conectar a você.",
     "CharCountTitle": "Número de caracteres excedido",
@@ -525,7 +525,7 @@ const translation = {
   },
   "Verifier": {
     "UseVerifierCapability": "Usar o recurso Verificador?",
-    "AcceptDevCredentials": "Accept non-production credentials? (PB)",
+    "AcceptDevCredentials": "Aceitar credenciais que não sejam de produção",
     "UseDevVerifierTemplates": "Usar templates de verificador de desenvolvimento?",
     "Toggle": "Alternar capacidade do verificador",
     "ToggleDevTemplates": "Alternar Templates de Verificador de Desenvolvimento",

--- a/packages/legacy/core/App/screens/Settings.tsx
+++ b/packages/legacy/core/App/screens/Settings.tsx
@@ -154,13 +154,6 @@ const Settings: React.FC<SettingsProps> = ({ navigation }) => {
           testID: testIdWithKey('Language'),
           onPress: () => navigation.navigate(Screens.Language),
         },
-        {
-          title: t('Settings.DataRetention'),
-          value: store.preferences.useDataRetention ? t('Global.On') : t('Global.Off'),
-          accessibilityLabel: t('Settings.DataRetention'),
-          testID: testIdWithKey('DataRetention'),
-          onPress: () => navigation.navigate(Screens.DataRetention),
-        },
       ],
     },
     ...(settings || []),
@@ -216,6 +209,17 @@ const Settings: React.FC<SettingsProps> = ({ navigation }) => {
         },
       ],
     })
+
+    const section = settingsSections.find((item) => item.header.title === t('Settings.AppSettings'))
+    if (section) {
+      section.data.splice(3, 0, {
+        title: t('Settings.DataRetention'),
+        value: store.preferences.useDataRetention ? t('Global.On') : t('Global.Off'),
+        accessibilityLabel: t('Settings.DataRetention'),
+        testID: testIdWithKey('DataRetention'),
+        onPress: () => navigation.navigate(Screens.DataRetention),
+      })
+    }
   }
 
   if (store.preferences.useConnectionInviterCapability) {

--- a/packages/legacy/core/__tests__/contexts/store.ts
+++ b/packages/legacy/core/__tests__/contexts/store.ts
@@ -1,50 +1,10 @@
-import { State } from "../../App/types/state";
+import { State } from '../../App/types/state'
+import { defaultState } from '../../App/contexts/store'
 
-export const defaultState: State = {
-    onboarding: {
-      didAgreeToTerms: false,
-      didCompleteTutorial: false,
-      didCreatePIN: false,
-      didConsiderBiometry: false,
-      didNameWallet: false,
-    },
-    authentication: {
-      didAuthenticate: false,
-    },
-    // NOTE: from AFJ 0.4.0 on we use Aries Askar. New wallets will be created with Askar from the start
-    // which we will know when we create the pin while using askar as a dependency.
-    migration: {
-      didMigrateToAskar: false,
-    },
-    loginAttempt: {
-      loginAttempts: 0,
-      servedPenalty: true,
-    },
-    lockout: {
-      displayNotification: false,
-    },
-    preferences: {
-      developerModeEnabled: false,
-      biometryPreferencesUpdated: false,
-      useBiometry: false,
-      useVerifierCapability: false,
-      useConnectionInviterCapability: false,
-      useDevVerifierTemplates: false,
-      acceptDevCredentials: false,
-      useDataRetention: true,
-      enableWalletNaming: false,
-      walletName: 'test-wallet',
-    },
-    tours: {
-      seenToursPrompt: false,
-      enableTours: true,
-      seenHomeTour: false,
-      seenCredentialsTour: false,
-      seenCredentialOfferTour: false,
-      seenProofRequestTour: false,
-    },
-    deepLink: {
-      activeDeepLink: '',
-    },
-    loading: false,
-  }
+export const testDefaultState: State = {
+  ...defaultState,
+  preferences: {
+    ...defaultState.preferences,
+    walletName: 'test-wallet',
+  },
+}

--- a/packages/legacy/core/__tests__/contexts/store.ts
+++ b/packages/legacy/core/__tests__/contexts/store.ts
@@ -1,0 +1,50 @@
+import { State } from "../../App/types/state";
+
+export const defaultState: State = {
+    onboarding: {
+      didAgreeToTerms: false,
+      didCompleteTutorial: false,
+      didCreatePIN: false,
+      didConsiderBiometry: false,
+      didNameWallet: false,
+    },
+    authentication: {
+      didAuthenticate: false,
+    },
+    // NOTE: from AFJ 0.4.0 on we use Aries Askar. New wallets will be created with Askar from the start
+    // which we will know when we create the pin while using askar as a dependency.
+    migration: {
+      didMigrateToAskar: false,
+    },
+    loginAttempt: {
+      loginAttempts: 0,
+      servedPenalty: true,
+    },
+    lockout: {
+      displayNotification: false,
+    },
+    preferences: {
+      developerModeEnabled: false,
+      biometryPreferencesUpdated: false,
+      useBiometry: false,
+      useVerifierCapability: false,
+      useConnectionInviterCapability: false,
+      useDevVerifierTemplates: false,
+      acceptDevCredentials: false,
+      useDataRetention: true,
+      enableWalletNaming: false,
+      walletName: 'test-wallet',
+    },
+    tours: {
+      seenToursPrompt: false,
+      enableTours: true,
+      seenHomeTour: false,
+      seenCredentialsTour: false,
+      seenCredentialOfferTour: false,
+      seenProofRequestTour: false,
+    },
+    deepLink: {
+      activeDeepLink: '',
+    },
+    loading: false,
+  }

--- a/packages/legacy/core/__tests__/screens/Settings.test.tsx
+++ b/packages/legacy/core/__tests__/screens/Settings.test.tsx
@@ -1,0 +1,83 @@
+import { useNavigation } from '@react-navigation/core'
+import { render } from '@testing-library/react-native'
+import React from 'react'
+
+import Settings from '../../App/screens/Settings'
+import configurationContext from '../contexts/configuration'
+import { ConfigurationContext } from '../../App/contexts/configuration'
+import { testIdWithKey } from '../../App/utils/testable'
+import { StoreContext, StoreProvider } from '../../App'
+import { defaultState } from '../contexts/store'
+
+jest.mock('@react-navigation/core', () => {
+  return require('../../__mocks__/custom/@react-navigation/core')
+})
+jest.mock('@react-navigation/native', () => {
+  return require('../../__mocks__/custom/@react-navigation/native')
+})
+jest.mock('react-native-fs', () => ({}))
+jest.mock('@hyperledger/anoncreds-react-native', () => ({}))
+jest.mock('@hyperledger/aries-askar-react-native', () => ({}))
+jest.mock('@hyperledger/indy-vdr-react-native', () => ({}))
+jest.mock('react-native-permissions', () => require('react-native-permissions/mock'))
+
+jest.mock('react-native-device-info', () => {
+  return {
+    getVersion: () => 1,
+    getBuildNumber: () => 1,
+  }
+})
+
+describe('Settings Screen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('Renders correctly', async () => {
+    const tree = render(
+      <ConfigurationContext.Provider value={configurationContext}>
+        <Settings navigation={useNavigation()} route={{} as any} />
+      </ConfigurationContext.Provider>
+    )
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('If developer mode is enabled, developer mode button is shown', async () => {
+    const customState = {
+      ...defaultState,
+      preferences: {
+        ...defaultState.preferences,
+        developerModeEnabled: true
+      }
+    } 
+    const tree = render(
+      <StoreContext.Provider value={[customState, () => { return }]}>
+        <ConfigurationContext.Provider value={configurationContext}>
+          <Settings navigation={useNavigation()} route={{} as any} />
+        </ConfigurationContext.Provider>
+      </StoreContext.Provider>
+    )
+    
+    const developerModeButton = tree.getByTestId(testIdWithKey('DeveloperOptions'))
+    expect(developerModeButton).not.toBeNull()    
+  })
+
+  test('If mobile verifier is enabled, verifier options are shown', async () => {
+    const customState = {
+      ...defaultState,
+      preferences: {
+        ...defaultState.preferences,
+        useVerifierCapability: true
+      }
+    }    
+    const tree = render(
+      <StoreContext.Provider value={[customState, () => { return }]}>
+        <ConfigurationContext.Provider value={configurationContext}>
+          <Settings navigation={useNavigation()} route={{} as any} />
+        </ConfigurationContext.Provider>
+      </StoreContext.Provider>
+    )
+    const proofButton = tree.getByTestId(testIdWithKey('ProofRequests'))
+    expect(proofButton).not.toBeNull()
+  })
+})

--- a/packages/legacy/core/__tests__/screens/Settings.test.tsx
+++ b/packages/legacy/core/__tests__/screens/Settings.test.tsx
@@ -7,7 +7,7 @@ import configurationContext from '../contexts/configuration'
 import { ConfigurationContext } from '../../App/contexts/configuration'
 import { testIdWithKey } from '../../App/utils/testable'
 import { StoreContext, StoreProvider } from '../../App'
-import { defaultState } from '../contexts/store'
+import { testDefaultState } from '../contexts/store'
 
 jest.mock('@react-navigation/core', () => {
   return require('../../__mocks__/custom/@react-navigation/core')
@@ -44,9 +44,9 @@ describe('Settings Screen', () => {
 
   test('If developer mode is enabled, developer mode button is shown', async () => {
     const customState = {
-      ...defaultState,
+      ...testDefaultState,
       preferences: {
-        ...defaultState.preferences,
+        ...testDefaultState.preferences,
         developerModeEnabled: true
       }
     } 
@@ -64,9 +64,9 @@ describe('Settings Screen', () => {
 
   test('If mobile verifier is enabled, verifier options are shown', async () => {
     const customState = {
-      ...defaultState,
+      ...testDefaultState,
       preferences: {
-        ...defaultState.preferences,
+        ...testDefaultState.preferences,
         useVerifierCapability: true
       }
     }    

--- a/packages/legacy/core/__tests__/screens/__snapshots__/Settings.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/Settings.test.tsx.snap
@@ -1,0 +1,790 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Settings Screen Renders correctly 1`] = `
+<RNCSafeAreaView
+  edges={
+    Array [
+      "bottom",
+      "left",
+      "right",
+    ]
+  }
+  style={
+    Object {
+      "backgroundColor": "#000000",
+      "width": "100%",
+    }
+  }
+>
+  <RCTScrollView
+    ListFooterComponent={[Function]}
+    data={
+      Array [
+        Object {
+          "data": Array [
+            Object {
+              "accessibilityLabel": "Screens.Contacts",
+              "onPress": [Function],
+              "testID": "com.ariesbifold:id/Contacts",
+              "title": "Screens.Contacts",
+            },
+            Object {
+              "accessibilityLabel": "Settings.WhatAreContacts",
+              "onPress": [Function],
+              "testID": "com.ariesbifold:id/WhatAreContacts",
+              "title": "Settings.WhatAreContacts",
+              "value": undefined,
+            },
+          ],
+          "header": Object {
+            "icon": "apartment",
+            "title": "Screens.Contacts",
+          },
+        },
+        Object {
+          "data": Array [
+            Object {
+              "accessibilityLabel": "Global.Biometrics",
+              "onPress": [Function],
+              "testID": "com.ariesbifold:id/Biometrics",
+              "title": "Global.Biometrics",
+              "value": "Global.Off",
+            },
+            Object {
+              "accessibilityLabel": "Settings.ChangePin",
+              "onPress": [Function],
+              "testID": "com.ariesbifold:id/Change Pin",
+              "title": "Settings.ChangePin",
+              "value": undefined,
+            },
+            Object {
+              "accessibilityLabel": "Settings.Language",
+              "onPress": [Function],
+              "testID": "com.ariesbifold:id/Language",
+              "title": "Settings.Language",
+              "value": "Language.English",
+            },
+          ],
+          "header": Object {
+            "icon": "settings",
+            "title": "Settings.AppSettings",
+          },
+        },
+      ]
+    }
+    getItem={[Function]}
+    getItemCount={[Function]}
+    keyExtractor={[Function]}
+    onContentSizeChange={[Function]}
+    onLayout={[Function]}
+    onMomentumScrollBegin={[Function]}
+    onMomentumScrollEnd={[Function]}
+    onScroll={[Function]}
+    onScrollBeginDrag={[Function]}
+    onScrollEndDrag={[Function]}
+    renderItem={[Function]}
+    scrollEventThrottle={50}
+    stickyHeaderIndices={Array []}
+  >
+    <View>
+      <View
+        onLayout={[Function]}
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "backgroundColor": "#313132",
+                "flexGrow": 1,
+                "paddingVertical": 24,
+              },
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "marginBottom": -11,
+                "paddingBottom": 0,
+                "paddingHorizontal": 25,
+              },
+            ]
+          }
+        >
+          <Text
+            accessible={false}
+            allowFontScaling={false}
+            style={
+              Array [
+                Object {
+                  "color": undefined,
+                  "fontSize": 24,
+                },
+                Object {
+                  "color": "#FFFFFF",
+                  "marginRight": 10,
+                },
+                Object {
+                  "fontFamily": "Material Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+          <Text
+            accessibilityRole="header"
+            style={
+              Array [
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 26,
+                  "fontWeight": "bold",
+                },
+                Object {
+                  "flexShrink": 1,
+                },
+              ]
+            }
+          >
+            Screens.Contacts
+          </Text>
+        </View>
+      </View>
+      <View
+        onLayout={[Function]}
+        style={null}
+      >
+        <View>
+          <View
+            style={
+              Array [
+                Object {
+                  "marginBottom": 10,
+                },
+              ]
+            }
+          />
+          <RCTScrollView
+            contentContainerStyle={
+              Object {
+                "flexGrow": 1,
+              }
+            }
+            horizontal={true}
+            style={
+              Object {
+                "backgroundColor": "#313132",
+                "flexGrow": 1,
+                "paddingVertical": 24,
+              }
+            }
+          >
+            <View>
+              <View
+                accessibilityLabel="Screens.Contacts"
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                nativeID="animatedComponent"
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "justifyContent": "space-between",
+                    "opacity": 1,
+                    "paddingHorizontal": 25,
+                  }
+                }
+                testID="com.ariesbifold:id/Contacts"
+              >
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 21,
+                        "fontWeight": "bold",
+                      },
+                      Object {
+                        "fontWeight": "normal",
+                        "marginRight": 14,
+                      },
+                    ]
+                  }
+                >
+                  Screens.Contacts
+                </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 21,
+                        "fontWeight": "bold",
+                      },
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontWeight": "normal",
+                      },
+                    ]
+                  }
+                />
+              </View>
+            </View>
+          </RCTScrollView>
+          <View
+            style={
+              Object {
+                "backgroundColor": "#313132",
+              }
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "#000000",
+                    "borderBottomWidth": 1,
+                    "marginHorizontal": 25,
+                  },
+                ]
+              }
+            />
+          </View>
+        </View>
+      </View>
+      <View
+        onLayout={[Function]}
+        style={null}
+      >
+        <View>
+          <RCTScrollView
+            contentContainerStyle={
+              Object {
+                "flexGrow": 1,
+              }
+            }
+            horizontal={true}
+            style={
+              Object {
+                "backgroundColor": "#313132",
+                "flexGrow": 1,
+                "paddingVertical": 24,
+              }
+            }
+          >
+            <View>
+              <View
+                accessibilityLabel="Settings.WhatAreContacts"
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                nativeID="animatedComponent"
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "justifyContent": "space-between",
+                    "opacity": 1,
+                    "paddingHorizontal": 25,
+                  }
+                }
+                testID="com.ariesbifold:id/WhatAreContacts"
+              >
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 21,
+                        "fontWeight": "bold",
+                      },
+                      Object {
+                        "fontWeight": "normal",
+                        "marginRight": 14,
+                      },
+                    ]
+                  }
+                >
+                  Settings.WhatAreContacts
+                </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 21,
+                        "fontWeight": "bold",
+                      },
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontWeight": "normal",
+                      },
+                    ]
+                  }
+                />
+              </View>
+            </View>
+          </RCTScrollView>
+          <View
+            style={
+              Array [
+                Object {
+                  "marginBottom": 10,
+                },
+              ]
+            }
+          />
+        </View>
+      </View>
+      <View
+        onLayout={[Function]}
+        style={null}
+      />
+      <View
+        onLayout={[Function]}
+        style={null}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "backgroundColor": "#313132",
+                "flexGrow": 1,
+                "paddingVertical": 24,
+              },
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "marginBottom": -11,
+                "paddingBottom": 0,
+                "paddingHorizontal": 25,
+              },
+            ]
+          }
+        >
+          <Text
+            accessible={false}
+            allowFontScaling={false}
+            style={
+              Array [
+                Object {
+                  "color": undefined,
+                  "fontSize": 24,
+                },
+                Object {
+                  "color": "#FFFFFF",
+                  "marginRight": 10,
+                },
+                Object {
+                  "fontFamily": "Material Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+          <Text
+            accessibilityRole="header"
+            style={
+              Array [
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 26,
+                  "fontWeight": "bold",
+                },
+                Object {
+                  "flexShrink": 1,
+                },
+              ]
+            }
+          >
+            Settings.AppSettings
+          </Text>
+        </View>
+      </View>
+      <View
+        onLayout={[Function]}
+        style={null}
+      >
+        <View>
+          <View
+            style={
+              Array [
+                Object {
+                  "marginBottom": 10,
+                },
+              ]
+            }
+          />
+          <RCTScrollView
+            contentContainerStyle={
+              Object {
+                "flexGrow": 1,
+              }
+            }
+            horizontal={true}
+            style={
+              Object {
+                "backgroundColor": "#313132",
+                "flexGrow": 1,
+                "paddingVertical": 24,
+              }
+            }
+          >
+            <View>
+              <View
+                accessibilityLabel="Global.Biometrics"
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                nativeID="animatedComponent"
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "justifyContent": "space-between",
+                    "opacity": 1,
+                    "paddingHorizontal": 25,
+                  }
+                }
+                testID="com.ariesbifold:id/Biometrics"
+              >
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 21,
+                        "fontWeight": "bold",
+                      },
+                      Object {
+                        "fontWeight": "normal",
+                        "marginRight": 14,
+                      },
+                    ]
+                  }
+                >
+                  Global.Biometrics
+                </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 21,
+                        "fontWeight": "bold",
+                      },
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontWeight": "normal",
+                      },
+                    ]
+                  }
+                >
+                  Global.Off
+                </Text>
+              </View>
+            </View>
+          </RCTScrollView>
+          <View
+            style={
+              Object {
+                "backgroundColor": "#313132",
+              }
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "#000000",
+                    "borderBottomWidth": 1,
+                    "marginHorizontal": 25,
+                  },
+                ]
+              }
+            />
+          </View>
+        </View>
+      </View>
+      <View
+        onLayout={[Function]}
+        style={null}
+      >
+        <View>
+          <RCTScrollView
+            contentContainerStyle={
+              Object {
+                "flexGrow": 1,
+              }
+            }
+            horizontal={true}
+            style={
+              Object {
+                "backgroundColor": "#313132",
+                "flexGrow": 1,
+                "paddingVertical": 24,
+              }
+            }
+          >
+            <View>
+              <View
+                accessibilityLabel="Settings.ChangePin"
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                nativeID="animatedComponent"
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "justifyContent": "space-between",
+                    "opacity": 1,
+                    "paddingHorizontal": 25,
+                  }
+                }
+                testID="com.ariesbifold:id/Change Pin"
+              >
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 21,
+                        "fontWeight": "bold",
+                      },
+                      Object {
+                        "fontWeight": "normal",
+                        "marginRight": 14,
+                      },
+                    ]
+                  }
+                >
+                  Settings.ChangePin
+                </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 21,
+                        "fontWeight": "bold",
+                      },
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontWeight": "normal",
+                      },
+                    ]
+                  }
+                />
+              </View>
+            </View>
+          </RCTScrollView>
+          <View
+            style={
+              Object {
+                "backgroundColor": "#313132",
+              }
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "borderBottomColor": "#000000",
+                    "borderBottomWidth": 1,
+                    "marginHorizontal": 25,
+                  },
+                ]
+              }
+            />
+          </View>
+        </View>
+      </View>
+      <View
+        onLayout={[Function]}
+        style={null}
+      >
+        <View>
+          <RCTScrollView
+            contentContainerStyle={
+              Object {
+                "flexGrow": 1,
+              }
+            }
+            horizontal={true}
+            style={
+              Object {
+                "backgroundColor": "#313132",
+                "flexGrow": 1,
+                "paddingVertical": 24,
+              }
+            }
+          >
+            <View>
+              <View
+                accessibilityLabel="Settings.Language"
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                nativeID="animatedComponent"
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "justifyContent": "space-between",
+                    "opacity": 1,
+                    "paddingHorizontal": 25,
+                  }
+                }
+                testID="com.ariesbifold:id/Language"
+              >
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 21,
+                        "fontWeight": "bold",
+                      },
+                      Object {
+                        "fontWeight": "normal",
+                        "marginRight": 14,
+                      },
+                    ]
+                  }
+                >
+                  Settings.Language
+                </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontSize": 21,
+                        "fontWeight": "bold",
+                      },
+                      Object {
+                        "color": "#FFFFFF",
+                        "fontWeight": "normal",
+                      },
+                    ]
+                  }
+                >
+                  Language.English
+                </Text>
+              </View>
+            </View>
+          </RCTScrollView>
+          <View
+            style={
+              Array [
+                Object {
+                  "marginBottom": 10,
+                },
+              ]
+            }
+          />
+        </View>
+      </View>
+      <View
+        onLayout={[Function]}
+        style={null}
+      />
+      <View
+        onLayout={[Function]}
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "marginVertical": 25,
+            }
+          }
+        >
+          <View
+            accessibilityState={
+              Object {
+                "disabled": false,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                }
+              }
+              testID="com.ariesbifold:id/Version"
+            >
+              Settings.Version 1 Settings.Build (1)
+            </Text>
+            <
+              height={64}
+              marginVertical={16}
+              width="50%"
+            />
+          </View>
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</RNCSafeAreaView>
+`;


### PR DESCRIPTION
# Summary of Changes

Since **Data retention** (introduced in #935)  is an options for the mobile verifier, it should not be shown if mobile verifier is not enabled.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [X] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [X] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [X] Updated documentation as needed for changed code and new or modified features;
- [X] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
