### PR TITLE
fix: empty scan screen when clicking Not Now.

### DIFF
--- a/packages/legacy/core/App/components/modals/CameraDisclosureModal.tsx
+++ b/packages/legacy/core/App/components/modals/CameraDisclosureModal.tsx
@@ -6,7 +6,7 @@ import { Modal, ScrollView, StyleSheet, Text, View, Linking } from 'react-native
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import { useTheme } from '../../contexts/theme'
-import { Screens, HomeStackParams } from '../../types/navigators'
+import { Screens, HomeStackParams, TabStacks } from '../../types/navigators'
 import { testIdWithKey } from '../../utils/testable'
 import Button, { ButtonType } from '../buttons/Button'
 
@@ -55,12 +55,12 @@ const CameraDisclosureModal: React.FC<CameraDisclosureModalProps> = ({ requestCa
   const onOpenSettingsTouched = async () => {
     setModalVisible(false)
     await Linking.openSettings()
-    navigation.navigate(Screens.Home)
+    navigation.getParent()?.navigate(TabStacks.HomeStack, { screen: Screens.Home })
   }
 
   const onNotNowTouched = () => {
     setModalVisible(false)
-    navigation.navigate(Screens.Home)
+    navigation.getParent()?.navigate(TabStacks.HomeStack, { screen: Screens.Home })
   }
 
   const onOpenSettingsDismissed = () => {


### PR DESCRIPTION
# Summary of Changes

Fix empty screen is displayed if the user does not allow camera usage after tapping the Scan button from the Credentials list 

# Related Issues

https://github.com/hyperledger/aries-mobile-agent-react-native/issues/914

# Pull Request Checklist

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.