### PR TITLE
fix: mobile connection chat navigation

### DIFF
--- a/packages/legacy/core/App/screens/Connection.tsx
+++ b/packages/legacy/core/App/screens/Connection.tsx
@@ -146,7 +146,6 @@ const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
 
     if (
       connectionId &&
-      oobRecord &&
       (!goalCode || (!goalCode.startsWith('aries.vc.verify') && !goalCode.startsWith('aries.vc.issue')))
     ) {
       // No goal code, we don't know what to expect next,


### PR DESCRIPTION
# Summary of Changes

Previously the wallet would only navigate to the chat screen from a connection loading screen if the connectionId ***and*** the oobId was not undefined. The oobId is only ever defined for the invitee, since they're the one's receiving the oob invitation. I removed the condition that checked if oobId was defined before navigating

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
