### PR TITLE
fix: predicate error message

### DIFF
--- a/packages/legacy/core/App/components/misc/CredentialCard.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard.tsx
@@ -20,6 +20,7 @@ interface CredentialCardProps {
   proof?: boolean
   displayItems?: (Attribute | Predicate)[]
   existsInWallet?: boolean
+  satisfiedPredicates?: boolean
 }
 
 const CredentialCard: React.FC<CredentialCardProps> = ({
@@ -30,6 +31,7 @@ const CredentialCard: React.FC<CredentialCardProps> = ({
   displayItems,
   credName,
   existsInWallet,
+  satisfiedPredicates,
   style = {},
   onPress = undefined,
 }) => {
@@ -43,6 +45,7 @@ const CredentialCard: React.FC<CredentialCardProps> = ({
           displayItems={displayItems}
           style={{ backgroundColor: ColorPallet.brand.secondaryBackground }}
           error={!existsInWallet}
+          predicateError={!satisfiedPredicates}
           credName={credName}
           credDefId={credDefId}
           schemaId={schemaId}

--- a/packages/legacy/core/App/components/misc/CredentialCard11.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard11.tsx
@@ -25,6 +25,7 @@ interface CredentialCard11Props {
   displayItems?: (Attribute | Predicate)[]
   revoked?: boolean
   error?: boolean
+  predicateError?: boolean
   elevated?: boolean
   credName?: string
   credDefId?: string
@@ -67,6 +68,7 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
   displayItems,
   onPress = undefined,
   error = false,
+  predicateError = false,
   elevated = false,
   credName,
   credDefId,
@@ -240,7 +242,7 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
               },
             ]}
           >
-            {!error ? (
+            {!predicateError && !error ? (
               (overlay.metaOverlay?.name ?? overlay.metaOverlay?.issuer ?? 'C')?.charAt(0).toUpperCase()
             ) : (
               <Icon name={'warning'} size={30} style={styles.errorIcon} />
@@ -400,7 +402,7 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
           styles.secondaryBodyContainer,
           {
             backgroundColor:
-              error || isProofRevoked
+              error || predicateError || isProofRevoked
                 ? ColorPallet.notification.errorBorder
                 : styles.secondaryBodyContainer.backgroundColor,
           },
@@ -418,7 +420,7 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
             {null}
           </ImageBackground>
         ) : (
-          !(error || proof || getSecondaryBackgroundColor()) && (
+          !(error || predicateError || proof || getSecondaryBackgroundColor()) && (
             <View
               style={[
                 {


### PR DESCRIPTION
# Summary of Changes

We are addressing an issue with proof requests involving multiple credentials. Previously, all proof items were marked in red as errors, even if only one of them was incorrect. Now, we are applying a filter based on the `credDefId` so that only the credential with the unsatisfied predicate is displayed with an error layout.

# Related Issues
N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [X] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [X] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [X] Updated documentation as needed for changed code and new or modified features;
- [X] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
