### PR TITLE
fix: chat navigation

### DIFF
--- a/packages/legacy/core/App/navigators/DeliveryStack.tsx
+++ b/packages/legacy/core/App/navigators/DeliveryStack.tsx
@@ -2,15 +2,12 @@ import { CardStyleInterpolators, createStackNavigator } from '@react-navigation/
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
-import HeaderButton, { ButtonLocation } from '../components/buttons/HeaderButton'
 import HeaderRightHome from '../components/buttons/HeaderHome'
 import { useTheme } from '../contexts/theme'
-import Chat from '../screens/Chat'
 import Connection from '../screens/Connection'
 import CredentialOffer from '../screens/CredentialOffer'
 import ProofRequest from '../screens/ProofRequest'
-import { DeliveryStackParams, Screens, TabStacks } from '../types/navigators'
-import { testIdWithKey } from '../utils/testable'
+import { DeliveryStackParams, Screens } from '../types/navigators'
 
 import { createDefaultStackOptions } from './defaultStackOptions'
 
@@ -42,24 +39,6 @@ const DeliveryStack: React.FC = () => {
         name={Screens.CredentialOffer}
         component={CredentialOffer}
         options={{ title: t('Screens.CredentialOffer') }}
-      />
-      <Stack.Screen
-        name={Screens.Chat}
-        component={Chat}
-        options={({ navigation }) => ({
-          title: t('Screens.CredentialOffer'),
-          headerLeft: () => (
-            <HeaderButton
-              buttonLocation={ButtonLocation.Left}
-              accessibilityLabel={t('Global.Back')}
-              testID={testIdWithKey('BackButton')}
-              onPress={() => {
-                navigation.getParent()?.navigate(TabStacks.HomeStack, { screen: Screens.Home })
-              }}
-              icon="arrow-left"
-            />
-          ),
-        })}
       />
     </Stack.Navigator>
   )

--- a/packages/legacy/core/App/navigators/RootStack.tsx
+++ b/packages/legacy/core/App/navigators/RootStack.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { AppState, DeviceEventEmitter } from 'react-native'
 
+import HeaderButton, { ButtonLocation } from '../components/buttons/HeaderButton'
 import { EventTypes, walletTimeout } from '../constants'
 import { useAuth } from '../contexts/auth'
 import { useConfiguration } from '../contexts/configuration'
@@ -13,13 +14,14 @@ import { useStore } from '../contexts/store'
 import { useTheme } from '../contexts/theme'
 import { useDeepLinks } from '../hooks/deep-links'
 import AttemptLockout from '../screens/AttemptLockout'
+import Chat from '../screens/Chat'
 import NameWallet from '../screens/NameWallet'
 import Onboarding from '../screens/Onboarding'
 import { createCarouselStyle } from '../screens/OnboardingPages'
 import PINCreate from '../screens/PINCreate'
 import PINEnter from '../screens/PINEnter'
 import { BifoldError } from '../types/error'
-import { AuthenticateStackParams, Screens, Stacks } from '../types/navigators'
+import { AuthenticateStackParams, Screens, Stacks, TabStacks } from '../types/navigators'
 import { connectFromInvitation, getOobDeepLink } from '../utils/helpers'
 import { testIdWithKey } from '../utils/testable'
 
@@ -191,6 +193,25 @@ const RootStack: React.FC = () => {
       <Stack.Navigator initialRouteName={Screens.Splash} screenOptions={{ ...defaultStackOptions, headerShown: false }}>
         <Stack.Screen name={Screens.Splash} component={splash} />
         <Stack.Screen name={Stacks.TabStack} component={TabStack} />
+        <Stack.Screen
+          name={Screens.Chat}
+          component={Chat}
+          options={({ navigation }) => ({
+            headerShown: true,
+            title: t('Screens.CredentialOffer'),
+            headerLeft: () => (
+              <HeaderButton
+                buttonLocation={ButtonLocation.Left}
+                accessibilityLabel={t('Global.Back')}
+                testID={testIdWithKey('BackButton')}
+                onPress={() => {
+                  navigation.navigate(TabStacks.HomeStack, { screen: Screens.Home })
+                }}
+                icon="arrow-left"
+              />
+            ),
+          })}
+        />
         <Stack.Screen
           name={Stacks.ConnectStack}
           component={ConnectStack}

--- a/packages/legacy/core/App/screens/Chat.tsx
+++ b/packages/legacy/core/App/screens/Chat.tsx
@@ -7,7 +7,8 @@ import {
   ProofState,
 } from '@aries-framework/core'
 import { useAgent, useBasicMessagesByConnectionId, useConnectionById } from '@aries-framework/react-hooks'
-import { StackScreenProps } from '@react-navigation/stack'
+import { useNavigation } from '@react-navigation/core'
+import { StackNavigationProp, StackScreenProps } from '@react-navigation/stack'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Linking, Text } from 'react-native'
@@ -28,7 +29,7 @@ import { useCredentialsByConnectionId } from '../hooks/credentials'
 import { useProofsByConnectionId } from '../hooks/proofs'
 import { Role } from '../types/chat'
 import { BasicMessageMetadata, basicMessageCustomMetadata } from '../types/metadata'
-import { ContactStackParams, Screens, Stacks } from '../types/navigators'
+import { RootStackParams, ContactStackParams, Screens, Stacks } from '../types/navigators'
 import {
   getCredentialEventLabel,
   getCredentialEventRole,
@@ -37,9 +38,9 @@ import {
   getProofEventRole,
 } from '../utils/helpers'
 
-type ChatProps = StackScreenProps<ContactStackParams, Screens.Chat>
+type ChatProps = StackScreenProps<ContactStackParams, Screens.Chat> | StackScreenProps<RootStackParams, Screens.Chat>
 
-const Chat: React.FC<ChatProps> = ({ navigation, route }) => {
+const Chat: React.FC<ChatProps> = ({ route }) => {
   if (!route?.params) {
     throw new Error('Chat route params were not set properly')
   }
@@ -48,6 +49,7 @@ const Chat: React.FC<ChatProps> = ({ navigation, route }) => {
   const [store] = useStore()
   const { t } = useTranslation()
   const { agent } = useAgent()
+  const navigation = useNavigation<StackNavigationProp<RootStackParams | ContactStackParams>>()
   const connection = useConnectionById(connectionId)
   const basicMessages = useBasicMessagesByConnectionId(connectionId)
   const credentials = useCredentialsByConnectionId(connectionId)
@@ -168,13 +170,13 @@ const Chat: React.FC<ChatProps> = ({ navigation, route }) => {
           onDetails: () => {
             const navMap: { [key in CredentialState]?: () => void } = {
               [CredentialState.Done]: () => {
-                navigation.getParent()?.navigate(Stacks.ContactStack, {
+                navigation.navigate(Stacks.ContactStack as any, {
                   screen: Screens.CredentialDetails,
                   params: { credential: record },
                 })
               },
               [CredentialState.OfferReceived]: () => {
-                navigation.getParent()?.navigate(Stacks.ContactStack, {
+                navigation.navigate(Stacks.ContactStack as any, {
                   screen: Screens.CredentialOffer,
                   params: { credentialId: record.id },
                 })
@@ -205,7 +207,7 @@ const Chat: React.FC<ChatProps> = ({ navigation, route }) => {
           messageOpensCallbackType: callbackTypeForMessage(record),
           onDetails: () => {
             const toProofDetails = () => {
-              navigation.getParent()?.navigate(Stacks.ContactStack, {
+              navigation.navigate(Stacks.ContactStack as any, {
                 screen: Screens.ProofDetails,
                 params: {
                   recordId: record.id,
@@ -221,7 +223,7 @@ const Chat: React.FC<ChatProps> = ({ navigation, route }) => {
               [ProofState.PresentationSent]: toProofDetails,
               [ProofState.PresentationReceived]: toProofDetails,
               [ProofState.RequestReceived]: () => {
-                navigation.getParent()?.navigate(Stacks.ContactStack, {
+                navigation.navigate(Stacks.ContactStack as any, {
                   screen: Screens.ProofRequest,
                   params: { proofId: record.id },
                 })
@@ -266,7 +268,7 @@ const Chat: React.FC<ChatProps> = ({ navigation, route }) => {
   )
 
   const onSendRequest = useCallback(async () => {
-    navigation.getParent()?.navigate(Stacks.ProofRequestsStack, {
+    navigation.navigate(Stacks.ProofRequestsStack as any, {
       screen: Screens.ProofRequests,
       params: { navigation: navigation, connectionId },
     })

--- a/packages/legacy/core/App/screens/Connection.tsx
+++ b/packages/legacy/core/App/screens/Connection.tsx
@@ -1,5 +1,5 @@
 import { useConnectionById } from '@aries-framework/react-hooks'
-import { useFocusEffect } from '@react-navigation/native'
+import { CommonActions, useFocusEffect } from '@react-navigation/native'
 import { StackScreenProps } from '@react-navigation/stack'
 import React, { useCallback, useEffect, useMemo, useReducer, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -12,7 +12,7 @@ import { useConfiguration } from '../contexts/configuration'
 import { useTheme } from '../contexts/theme'
 import { useOutOfBandByConnectionId } from '../hooks/connections'
 import { useNotifications } from '../hooks/notifications'
-import { Screens, TabStacks, DeliveryStackParams } from '../types/navigators'
+import { Screens, TabStacks, DeliveryStackParams, Stacks } from '../types/navigators'
 import { testIdWithKey } from '../utils/testable'
 
 type ConnectionProps = StackScreenProps<DeliveryStackParams, Screens.Connection>
@@ -149,8 +149,14 @@ const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
       (!goalCode || (!goalCode.startsWith('aries.vc.verify') && !goalCode.startsWith('aries.vc.issue')))
     ) {
       // No goal code, we don't know what to expect next,
-      // navigate to the chat screen.
-      navigation.navigate(Screens.Chat, { connectionId })
+      // navigate to the chat screen and set home screen as only history
+      navigation.getParent()?.dispatch(
+        CommonActions.reset({
+          index: 1,
+          routes: [{ name: Stacks.TabStack }, { name: Screens.Chat, params: { connectionId } }],
+        })
+      )
+
       dispatch({ isVisible: false })
       return
     }

--- a/packages/legacy/core/App/types/navigators.ts
+++ b/packages/legacy/core/App/types/navigators.ts
@@ -57,6 +57,7 @@ export enum TabStacks {
 export type RootStackParams = {
   [Screens.Splash]: undefined
   [Stacks.TabStack]: NavigatorScreenParams<TabStackParams>
+  [Screens.Chat]: { connectionId: string }
   [Stacks.ConnectStack]: NavigatorScreenParams<ConnectStackParams>
   [Stacks.SettingStack]: NavigatorScreenParams<SettingStackParams>
   [Stacks.ContactStack]: NavigatorScreenParams<ContactStackParams>

--- a/packages/legacy/core/__mocks__/custom/@react-navigation/core.ts
+++ b/packages/legacy/core/__mocks__/custom/@react-navigation/core.ts
@@ -1,10 +1,11 @@
 const navigate = jest.fn()
-
+const dispatch = jest.fn()
 const navigation = {
   navigate,
   setOptions: jest.fn(),
   getParent: jest.fn(() => ({
     navigate,
+    dispatch,
   })),
   getState: jest.fn(() => ({
     index: jest.fn(),
@@ -13,7 +14,7 @@ const navigation = {
   pop: jest.fn(),
   reset: jest.fn(),
   isFocused: () => true,
-  dispatch: jest.fn(),
+  dispatch,
 }
 
 const useNavigation = () => {

--- a/packages/legacy/core/__mocks__/custom/@react-navigation/native.ts
+++ b/packages/legacy/core/__mocks__/custom/@react-navigation/native.ts
@@ -3,8 +3,12 @@
 const useFocusEffect = jest.fn()
 const createNavigatorFactory = jest.fn()
 
+const CommonActions = {
+  reset: jest.fn(),
+}
+
 const useIsFocused = () => {
   return true
 }
 
-export { useIsFocused, useFocusEffect, createNavigatorFactory }
+export { useIsFocused, useFocusEffect, createNavigatorFactory, CommonActions }

--- a/packages/legacy/core/__tests__/screens/Connection.test.tsx
+++ b/packages/legacy/core/__tests__/screens/Connection.test.tsx
@@ -1,18 +1,19 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useConnectionById, useProofById } from '@aries-framework/react-hooks'
+import { useNavigation } from '@react-navigation/core'
+import { CommonActions } from '@react-navigation/native'
 import { render, waitFor, fireEvent } from '@testing-library/react-native'
 import fs from 'fs'
 import path from 'path'
 import React from 'react'
 
 import { ConfigurationContext } from '../../App/contexts/configuration'
+import { useOutOfBandByConnectionId } from '../../App/hooks/connections'
 import { useNotifications } from '../../App/hooks/notifications'
 import ConnectionModal from '../../App/screens/Connection'
+import { testIdWithKey } from '../../App/utils/testable'
 import configurationContext from '../contexts/configuration'
 import timeTravel from '../helpers/timetravel'
-import { useOutOfBandByConnectionId } from '../../App/hooks/connections'
-import { useNavigation } from '@react-navigation/core'
-import { testIdWithKey } from '../../App/utils/testable'
 
 const proofNotifPath = path.join(__dirname, '../fixtures/proof-notif.json')
 const proofNotif = JSON.parse(fs.readFileSync(proofNotifPath, 'utf8'))
@@ -152,8 +153,11 @@ describe('ConnectionModal Component', () => {
     const tree = render(element)
 
     expect(tree).toMatchSnapshot()
-    expect(navigation.navigate).toBeCalledTimes(1)
-    expect(navigation.navigate).toBeCalledWith('Chat', { connectionId: connection.id })
+    expect(navigation.getParent()?.dispatch).toBeCalledTimes(1)
+    expect(CommonActions.reset).toBeCalledWith({
+      index: 1,
+      routes: [{ name: 'Tab Stack' }, { name: 'Chat', params: { connectionId: connection.id } }],
+    })
   })
 
   test('No connection proof request auto navigate', async () => {


### PR DESCRIPTION
# Summary of Changes

This PR changes the navigation to the chat screen from the connection screen such that the only history is the home screen, preventing users from using back gestures or hardware back navigation to get to an empty connection or scan screen.

Here is what it looks like:
![chat_navigation](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/32586431/2e7bdc6b-b3c0-4660-896c-a80a69b3b615)

# Related Issues

Please reference here any issue #'s that are relevant to this PR, or simply enter "N/A" if this PR does not relate to any existing issues.

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
