### PR TITLE
fix: deep link error when no params

### DIFF
--- a/packages/legacy/core/App/navigators/RootStack.tsx
+++ b/packages/legacy/core/App/navigators/RootStack.tsx
@@ -70,6 +70,15 @@ const RootStack: React.FC = () => {
   // handle deeplink events
   useEffect(() => {
     async function handleDeepLink(deepLink: string) {
+      // If it's just the general link with no params, set link inactive and do nothing
+      if (deepLink.endsWith('//')) {
+        dispatch({
+          type: DispatchAction.ACTIVE_DEEP_LINK,
+          payload: [undefined],
+        })
+        return
+      }
+
       try {
         // Try connection based
         const connectionRecord = await connectFromInvitation(deepLink, agent)
@@ -102,6 +111,7 @@ const RootStack: React.FC = () => {
         payload: [undefined],
       })
     }
+
     if (agent && state.deepLink.activeDeepLink && state.authentication.didAuthenticate) {
       handleDeepLink(state.deepLink.activeDeepLink)
     }


### PR DESCRIPTION
# Summary of Changes

Previously if a deep link to the app was used that didn't have an invitation or connection included, it would throw an error as the connection wasn't able to be parsed. This change checks if it's just a general deep link to the app and early exits the logic without throwing an error. It's a very small and simple change and it's quite difficult to write tests for the RootStack so I'm hoping this PR can squeeze by without.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [ ] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
