### PR TITLE
fix: deeplink issue where no params are set

### DIFF
--- a/packages/legacy/core/App/navigators/RootStack.tsx
+++ b/packages/legacy/core/App/navigators/RootStack.tsx
@@ -1,6 +1,7 @@
 import { useAgent } from '@aries-framework/react-hooks'
 import { useNavigation } from '@react-navigation/core'
 import { createStackNavigator, StackCardStyleInterpolator, StackNavigationProp } from '@react-navigation/stack'
+import { parseUrl } from 'query-string'
 import React, { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { AppState, DeviceEventEmitter } from 'react-native'
@@ -89,6 +90,16 @@ const RootStack: React.FC = () => {
       } catch {
         try {
           // Try connectionless here
+          const queryParams = parseUrl(deepLink).query
+          const param = queryParams['d_m'] ?? queryParams['c_i']
+          // if missing both of the required params, don't attempt to open OOB
+          if (!param) {
+            dispatch({
+              type: DispatchAction.ACTIVE_DEEP_LINK,
+              payload: [undefined],
+            })
+            return
+          }
           const message = await getOobDeepLink(deepLink, agent)
           navigation.navigate(Stacks.ConnectionStack as any, {
             screen: Screens.Connection,


### PR DESCRIPTION
# Summary of Changes

This PR fixes the deeplink error issue sometimes caused by other apps linking into Bifold / BC Wallet without params. The RootStack component is quite difficult to set up for unit / integration testing and it's a small change so I'm hoping we can slide this one by without, given the urgency.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [ ] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
