### PR TITLE
fix: connection not deleted after connectionless proof

### DIFF
--- a/packages/legacy/core/App/screens/ProofDetails.tsx
+++ b/packages/legacy/core/App/screens/ProofDetails.tsx
@@ -275,6 +275,9 @@ const ProofDetails: React.FC<ProofDetailsProps> = ({ route, navigation }) => {
       if (!store.preferences.useDataRetention) {
         agent?.proofs.deleteById(recordId)
       }
+      if ((record?.metadata.get(ProofMetadata.customMetadata) as ProofCustomMetadata).delete_conn_after_seen) {
+        agent?.connections.deleteById(record?.connectionId ?? '')
+      }
     }
   }, [])
 

--- a/packages/legacy/core/App/screens/ProofRequesting.tsx
+++ b/packages/legacy/core/App/screens/ProofRequesting.tsx
@@ -9,7 +9,14 @@ import { useTranslation } from 'react-i18next'
 import { BackHandler, DeviceEventEmitter, useWindowDimensions, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
-import { isPresentationFailed, isPresentationReceived, linkProofWithTemplate, sendProofRequest } from '../../verifier'
+import {
+  ProofCustomMetadata,
+  ProofMetadata,
+  isPresentationFailed,
+  isPresentationReceived,
+  linkProofWithTemplate,
+  sendProofRequest,
+} from '../../verifier'
 import LoadingIndicator from '../components/animated/LoadingIndicator'
 import Button, { ButtonType } from '../components/buttons/Button'
 import QRRenderer from '../components/misc/QRRenderer'
@@ -154,6 +161,9 @@ const ProofRequesting: React.FC<ProofRequestingProps> = ({ route, navigation }) 
         // send proof logic
         const result = await sendProofRequest(agent, template, record.id, predicateValues)
         if (result?.proofRecord) {
+          // verifier side doesn't have access to the goal code so we need to add metadata here
+          const metadata = result.proofRecord.metadata.get(ProofMetadata.customMetadata) as ProofCustomMetadata
+          result.proofRecord.metadata.set(ProofMetadata.customMetadata, { ...metadata, delete_conn_after_seen: true })
           linkProofWithTemplate(agent, result.proofRecord, templateId)
         }
         setProofRecordId(result?.proofRecord.id)

--- a/packages/legacy/core/verifier/types/metadata.ts
+++ b/packages/legacy/core/verifier/types/metadata.ts
@@ -5,4 +5,5 @@ export enum ProofMetadata {
 export interface ProofCustomMetadata {
   details_seen?: boolean
   proof_request_template_id?: string
+  delete_conn_after_seen?: boolean
 }


### PR DESCRIPTION
# Summary of Changes

Previously during a connectionless proof, if the verifier closes the app or goes to the home screen before the holder sends their presentation, then if the verifier open the proof notification from the home screen and then leaves the proof notification page then the connection would be preserved. 

I've altered the functionality so that the connection will always be deleted after viewing a connectionless proof, regardless of where the proof is viewed
![retention](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/36937407/8f21f381-fe89-4593-beb9-db3c49813ba0)


# Related Issues
N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
