### PR TITLE
fix: line break when it’s a long attribute

### DIFF
--- a/packages/legacy/core/App/components/misc/CredentialCard11.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard11.tsx
@@ -130,6 +130,8 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
     primaryBodyContainer: {
       flexGrow: 1,
       padding,
+      marginLeft: -1 * logoHeight + padding,
+      marginRight: logoHeight * 2,
     },
     imageAttr: {
       height: 150,
@@ -366,70 +368,62 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
   const CredentialCardPrimaryBody: React.FC = () => {
     return (
       <View testID={testIdWithKey('CredentialCardPrimaryBody')} style={styles.primaryBodyContainer}>
-        <View
-          style={{
-            marginLeft: -1 * logoHeight + padding,
-            margin: -1,
-            marginRight: 40,
-          }}
-        >
-          <View>
-            {!(overlay.metaOverlay?.issuer === 'Unknown Contact' && proof) && (
-              <View style={{ flexDirection: 'row' }}>
-                <Text
-                  testID={testIdWithKey('CredentialIssuer')}
-                  style={[
-                    TextTheme.label,
-                    styles.textContainer,
-                    {
-                      lineHeight: 19,
-                      opacity: 0.8,
-                      flex: 1,
-                      flexWrap: 'wrap',
-                    },
-                  ]}
-                >
-                  {overlay.metaOverlay?.issuer}
-                </Text>
-              </View>
-            )}
+        <View>
+          {!(overlay.metaOverlay?.issuer === 'Unknown Contact' && proof) && (
             <View style={{ flexDirection: 'row' }}>
               <Text
-                testID={testIdWithKey('CredentialName')}
+                testID={testIdWithKey('CredentialIssuer')}
                 style={[
-                  TextTheme.normal,
+                  TextTheme.label,
                   styles.textContainer,
                   {
-                    fontWeight: 'bold',
-                    lineHeight: 24,
+                    lineHeight: 19,
+                    opacity: 0.8,
                     flex: 1,
                     flexWrap: 'wrap',
-                    color: allPI && proof ? ColorPallet.notification.warnText : styles.textContainer.color,
                   },
                 ]}
               >
-                {overlay.metaOverlay?.name}
-              </Text>
-            </View>
-          </View>
-          {(error || isProofRevoked) && (
-            <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-              <Icon style={[styles.errorIcon]} name="close" size={30} />
-
-              <Text style={[styles.errorText]} testID={testIdWithKey('RevokedOrNotAvailable')} numberOfLines={1}>
-                {error ? t('ProofRequest.NotAvailableInYourWallet') : t('CredentialDetails.Revoked')}
+                {overlay.metaOverlay?.issuer}
               </Text>
             </View>
           )}
-          <FlatList
-            data={cardData}
-            scrollEnabled={false}
-            initialNumToRender={cardData?.length}
-            renderItem={({ item }) => {
-              return renderCardAttribute(item as Attribute & Predicate)
-            }}
-          />
+          <View style={{ flexDirection: 'row' }}>
+            <Text
+              testID={testIdWithKey('CredentialName')}
+              style={[
+                TextTheme.normal,
+                styles.textContainer,
+                {
+                  fontWeight: 'bold',
+                  lineHeight: 24,
+                  flex: 1,
+                  flexWrap: 'wrap',
+                  color: allPI && proof ? ColorPallet.notification.warnText : styles.textContainer.color,
+                },
+              ]}
+            >
+              {overlay.metaOverlay?.name}
+            </Text>
+          </View>
         </View>
+        {(error || isProofRevoked) && (
+          <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+            <Icon style={[styles.errorIcon]} name="close" size={30} />
+
+            <Text style={[styles.errorText]} testID={testIdWithKey('RevokedOrNotAvailable')} numberOfLines={1}>
+              {error ? t('ProofRequest.NotAvailableInYourWallet') : t('CredentialDetails.Revoked')}
+            </Text>
+          </View>
+        )}
+        <FlatList
+          data={cardData}
+          scrollEnabled={false}
+          initialNumToRender={cardData?.length}
+          renderItem={({ item }) => {
+            return renderCardAttribute(item as Attribute & Predicate)
+          }}
+        />
       </View>
     )
   }

--- a/packages/legacy/core/App/components/misc/CredentialCard11.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard11.tsx
@@ -128,10 +128,9 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
       backgroundColor: getSecondaryBackgroundColor() ?? overlay.brandingOverlay?.primaryBackgroundColor,
     },
     primaryBodyContainer: {
-      flexGrow: 1,
+      flex: 1,
       padding,
       marginLeft: -1 * logoHeight + padding,
-      marginRight: logoHeight * 2,
     },
     imageAttr: {
       height: 150,

--- a/packages/legacy/core/App/components/misc/CredentialCard11.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard11.tsx
@@ -131,7 +131,7 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
       flexGrow: 1,
       padding,
       marginLeft: -1 * logoHeight + padding,
-      marginRight: logoHeight * 2,
+      marginRight: logoHeight + (logoHeight - padding) + padding,
     },
     imageAttr: {
       height: 150,

--- a/packages/legacy/core/App/components/misc/CredentialCard11.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard11.tsx
@@ -131,7 +131,7 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
       flexGrow: 1,
       padding,
       marginLeft: -1 * logoHeight + padding,
-      marginRight: logoHeight + (logoHeight - padding) + padding,
+      marginRight: logoHeight * 2,
     },
     imageAttr: {
       height: 150,

--- a/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
@@ -426,123 +426,115 @@ exports[`displays a credential offer screen accepting a credential 1`] = `
                         style={
                           Object {
                             "flexGrow": 1,
+                            "marginLeft": -52.5,
+                            "marginRight": 180,
                             "padding": 37.5,
                           }
                         }
                         testID="com.ariesbifold:id/CredentialCardPrimaryBody"
                       >
-                        <View
-                          style={
-                            Object {
-                              "margin": -1,
-                              "marginLeft": -52.5,
-                              "marginRight": 40,
+                        <View>
+                          <View
+                            style={
+                              Object {
+                                "flexDirection": "row",
+                              }
                             }
-                          }
-                        >
-                          <View>
-                            <View
+                          >
+                            <Text
                               style={
-                                Object {
-                                  "flexDirection": "row",
-                                }
+                                Array [
+                                  Object {
+                                    "color": "#FFFFFF",
+                                    "fontSize": 14,
+                                    "fontWeight": "bold",
+                                  },
+                                  Object {
+                                    "color": "#FFFFFF",
+                                    "flexShrink": 1,
+                                  },
+                                  Object {
+                                    "flex": 1,
+                                    "flexWrap": "wrap",
+                                    "lineHeight": 19,
+                                    "opacity": 0.8,
+                                  },
+                                ]
                               }
+                              testID="com.ariesbifold:id/CredentialIssuer"
                             >
-                              <Text
-                                style={
-                                  Array [
-                                    Object {
-                                      "color": "#FFFFFF",
-                                      "fontSize": 14,
-                                      "fontWeight": "bold",
-                                    },
-                                    Object {
-                                      "color": "#FFFFFF",
-                                      "flexShrink": 1,
-                                    },
-                                    Object {
-                                      "flex": 1,
-                                      "flexWrap": "wrap",
-                                      "lineHeight": 19,
-                                      "opacity": 0.8,
-                                    },
-                                  ]
-                                }
-                                testID="com.ariesbifold:id/CredentialIssuer"
-                              >
-                                faber.agent
-                              </Text>
-                            </View>
-                            <View
-                              style={
-                                Object {
-                                  "flexDirection": "row",
-                                }
-                              }
-                            >
-                              <Text
-                                style={
-                                  Array [
-                                    Object {
-                                      "color": "#FFFFFF",
-                                      "fontSize": 18,
-                                      "fontWeight": "normal",
-                                    },
-                                    Object {
-                                      "color": "#FFFFFF",
-                                      "flexShrink": 1,
-                                    },
-                                    Object {
-                                      "color": "#FFFFFF",
-                                      "flex": 1,
-                                      "flexWrap": "wrap",
-                                      "fontWeight": "bold",
-                                      "lineHeight": 24,
-                                    },
-                                  ]
-                                }
-                                testID="com.ariesbifold:id/CredentialName"
-                              >
-                                Credential
-                              </Text>
-                            </View>
+                              faber.agent
+                            </Text>
                           </View>
                           <View
-                            data={
-                              Array [
-                                undefined,
-                                undefined,
-                              ]
+                            style={
+                              Object {
+                                "flexDirection": "row",
+                              }
                             }
-                            getItem={[Function]}
-                            getItemCount={[Function]}
-                            initialNumToRender={2}
-                            keyExtractor={[Function]}
-                            onContentSizeChange={[Function]}
-                            onLayout={[Function]}
-                            onMomentumScrollBegin={[Function]}
-                            onMomentumScrollEnd={[Function]}
-                            onScroll={[Function]}
-                            onScrollBeginDrag={[Function]}
-                            onScrollEndDrag={[Function]}
-                            removeClippedSubviews={false}
-                            renderItem={[Function]}
-                            scrollEnabled={false}
-                            scrollEventThrottle={50}
-                            stickyHeaderIndices={Array []}
-                            viewabilityConfigCallbackPairs={Array []}
                           >
-                            <View
-                              onFocusCapture={[Function]}
-                              onLayout={[Function]}
-                              style={null}
-                            />
-                            <View
-                              onFocusCapture={[Function]}
-                              onLayout={[Function]}
-                              style={null}
-                            />
+                            <Text
+                              style={
+                                Array [
+                                  Object {
+                                    "color": "#FFFFFF",
+                                    "fontSize": 18,
+                                    "fontWeight": "normal",
+                                  },
+                                  Object {
+                                    "color": "#FFFFFF",
+                                    "flexShrink": 1,
+                                  },
+                                  Object {
+                                    "color": "#FFFFFF",
+                                    "flex": 1,
+                                    "flexWrap": "wrap",
+                                    "fontWeight": "bold",
+                                    "lineHeight": 24,
+                                  },
+                                ]
+                              }
+                              testID="com.ariesbifold:id/CredentialName"
+                            >
+                              Credential
+                            </Text>
                           </View>
+                        </View>
+                        <View
+                          data={
+                            Array [
+                              undefined,
+                              undefined,
+                            ]
+                          }
+                          getItem={[Function]}
+                          getItemCount={[Function]}
+                          initialNumToRender={2}
+                          keyExtractor={[Function]}
+                          onContentSizeChange={[Function]}
+                          onLayout={[Function]}
+                          onMomentumScrollBegin={[Function]}
+                          onMomentumScrollEnd={[Function]}
+                          onScroll={[Function]}
+                          onScrollBeginDrag={[Function]}
+                          onScrollEndDrag={[Function]}
+                          removeClippedSubviews={false}
+                          renderItem={[Function]}
+                          scrollEnabled={false}
+                          scrollEventThrottle={50}
+                          stickyHeaderIndices={Array []}
+                          viewabilityConfigCallbackPairs={Array []}
+                        >
+                          <View
+                            onFocusCapture={[Function]}
+                            onLayout={[Function]}
+                            style={null}
+                          />
+                          <View
+                            onFocusCapture={[Function]}
+                            onLayout={[Function]}
+                            style={null}
+                          />
                         </View>
                       </View>
                       <View
@@ -1971,123 +1963,115 @@ exports[`displays a credential offer screen declining a credential 1`] = `
                         style={
                           Object {
                             "flexGrow": 1,
+                            "marginLeft": -52.5,
+                            "marginRight": 180,
                             "padding": 37.5,
                           }
                         }
                         testID="com.ariesbifold:id/CredentialCardPrimaryBody"
                       >
-                        <View
-                          style={
-                            Object {
-                              "margin": -1,
-                              "marginLeft": -52.5,
-                              "marginRight": 40,
+                        <View>
+                          <View
+                            style={
+                              Object {
+                                "flexDirection": "row",
+                              }
                             }
-                          }
-                        >
-                          <View>
-                            <View
+                          >
+                            <Text
                               style={
-                                Object {
-                                  "flexDirection": "row",
-                                }
+                                Array [
+                                  Object {
+                                    "color": "#FFFFFF",
+                                    "fontSize": 14,
+                                    "fontWeight": "bold",
+                                  },
+                                  Object {
+                                    "color": "#FFFFFF",
+                                    "flexShrink": 1,
+                                  },
+                                  Object {
+                                    "flex": 1,
+                                    "flexWrap": "wrap",
+                                    "lineHeight": 19,
+                                    "opacity": 0.8,
+                                  },
+                                ]
                               }
+                              testID="com.ariesbifold:id/CredentialIssuer"
                             >
-                              <Text
-                                style={
-                                  Array [
-                                    Object {
-                                      "color": "#FFFFFF",
-                                      "fontSize": 14,
-                                      "fontWeight": "bold",
-                                    },
-                                    Object {
-                                      "color": "#FFFFFF",
-                                      "flexShrink": 1,
-                                    },
-                                    Object {
-                                      "flex": 1,
-                                      "flexWrap": "wrap",
-                                      "lineHeight": 19,
-                                      "opacity": 0.8,
-                                    },
-                                  ]
-                                }
-                                testID="com.ariesbifold:id/CredentialIssuer"
-                              >
-                                faber.agent
-                              </Text>
-                            </View>
-                            <View
-                              style={
-                                Object {
-                                  "flexDirection": "row",
-                                }
-                              }
-                            >
-                              <Text
-                                style={
-                                  Array [
-                                    Object {
-                                      "color": "#FFFFFF",
-                                      "fontSize": 18,
-                                      "fontWeight": "normal",
-                                    },
-                                    Object {
-                                      "color": "#FFFFFF",
-                                      "flexShrink": 1,
-                                    },
-                                    Object {
-                                      "color": "#FFFFFF",
-                                      "flex": 1,
-                                      "flexWrap": "wrap",
-                                      "fontWeight": "bold",
-                                      "lineHeight": 24,
-                                    },
-                                  ]
-                                }
-                                testID="com.ariesbifold:id/CredentialName"
-                              >
-                                Credential
-                              </Text>
-                            </View>
+                              faber.agent
+                            </Text>
                           </View>
                           <View
-                            data={
-                              Array [
-                                undefined,
-                                undefined,
-                              ]
+                            style={
+                              Object {
+                                "flexDirection": "row",
+                              }
                             }
-                            getItem={[Function]}
-                            getItemCount={[Function]}
-                            initialNumToRender={2}
-                            keyExtractor={[Function]}
-                            onContentSizeChange={[Function]}
-                            onLayout={[Function]}
-                            onMomentumScrollBegin={[Function]}
-                            onMomentumScrollEnd={[Function]}
-                            onScroll={[Function]}
-                            onScrollBeginDrag={[Function]}
-                            onScrollEndDrag={[Function]}
-                            removeClippedSubviews={false}
-                            renderItem={[Function]}
-                            scrollEnabled={false}
-                            scrollEventThrottle={50}
-                            stickyHeaderIndices={Array []}
-                            viewabilityConfigCallbackPairs={Array []}
                           >
-                            <View
-                              onFocusCapture={[Function]}
-                              onLayout={[Function]}
-                              style={null}
-                            />
-                            <View
-                              onFocusCapture={[Function]}
-                              onLayout={[Function]}
-                              style={null}
-                            />
+                            <Text
+                              style={
+                                Array [
+                                  Object {
+                                    "color": "#FFFFFF",
+                                    "fontSize": 18,
+                                    "fontWeight": "normal",
+                                  },
+                                  Object {
+                                    "color": "#FFFFFF",
+                                    "flexShrink": 1,
+                                  },
+                                  Object {
+                                    "color": "#FFFFFF",
+                                    "flex": 1,
+                                    "flexWrap": "wrap",
+                                    "fontWeight": "bold",
+                                    "lineHeight": 24,
+                                  },
+                                ]
+                              }
+                              testID="com.ariesbifold:id/CredentialName"
+                            >
+                              Credential
+                            </Text>
                           </View>
+                        </View>
+                        <View
+                          data={
+                            Array [
+                              undefined,
+                              undefined,
+                            ]
+                          }
+                          getItem={[Function]}
+                          getItemCount={[Function]}
+                          initialNumToRender={2}
+                          keyExtractor={[Function]}
+                          onContentSizeChange={[Function]}
+                          onLayout={[Function]}
+                          onMomentumScrollBegin={[Function]}
+                          onMomentumScrollEnd={[Function]}
+                          onScroll={[Function]}
+                          onScrollBeginDrag={[Function]}
+                          onScrollEndDrag={[Function]}
+                          removeClippedSubviews={false}
+                          renderItem={[Function]}
+                          scrollEnabled={false}
+                          scrollEventThrottle={50}
+                          stickyHeaderIndices={Array []}
+                          viewabilityConfigCallbackPairs={Array []}
+                        >
+                          <View
+                            onFocusCapture={[Function]}
+                            onLayout={[Function]}
+                            style={null}
+                          />
+                          <View
+                            onFocusCapture={[Function]}
+                            onLayout={[Function]}
+                            style={null}
+                          />
                         </View>
                       </View>
                       <View
@@ -3736,123 +3720,115 @@ exports[`displays a credential offer screen renders correctly 1`] = `
                         style={
                           Object {
                             "flexGrow": 1,
+                            "marginLeft": -52.5,
+                            "marginRight": 180,
                             "padding": 37.5,
                           }
                         }
                         testID="com.ariesbifold:id/CredentialCardPrimaryBody"
                       >
-                        <View
-                          style={
-                            Object {
-                              "margin": -1,
-                              "marginLeft": -52.5,
-                              "marginRight": 40,
+                        <View>
+                          <View
+                            style={
+                              Object {
+                                "flexDirection": "row",
+                              }
                             }
-                          }
-                        >
-                          <View>
-                            <View
+                          >
+                            <Text
                               style={
-                                Object {
-                                  "flexDirection": "row",
-                                }
+                                Array [
+                                  Object {
+                                    "color": "#FFFFFF",
+                                    "fontSize": 14,
+                                    "fontWeight": "bold",
+                                  },
+                                  Object {
+                                    "color": "#FFFFFF",
+                                    "flexShrink": 1,
+                                  },
+                                  Object {
+                                    "flex": 1,
+                                    "flexWrap": "wrap",
+                                    "lineHeight": 19,
+                                    "opacity": 0.8,
+                                  },
+                                ]
                               }
+                              testID="com.ariesbifold:id/CredentialIssuer"
                             >
-                              <Text
-                                style={
-                                  Array [
-                                    Object {
-                                      "color": "#FFFFFF",
-                                      "fontSize": 14,
-                                      "fontWeight": "bold",
-                                    },
-                                    Object {
-                                      "color": "#FFFFFF",
-                                      "flexShrink": 1,
-                                    },
-                                    Object {
-                                      "flex": 1,
-                                      "flexWrap": "wrap",
-                                      "lineHeight": 19,
-                                      "opacity": 0.8,
-                                    },
-                                  ]
-                                }
-                                testID="com.ariesbifold:id/CredentialIssuer"
-                              >
-                                faber.agent
-                              </Text>
-                            </View>
-                            <View
-                              style={
-                                Object {
-                                  "flexDirection": "row",
-                                }
-                              }
-                            >
-                              <Text
-                                style={
-                                  Array [
-                                    Object {
-                                      "color": "#FFFFFF",
-                                      "fontSize": 18,
-                                      "fontWeight": "normal",
-                                    },
-                                    Object {
-                                      "color": "#FFFFFF",
-                                      "flexShrink": 1,
-                                    },
-                                    Object {
-                                      "color": "#FFFFFF",
-                                      "flex": 1,
-                                      "flexWrap": "wrap",
-                                      "fontWeight": "bold",
-                                      "lineHeight": 24,
-                                    },
-                                  ]
-                                }
-                                testID="com.ariesbifold:id/CredentialName"
-                              >
-                                Credential
-                              </Text>
-                            </View>
+                              faber.agent
+                            </Text>
                           </View>
                           <View
-                            data={
-                              Array [
-                                undefined,
-                                undefined,
-                              ]
+                            style={
+                              Object {
+                                "flexDirection": "row",
+                              }
                             }
-                            getItem={[Function]}
-                            getItemCount={[Function]}
-                            initialNumToRender={2}
-                            keyExtractor={[Function]}
-                            onContentSizeChange={[Function]}
-                            onLayout={[Function]}
-                            onMomentumScrollBegin={[Function]}
-                            onMomentumScrollEnd={[Function]}
-                            onScroll={[Function]}
-                            onScrollBeginDrag={[Function]}
-                            onScrollEndDrag={[Function]}
-                            removeClippedSubviews={false}
-                            renderItem={[Function]}
-                            scrollEnabled={false}
-                            scrollEventThrottle={50}
-                            stickyHeaderIndices={Array []}
-                            viewabilityConfigCallbackPairs={Array []}
                           >
-                            <View
-                              onFocusCapture={[Function]}
-                              onLayout={[Function]}
-                              style={null}
-                            />
-                            <View
-                              onFocusCapture={[Function]}
-                              onLayout={[Function]}
-                              style={null}
-                            />
+                            <Text
+                              style={
+                                Array [
+                                  Object {
+                                    "color": "#FFFFFF",
+                                    "fontSize": 18,
+                                    "fontWeight": "normal",
+                                  },
+                                  Object {
+                                    "color": "#FFFFFF",
+                                    "flexShrink": 1,
+                                  },
+                                  Object {
+                                    "color": "#FFFFFF",
+                                    "flex": 1,
+                                    "flexWrap": "wrap",
+                                    "fontWeight": "bold",
+                                    "lineHeight": 24,
+                                  },
+                                ]
+                              }
+                              testID="com.ariesbifold:id/CredentialName"
+                            >
+                              Credential
+                            </Text>
                           </View>
+                        </View>
+                        <View
+                          data={
+                            Array [
+                              undefined,
+                              undefined,
+                            ]
+                          }
+                          getItem={[Function]}
+                          getItemCount={[Function]}
+                          initialNumToRender={2}
+                          keyExtractor={[Function]}
+                          onContentSizeChange={[Function]}
+                          onLayout={[Function]}
+                          onMomentumScrollBegin={[Function]}
+                          onMomentumScrollEnd={[Function]}
+                          onScroll={[Function]}
+                          onScrollBeginDrag={[Function]}
+                          onScrollEndDrag={[Function]}
+                          removeClippedSubviews={false}
+                          renderItem={[Function]}
+                          scrollEnabled={false}
+                          scrollEventThrottle={50}
+                          stickyHeaderIndices={Array []}
+                          viewabilityConfigCallbackPairs={Array []}
+                        >
+                          <View
+                            onFocusCapture={[Function]}
+                            onLayout={[Function]}
+                            style={null}
+                          />
+                          <View
+                            onFocusCapture={[Function]}
+                            onLayout={[Function]}
+                            style={null}
+                          />
                         </View>
                       </View>
                       <View

--- a/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
@@ -425,9 +425,8 @@ exports[`displays a credential offer screen accepting a credential 1`] = `
                       <View
                         style={
                           Object {
-                            "flexGrow": 1,
+                            "flex": 1,
                             "marginLeft": -52.5,
-                            "marginRight": 180,
                             "padding": 37.5,
                           }
                         }
@@ -1962,9 +1961,8 @@ exports[`displays a credential offer screen declining a credential 1`] = `
                       <View
                         style={
                           Object {
-                            "flexGrow": 1,
+                            "flex": 1,
                             "marginLeft": -52.5,
-                            "marginRight": 180,
                             "padding": 37.5,
                           }
                         }
@@ -3719,9 +3717,8 @@ exports[`displays a credential offer screen renders correctly 1`] = `
                       <View
                         style={
                           Object {
-                            "flexGrow": 1,
+                            "flex": 1,
                             "marginLeft": -52.5,
-                            "marginRight": 180,
                             "padding": 37.5,
                           }
                         }


### PR DESCRIPTION
# Summary of Changes

Line break when it’s a long attribute.
The previous attempt didn't cover all scenarios.

`marginRight` set to `logoHeight * 2` to compensate the left distance of `logoHeight + (logoHeight - padding) + padding`
# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [X] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [X] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [X] Updated documentation as needed for changed code and new or modified features;
- [X] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
