### PR TITLE
fix: fixed labels in chat and pin screen

### DIFF
--- a/packages/legacy/core/App/screens/Chat.tsx
+++ b/packages/legacy/core/App/screens/Chat.tsx
@@ -109,6 +109,7 @@ const Chat: React.FC<ChatProps> = ({ route }) => {
                   <Text
                     onPress={() => handleLinkPress(link)}
                     style={{ color: ColorPallet.brand.link, textDecorationLine: 'underline' }}
+                    accessibilityRole={'link'}
                   >
                     {link}
                   </Text>

--- a/packages/legacy/core/App/screens/PINCreate.tsx
+++ b/packages/legacy/core/App/screens/PINCreate.tsx
@@ -246,7 +246,7 @@ const PINCreate: React.FC<PINCreateProps> = ({ setAuthenticated, route }) => {
               }
             }}
             testID={testIdWithKey('ReenterPIN')}
-            accessibilityLabel={t('PINCreate.ReenterPIN')}
+            accessibilityLabel={t('PINCreate.ReenterPIN', { new: updatePin ? t('PINCreate.NewPIN') + ' ' : '' })}
             autoFocus={false}
             ref={PINTwoInputRef}
           />


### PR DESCRIPTION
# Summary of Changes

- Updated the accessibility label on the pin screen, previously it would read out the translation template rather than the resulting value 
- Updated link accessibility in chat. Labelled link items with the link accessibility role  

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
