### PR TITLE
fix: missing cred proof grouping

### DIFF
--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -76,7 +76,7 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
   const { start } = useTour()
   const screenIsFocused = useIsFocused()
 
-  const hasSomeCred = useMemo(() => activeCreds.some(cred => cred.credDefId !== undefined), [activeCreds])
+  const hasMatchingCredDef = useMemo(() => activeCreds.some((cred) => cred.credDefId !== undefined), [activeCreds])
 
   const styles = StyleSheet.create({
     pageContainer: {
@@ -234,16 +234,16 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
 
           const selectRetrievedCredentials: AnonCredsCredentialsForProofRequest | undefined = retrievedCredentials
             ? {
-              ...retrievedCredentials,
-              attributes: formatCredentials(retrievedCredentials.attributes, credList) as Record<
-                string,
-                AnonCredsRequestedAttributeMatch[]
-              >,
-              predicates: formatCredentials(retrievedCredentials.predicates, credList) as Record<
-                string,
-                AnonCredsRequestedPredicateMatch[]
-              >,
-            }
+                ...retrievedCredentials,
+                attributes: formatCredentials(retrievedCredentials.attributes, credList) as Record<
+                  string,
+                  AnonCredsRequestedAttributeMatch[]
+                >,
+                predicates: formatCredentials(retrievedCredentials.predicates, credList) as Record<
+                  string,
+                  AnonCredsRequestedPredicateMatch[]
+                >,
+              }
             : undefined
           setRetrievedCredentials(selectRetrievedCredentials)
 
@@ -460,7 +460,7 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
                 </View>
               )}
             </View>
-            {!hasAvailableCredentials && hasSomeCred && (
+            {!hasAvailableCredentials && hasMatchingCredDef && (
               <Text
                 style={{
                   ...TextTheme.title,
@@ -554,8 +554,8 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
                     handleAltCredChange={
                       item.altCredentials && item.altCredentials.length > 1
                         ? () => {
-                          handleAltCredChange(item.credId, item.altCredentials ?? [item.credId])
-                        }
+                            handleAltCredChange(item.credId, item.altCredentials ?? [item.credId])
+                          }
                         : undefined
                     }
                     proof={true}
@@ -584,14 +584,16 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
                 <View style={styles.pageMargin}>
                   {!loading && (
                     <>
-                      {hasSomeCred && (<View
-                        style={{
-                          width: 'auto',
-                          borderWidth: 1,
-                          borderColor: ColorPallet.grayscale.lightGrey,
-                          marginTop: 20,
-                        }}
-                      ></View>)}
+                      {hasMatchingCredDef && (
+                        <View
+                          style={{
+                            width: 'auto',
+                            borderWidth: 1,
+                            borderColor: ColorPallet.grayscale.lightGrey,
+                            marginTop: 20,
+                          }}
+                        />
+                      )}
                       <Text
                         style={{
                           ...TextTheme.title,

--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -76,6 +76,8 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
   const { start } = useTour()
   const screenIsFocused = useIsFocused()
 
+  const hasSomeCred = useMemo(() => activeCreds.some(cred => cred.credDefId !== undefined), [activeCreds])
+
   const styles = StyleSheet.create({
     pageContainer: {
       flex: 1,
@@ -232,16 +234,16 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
 
           const selectRetrievedCredentials: AnonCredsCredentialsForProofRequest | undefined = retrievedCredentials
             ? {
-                ...retrievedCredentials,
-                attributes: formatCredentials(retrievedCredentials.attributes, credList) as Record<
-                  string,
-                  AnonCredsRequestedAttributeMatch[]
-                >,
-                predicates: formatCredentials(retrievedCredentials.predicates, credList) as Record<
-                  string,
-                  AnonCredsRequestedPredicateMatch[]
-                >,
-              }
+              ...retrievedCredentials,
+              attributes: formatCredentials(retrievedCredentials.attributes, credList) as Record<
+                string,
+                AnonCredsRequestedAttributeMatch[]
+              >,
+              predicates: formatCredentials(retrievedCredentials.predicates, credList) as Record<
+                string,
+                AnonCredsRequestedPredicateMatch[]
+              >,
+            }
             : undefined
           setRetrievedCredentials(selectRetrievedCredentials)
 
@@ -458,7 +460,7 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
                 </View>
               )}
             </View>
-            {!hasAvailableCredentials && (
+            {!hasAvailableCredentials && hasSomeCred && (
               <Text
                 style={{
                   ...TextTheme.title,
@@ -552,8 +554,8 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
                     handleAltCredChange={
                       item.altCredentials && item.altCredentials.length > 1
                         ? () => {
-                            handleAltCredChange(item.credId, item.altCredentials ?? [item.credId])
-                          }
+                          handleAltCredChange(item.credId, item.altCredentials ?? [item.credId])
+                        }
                         : undefined
                     }
                     proof={true}
@@ -582,14 +584,14 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
                 <View style={styles.pageMargin}>
                   {!loading && (
                     <>
-                      <View
+                      {hasSomeCred && (<View
                         style={{
                           width: 'auto',
                           borderWidth: 1,
                           borderColor: ColorPallet.grayscale.lightGrey,
                           marginTop: 20,
                         }}
-                      ></View>
+                      ></View>)}
                       <Text
                         style={{
                           ...TextTheme.title,

--- a/packages/legacy/core/App/utils/helpers.ts
+++ b/packages/legacy/core/App/utils/helpers.ts
@@ -468,10 +468,10 @@ export const processProofAttributes = (
 
     if (credentialList.length <= 0) {
       const missingAttributes = addMissingDisplayAttributes(requestedProofAttributes[key])
-      if (!processedAttributes[key]) {
-        processedAttributes[key] = missingAttributes
+      if (!processedAttributes[missingAttributes.credName]) {
+        processedAttributes[missingAttributes.credName] = missingAttributes
       } else {
-        processedAttributes[key].attributes?.push(...(missingAttributes.attributes ?? []))
+        processedAttributes[missingAttributes.credName].attributes?.push(...(missingAttributes.attributes ?? []))
       }
     }
 
@@ -494,7 +494,6 @@ export const processProofAttributes = (
       } else {
         continue
       }
-
       for (const attributeName of [...(names ?? (name && [name]) ?? [])]) {
         if (!processedAttributes[credential?.credentialId]) {
           // init processedAttributes object
@@ -600,10 +599,10 @@ export const processProofPredicates = (
     const { name, p_type: pType, p_value: pValue, non_revoked } = requestedProofPredicates[key]
     if (credentialList.length <= 0) {
       const missingPredicates = addMissingDisplayPredicates(requestedProofPredicates[key])
-      if (!processedPredicates[key]) {
-        processedPredicates[key] = missingPredicates
+      if (!processedPredicates[missingPredicates.credName]) {
+        processedPredicates[missingPredicates.credName] = missingPredicates
       } else {
-        processedPredicates[key].predicates?.push(...(missingPredicates.predicates ?? []))
+        processedPredicates[missingPredicates.credName].predicates?.push(...(missingPredicates.predicates ?? []))
       }
     }
 


### PR DESCRIPTION
# Summary of Changes

Previously if a credential was missing from a proof request, it wouldn't be displayed properly in the proof request screen, predicates and attributes would be split so that it appears that they're coming from two different credentials. I've added functionality to properly group missing credentials. Additionally I fixed some UI bugs that present themselves when all credenbtials in a proof don't exist in the wallet

# Related Issues

#1011 

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
