### PR TITLE
feat: changed order of mobile verifier buttons

### DIFF
--- a/packages/legacy/core/App/localization/en/index.ts
+++ b/packages/legacy/core/App/localization/en/index.ts
@@ -628,6 +628,7 @@ const translation = {
     "Parameterizable": "Parameterizable",
     "RefreshQR": "Refresh QR Code",
     "GenerateNewQR": "Request another proof",
+    "BackToList": "Back to list",
     "ShareLink": "Share link",
     "ScanQR": "Show this QR code to the other person",
     "ScanQRComment": "After the QR code is scanned, a proof request will be sent.",

--- a/packages/legacy/core/App/localization/fr/index.ts
+++ b/packages/legacy/core/App/localization/fr/index.ts
@@ -610,6 +610,7 @@ const translation = {
         "Parameterizable": "Paramétrable",
         "RefreshQR": "Refresh QR Code (FR)",
         "GenerateNewQR": "Request another proof (FR)",
+        "BackToList": "Back to list (FR)",
         "ShareLink": "Lien de partage",
         "ScanQR": "Show this QR code to the other person (FR)",
         "ScanQRComment": "After the QR code is scanned, a proof request will be sent. (FR)",

--- a/packages/legacy/core/App/localization/pt-br/index.ts
+++ b/packages/legacy/core/App/localization/pt-br/index.ts
@@ -586,6 +586,7 @@ const translation = {
     "Parameterizable": "Parametrizável",
     "RefreshQR": "Atualizar QR Code",
     "GenerateNewQR": "Requisitar outra prova",
+    "BackToList": "Back to list (PB)",
     "ShareLink": "Compartilhar link",
     "ScanQR": "Mostrar este QR code para a outra pessoa",
     "ScanQRComment": "Depois do QR code ser scaneado, a requisição de prova será enviada.",

--- a/packages/legacy/core/App/screens/ProofDetails.tsx
+++ b/packages/legacy/core/App/screens/ProofDetails.tsx
@@ -122,7 +122,7 @@ const VerifiedProof: React.FC<VerifiedProofProps> = ({
     }
   }, [navigation])
 
-  const onDone = useCallback(() => {
+  const onBack = useCallback(() => {
     navigation.navigate(Screens.ProofRequests, {})
   }, [navigation])
 
@@ -178,19 +178,19 @@ const VerifiedProof: React.FC<VerifiedProofProps> = ({
         <View style={styles.footerButton}>
           <View style={{ marginBottom: 15 }}>
             <Button
-              title={t('Global.Done')}
-              accessibilityLabel={t('Global.Done')}
-              testID={testIdWithKey('Done')}
+              title={t('Verifier.GenerateNewQR')}
+              accessibilityLabel={t('Verifier.GenerateNewQR')}
+              testID={testIdWithKey('GenerateNewQR')}
               buttonType={ButtonType.Primary}
-              onPress={onDone}
+              onPress={onGenerateNew}
             />
           </View>
           <Button
-            title={t('Verifier.GenerateNewQR')}
-            accessibilityLabel={t('Verifier.GenerateNewQR')}
-            testID={testIdWithKey('GenerateNewQR')}
+            title={t('Verifier.BackToList')}
+            accessibilityLabel={t('Verifier.BackToList')}
+            testID={testIdWithKey('BackToList')}
             buttonType={ButtonType.Secondary}
-            onPress={onGenerateNew}
+            onPress={onBack}
           />
         </View>
       </View>

--- a/packages/legacy/core/__tests__/screens/ProofDetails.test.tsx
+++ b/packages/legacy/core/__tests__/screens/ProofDetails.test.tsx
@@ -184,7 +184,7 @@ describe('ProofDetails Component', () => {
       const navigation = useNavigation()
       const { findByTestId } = renderView({ recordId: testVerifiedProofRequest.id, isHistory: false })
 
-      const doneButton = await findByTestId(testIdWithKey('Done'))
+      const doneButton = await findByTestId(testIdWithKey('BackToList'))
       fireEvent(doneButton, 'press')
 
       expect(doneButton).not.toBeNull()

--- a/packages/legacy/core/__tests__/screens/__snapshots__/ProofDetails.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/ProofDetails.test.tsx.snap
@@ -418,7 +418,7 @@ exports[`ProofDetails Component with a verified proof record renders correctly w
             }
           >
             <View
-              accessibilityLabel="Global.Done"
+              accessibilityLabel="Verifier.GenerateNewQR"
               accessibilityRole="button"
               accessibilityState={
                 Object {
@@ -455,7 +455,7 @@ exports[`ProofDetails Component with a verified proof record renders correctly w
                   "padding": 16,
                 }
               }
-              testID="com.ariesbifold:id/Done"
+              testID="com.ariesbifold:id/GenerateNewQR"
             >
               <View
                 style={
@@ -481,13 +481,13 @@ exports[`ProofDetails Component with a verified proof record renders correctly w
                     ]
                   }
                 >
-                  Global.Done
+                  Verifier.GenerateNewQR
                 </Text>
               </View>
             </View>
           </View>
           <View
-            accessibilityLabel="Verifier.GenerateNewQR"
+            accessibilityLabel="Verifier.BackToList"
             accessibilityRole="button"
             accessibilityState={
               Object {
@@ -525,7 +525,7 @@ exports[`ProofDetails Component with a verified proof record renders correctly w
                 "padding": 16,
               }
             }
-            testID="com.ariesbifold:id/GenerateNewQR"
+            testID="com.ariesbifold:id/BackToList"
           >
             <View
               style={
@@ -551,7 +551,7 @@ exports[`ProofDetails Component with a verified proof record renders correctly w
                   ]
                 }
               >
-                Verifier.GenerateNewQR
+                Verifier.BackToList
               </Text>
             </View>
           </View>


### PR DESCRIPTION
# Summary of Changes

Changed the order of the mobile verifier options to prioritize requesting another proof instead of going back to the list screen.
![image](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/36937407/c4e58c65-b625-4209-91c5-32f8eec0fff5)

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
