### PR TITLE
feat: remove connection notification in proof/offer over existing connection

### DIFF
--- a/packages/legacy/core/App/screens/CredentialOffer.tsx
+++ b/packages/legacy/core/App/screens/CredentialOffer.tsx
@@ -36,6 +36,7 @@ import { buildFieldsFromAnonCredsCredential } from '../utils/oca'
 import { testIdWithKey } from '../utils/testable'
 
 import CredentialOfferAccept from './CredentialOfferAccept'
+import { useOutOfBandByConnectionId } from '../hooks/connections'
 
 type CredentialOfferProps = StackScreenProps<NotificationStackParams, Screens.CredentialOffer>
 
@@ -62,6 +63,7 @@ const CredentialOffer: React.FC<CredentialOfferProps> = ({ navigation, route }) 
   const [store, dispatch] = useStore()
   const { start } = useTour()
   const screenIsFocused = useIsFocused()
+  const goalCode = useOutOfBandByConnectionId(credential?.connectionId ?? '')?.outOfBandInvitation.goalCode
 
   const styles = StyleSheet.create({
     headerTextContainer: {
@@ -220,7 +222,7 @@ const CredentialOffer: React.FC<CredentialOfferProps> = ({ navigation, route }) 
         }}
       >
         {loading ? <RecordLoading /> : null}
-        <ConnectionAlert connectionID={credentialConnectionLabel} />
+        {credentialConnectionLabel && goalCode === 'aries.vc.issue' ? (<ConnectionAlert connectionID={credentialConnectionLabel} />) : null}
         <View style={styles.footerButton}>
           <Button
             title={t('Global.Accept')}

--- a/packages/legacy/core/App/screens/CredentialOffer.tsx
+++ b/packages/legacy/core/App/screens/CredentialOffer.tsx
@@ -25,6 +25,7 @@ import { DispatchAction } from '../contexts/reducers/store'
 import { useStore } from '../contexts/store'
 import { useTheme } from '../contexts/theme'
 import { useTour } from '../contexts/tour/tour-context'
+import { useOutOfBandByConnectionId } from '../hooks/connections'
 import { BifoldError } from '../types/error'
 import { TabStacks, NotificationStackParams, Screens } from '../types/navigators'
 import { ModalUsage } from '../types/remove'
@@ -36,7 +37,6 @@ import { buildFieldsFromAnonCredsCredential } from '../utils/oca'
 import { testIdWithKey } from '../utils/testable'
 
 import CredentialOfferAccept from './CredentialOfferAccept'
-import { useOutOfBandByConnectionId } from '../hooks/connections'
 
 type CredentialOfferProps = StackScreenProps<NotificationStackParams, Screens.CredentialOffer>
 
@@ -222,7 +222,9 @@ const CredentialOffer: React.FC<CredentialOfferProps> = ({ navigation, route }) 
         }}
       >
         {loading ? <RecordLoading /> : null}
-        {credentialConnectionLabel && goalCode === 'aries.vc.issue' ? (<ConnectionAlert connectionID={credentialConnectionLabel} />) : null}
+        {credentialConnectionLabel && goalCode === 'aries.vc.issue' ? (
+          <ConnectionAlert connectionID={credentialConnectionLabel} />
+        ) : null}
         <View style={styles.footerButton}>
           <Button
             title={t('Global.Accept')}

--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -494,7 +494,7 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
   const proofPageFooter = () => {
     return (
       <View style={[styles.pageFooter, styles.pageMargin]}>
-        {!loading && proofConnectionLabel && goalCode !== 'aries.vc.verify.once' ? (
+        {!loading && proofConnectionLabel && goalCode === 'aries.vc.verify' ? (
           <ConnectionAlert connectionID={proofConnectionLabel} />
         ) : null}
         <View style={styles.footerButton}>

--- a/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
@@ -28,9 +28,6 @@ exports[`displays a credential offer screen accepting a credential 1`] = `
             }
           }
         >
-          <ConnectionAlert
-            connectionID="faber.agent"
-          />
           <View
             style={
               Object {
@@ -1046,122 +1043,6 @@ exports[`displays a credential offer screen accepting a credential 1`] = `
               }
             }
           >
-            <View
-              style={
-                Object {
-                  "backgroundColor": "#313132",
-                  "borderLeftColor": "#FCBA19",
-                  "borderLeftWidth": 10,
-                  "flex": 1,
-                  "marginVertical": 15,
-                  "paddingLeft": 10,
-                  "paddingVertical": 15,
-                }
-              }
-            >
-              <View
-                style={
-                  Object {
-                    "flexDirection": "row",
-                  }
-                }
-              >
-                <Text
-                  style={
-                    Object {
-                      "color": "#FFFFFF",
-                      "fontSize": 20,
-                      "fontWeight": "bold",
-                      "marginBottom": 5,
-                    }
-                  }
-                >
-                  ConnectionAlert.AddedContacts
-                </Text>
-                <View
-                  accessibilityLabel="ConnectionAlert.WhatAreContacts"
-                  accessibilityRole="button"
-                  accessibilityState={
-                    Object {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": undefined,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    Object {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  hitSlop={
-                    Object {
-                      "bottom": 44,
-                      "left": 44,
-                      "right": 44,
-                      "top": 44,
-                    }
-                  }
-                  onClick={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    Object {
-                      "opacity": 1,
-                    }
-                  }
-                  testID="Global.Info"
-                >
-                  <Text
-                    allowFontScaling={false}
-                    selectable={false}
-                    style={
-                      Array [
-                        Object {
-                          "color": undefined,
-                          "fontSize": 30,
-                        },
-                        Object {
-                          "color": "#0099FF",
-                          "marginLeft": 10,
-                        },
-                        Object {
-                          "fontFamily": "Material Design Icons",
-                          "fontStyle": "normal",
-                          "fontWeight": "normal",
-                        },
-                        Object {},
-                      ]
-                    }
-                  >
-                    󰋽
-                  </Text>
-                </View>
-              </View>
-              <Text
-                style={
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "normal",
-                    "marginVertical": 5,
-                  }
-                }
-              >
-                ConnectionAlert.NotificationBodyUpperfaber.agentConnectionAlert.NotificationBodyLower
-              </Text>
-            </View>
             <View
               style={
                 Object {
@@ -1573,9 +1454,6 @@ exports[`displays a credential offer screen declining a credential 1`] = `
             }
           }
         >
-          <ConnectionAlert
-            connectionID="faber.agent"
-          />
           <View
             style={
               Object {
@@ -2591,122 +2469,6 @@ exports[`displays a credential offer screen declining a credential 1`] = `
               }
             }
           >
-            <View
-              style={
-                Object {
-                  "backgroundColor": "#313132",
-                  "borderLeftColor": "#FCBA19",
-                  "borderLeftWidth": 10,
-                  "flex": 1,
-                  "marginVertical": 15,
-                  "paddingLeft": 10,
-                  "paddingVertical": 15,
-                }
-              }
-            >
-              <View
-                style={
-                  Object {
-                    "flexDirection": "row",
-                  }
-                }
-              >
-                <Text
-                  style={
-                    Object {
-                      "color": "#FFFFFF",
-                      "fontSize": 20,
-                      "fontWeight": "bold",
-                      "marginBottom": 5,
-                    }
-                  }
-                >
-                  ConnectionAlert.AddedContacts
-                </Text>
-                <View
-                  accessibilityLabel="ConnectionAlert.WhatAreContacts"
-                  accessibilityRole="button"
-                  accessibilityState={
-                    Object {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": undefined,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    Object {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  hitSlop={
-                    Object {
-                      "bottom": 44,
-                      "left": 44,
-                      "right": 44,
-                      "top": 44,
-                    }
-                  }
-                  onClick={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    Object {
-                      "opacity": 1,
-                    }
-                  }
-                  testID="Global.Info"
-                >
-                  <Text
-                    allowFontScaling={false}
-                    selectable={false}
-                    style={
-                      Array [
-                        Object {
-                          "color": undefined,
-                          "fontSize": 30,
-                        },
-                        Object {
-                          "color": "#0099FF",
-                          "marginLeft": 10,
-                        },
-                        Object {
-                          "fontFamily": "Material Design Icons",
-                          "fontStyle": "normal",
-                          "fontWeight": "normal",
-                        },
-                        Object {},
-                      ]
-                    }
-                  >
-                    󰋽
-                  </Text>
-                </View>
-              </View>
-              <Text
-                style={
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "normal",
-                    "marginVertical": 5,
-                  }
-                }
-              >
-                ConnectionAlert.NotificationBodyUpperfaber.agentConnectionAlert.NotificationBodyLower
-              </Text>
-            </View>
             <View
               style={
                 Object {
@@ -3338,9 +3100,6 @@ exports[`displays a credential offer screen renders correctly 1`] = `
             }
           }
         >
-          <ConnectionAlert
-            connectionID="faber.agent"
-          />
           <View
             style={
               Object {
@@ -4356,122 +4115,6 @@ exports[`displays a credential offer screen renders correctly 1`] = `
               }
             }
           >
-            <View
-              style={
-                Object {
-                  "backgroundColor": "#313132",
-                  "borderLeftColor": "#FCBA19",
-                  "borderLeftWidth": 10,
-                  "flex": 1,
-                  "marginVertical": 15,
-                  "paddingLeft": 10,
-                  "paddingVertical": 15,
-                }
-              }
-            >
-              <View
-                style={
-                  Object {
-                    "flexDirection": "row",
-                  }
-                }
-              >
-                <Text
-                  style={
-                    Object {
-                      "color": "#FFFFFF",
-                      "fontSize": 20,
-                      "fontWeight": "bold",
-                      "marginBottom": 5,
-                    }
-                  }
-                >
-                  ConnectionAlert.AddedContacts
-                </Text>
-                <View
-                  accessibilityLabel="ConnectionAlert.WhatAreContacts"
-                  accessibilityRole="button"
-                  accessibilityState={
-                    Object {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": undefined,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    Object {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  hitSlop={
-                    Object {
-                      "bottom": 44,
-                      "left": 44,
-                      "right": 44,
-                      "top": 44,
-                    }
-                  }
-                  onClick={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    Object {
-                      "opacity": 1,
-                    }
-                  }
-                  testID="Global.Info"
-                >
-                  <Text
-                    allowFontScaling={false}
-                    selectable={false}
-                    style={
-                      Array [
-                        Object {
-                          "color": undefined,
-                          "fontSize": 30,
-                        },
-                        Object {
-                          "color": "#0099FF",
-                          "marginLeft": 10,
-                        },
-                        Object {
-                          "fontFamily": "Material Design Icons",
-                          "fontStyle": "normal",
-                          "fontWeight": "normal",
-                        },
-                        Object {},
-                      ]
-                    }
-                  >
-                    󰋽
-                  </Text>
-                </View>
-              </View>
-              <Text
-                style={
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "normal",
-                    "marginVertical": 5,
-                  }
-                }
-              >
-                ConnectionAlert.NotificationBodyUpperfaber.agentConnectionAlert.NotificationBodyLower
-              </Text>
-            </View>
             <View
               style={
                 Object {


### PR DESCRIPTION
# Summary of Changes

Any proof or credential offer that doesn't have the goal code 'aries.vc.issue' or 'aries.vc.verify' will be sent over an existing connection because the user will first be directed to the connection screen and then receive an offer there. This change remove the connection alert unless the goalcode is one of the two specified above.

# Related Issues
N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
