### PR TITLE
feat: added support for reporting in error modal

### DIFF
--- a/packages/legacy/core/App/components/misc/InfoBox.tsx
+++ b/packages/legacy/core/App/components/misc/InfoBox.tsx
@@ -25,6 +25,8 @@ interface BifoldErrorProps {
   description?: string
   bodyContent?: Element
   message?: string
+  secondaryCallToActionTitle?: string
+  secondaryCallToActionPressed?: GenericFn
   onCallToActionPressed?: GenericFn
   onCallToActionLabel?: string
   onClosePressed?: GenericFn
@@ -36,6 +38,8 @@ const InfoBox: React.FC<BifoldErrorProps> = ({
   description,
   bodyContent,
   message,
+  secondaryCallToActionTitle,
+  secondaryCallToActionPressed,
   onCallToActionPressed,
   onCallToActionLabel,
   onClosePressed,
@@ -225,6 +229,17 @@ const InfoBox: React.FC<BifoldErrorProps> = ({
                 testID={onCallToActionLabel ? testIdWithKey(onCallToActionLabel) : testIdWithKey('Okay')}
                 buttonType={ButtonType.Primary}
                 onPress={onCallToActionPressed}
+              />
+            </View>
+          )}
+          {secondaryCallToActionTitle && secondaryCallToActionPressed && (
+            <View style={{ paddingTop: 10 }}>
+              <Button
+                title={secondaryCallToActionTitle}
+                accessibilityLabel={secondaryCallToActionTitle}
+                testID={testIdWithKey(secondaryCallToActionTitle)}
+                buttonType={ButtonType.Secondary}
+                onPress={secondaryCallToActionPressed}
               />
             </View>
           )}

--- a/packages/legacy/core/App/components/modals/ErrorModal.tsx
+++ b/packages/legacy/core/App/components/modals/ErrorModal.tsx
@@ -8,7 +8,11 @@ import { useTheme } from '../../contexts/theme'
 import { BifoldError } from '../../types/error'
 import InfoBox, { InfoBoxType } from '../misc/InfoBox'
 
-const ErrorModal: React.FC = () => {
+interface ErrorModalProps {
+  reportProblemAction?: (error: BifoldError) => void
+}
+
+const ErrorModal: React.FC<ErrorModalProps> = ({ reportProblemAction }) => {
   const { height } = useWindowDimensions()
   const { t } = useTranslation()
   const [modalVisible, setModalVisible] = useState<boolean>(false)
@@ -64,6 +68,8 @@ const ErrorModal: React.FC = () => {
           description={error ? error.description : t('Error.Problem')}
           message={formattedMessageForError(error ?? null)}
           onCallToActionPressed={onDismissModalTouched}
+          secondaryCallToActionTitle={t('Error.ReportThisProblem')}
+          secondaryCallToActionPressed={reportProblemAction && error ? () => reportProblemAction(error) : undefined}
         />
       </SafeAreaView>
     </Modal>

--- a/packages/legacy/core/App/localization/en/index.ts
+++ b/packages/legacy/core/App/localization/en/index.ts
@@ -78,6 +78,7 @@ const translation = {
     "code_pt-BR": "Portuguese",
   },
   "Error": {
+    "ReportThisProblem": "Report this problem",
     "Unknown": "Unknown Error",
     "Problem": "A problem has occurred",
     "ErrorCode": "Error code",

--- a/packages/legacy/core/App/localization/fr/index.ts
+++ b/packages/legacy/core/App/localization/fr/index.ts
@@ -78,6 +78,7 @@ const translation = {
         "code_pt-BR": "Portugais",
     },
     "Error": {
+        "ReportThisProblem": "Report this problem (FR)",
         "Unknown": "Erreur inconnue",
         "Problem": "Un problème est survenu",
         "ErrorCode": "Code d'erreur",

--- a/packages/legacy/core/App/localization/pt-br/index.ts
+++ b/packages/legacy/core/App/localization/pt-br/index.ts
@@ -77,6 +77,7 @@ const translation = {
     "code_pt-BR": "Português",
   },
   "Error": {
+    "ReportThisProblem": "Report this problem (PB)",
     "Unknown": "Erro Desconhecido",
     "Problem": "Ocorreu um problema",
     "ErrorCode": "Código de Erro",


### PR DESCRIPTION
# Summary of Changes

Added callback function for reporting on error modals. `Report this problem` will not display unless the callback function is passed in to the error modal
<img width="463" alt="image" src="https://github.com/hyperledger/aries-mobile-agent-react-native/assets/36937407/4d62ca4a-ddba-40f2-9670-4470794b12dc">


# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
