### PR TITLE
feat: hide attribute if value is blank

### DIFF
--- a/packages/legacy/core/App/components/record/RecordDateIntField.tsx
+++ b/packages/legacy/core/App/components/record/RecordDateIntField.tsx
@@ -22,6 +22,10 @@ const RecordDateIntField: React.FC<RecordBinaryFieldProps> = ({ field, shown, st
 
   useEffect(() => {
     const dateint = field.value as string
+    if (!dateint) {
+      setDate('')
+      return
+    }
     if (dateint.length === dateIntFormat.length) {
       const year = dateint.substring(0, 4)
       const month = dateint.substring(4, 6)

--- a/packages/legacy/core/App/screens/CredentialDetails.tsx
+++ b/packages/legacy/core/App/screens/CredentialDetails.tsx
@@ -3,7 +3,7 @@ import type { StackScreenProps } from '@react-navigation/stack'
 import { CredentialExchangeRecord } from '@aries-framework/core'
 import { useAgent } from '@aries-framework/react-hooks'
 import { BrandingOverlay } from '@hyperledger/aries-oca'
-import { BrandingOverlayType, CredentialOverlay } from '@hyperledger/aries-oca/build/legacy'
+import { Attribute, BrandingOverlayType, CredentialOverlay } from '@hyperledger/aries-oca/build/legacy'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { DeviceEventEmitter, Image, ImageBackground, StyleSheet, Text, View } from 'react-native'
@@ -148,7 +148,11 @@ const CredentialDetails: React.FC<CredentialDetailsProps> = ({ navigation, route
     }
 
     OCABundleResolver.resolveAllBundles(params).then((bundle) => {
-      setOverlay({ ...overlay, ...(bundle as CredentialOverlay<BrandingOverlay>) })
+      setOverlay({
+        ...overlay,
+        ...(bundle as CredentialOverlay<BrandingOverlay>),
+        presentationFields: bundle.presentationFields?.filter((field) => (field as Attribute).value),
+      })
     })
   }, [credential])
 

--- a/packages/legacy/core/App/screens/CredentialOffer.tsx
+++ b/packages/legacy/core/App/screens/CredentialOffer.tsx
@@ -3,7 +3,7 @@ import { AnonCredsCredentialMetadataKey } from '@aries-framework/anoncreds/build
 import { CredentialPreviewAttribute } from '@aries-framework/core'
 import { useCredentialById } from '@aries-framework/react-hooks'
 import { BrandingOverlay } from '@hyperledger/aries-oca'
-import { CredentialOverlay } from '@hyperledger/aries-oca/build/legacy'
+import { Attribute, CredentialOverlay } from '@hyperledger/aries-oca/build/legacy'
 import { useIsFocused } from '@react-navigation/core'
 import { StackScreenProps } from '@react-navigation/stack'
 import React, { useEffect, useState } from 'react'
@@ -151,7 +151,7 @@ const CredentialOffer: React.FC<CredentialOfferProps> = ({ navigation, route }) 
     updateCredentialPreview()
       .then(() => resolvePresentationFields())
       .then(({ fields }) => {
-        setOverlay({ ...overlay, presentationFields: fields })
+        setOverlay({ ...overlay, presentationFields: (fields as Attribute[]).filter((field) => field.value) })
         setLoading(false)
       })
   }, [credential])


### PR DESCRIPTION
# Summary of Changes

The BC Services card has an expiry date attribute that isn't being used right now. Currently this attribute shows up as an invalid date since it is blank. This change hides all attributes from the credential offer and credential details screen which have blank attributes.

## previous:
![image](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/36937407/3cbfdb51-d4d5-4523-8fb7-ea84e68bb892)


## now:
![image](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/36937407/fb96a89f-b492-4b8d-bf66-52f207a31845)


# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
