### PR TITLE
fix: oca credential formatter now returns all attributes

### DIFF
--- a/packages/oca/src/formatters/credential/LocalizedCredential.ts
+++ b/packages/oca/src/formatters/credential/LocalizedCredential.ts
@@ -30,11 +30,8 @@ export default class LocalizedCredential {
 
     this.attributes =
       credentialAttributes
-        ?.filter((attribute) => bundle.getFlaggedAttribute(attribute.name))
-        .map((attribute) => {
-          const overlayOptions = bundle.getAttribute(attribute.name) ?? { name: attribute.name, type: '' }
-          return new DisplayAttribute(attribute, overlayOptions, language)
-        }) ?? []
+        ?.filter((attribute) => bundle.getAttribute(attribute.name))
+        .map((attribute) => new DisplayAttribute(attribute, { name: attribute.name, type: '' }, language)) ?? []
   }
 
   get primaryAttribute(): DisplayAttribute | undefined {

--- a/packages/oca/src/formatters/credential/index.ts
+++ b/packages/oca/src/formatters/credential/index.ts
@@ -1,5 +1,5 @@
-import CredentialFromatter from './CredentialFormatter'
+import CredentialFormatter from './CredentialFormatter'
 import DisplayAttribute from './DisplayAttribute'
 import LocalizedCredential from './LocalizedCredential'
 
-export { CredentialFromatter, DisplayAttribute, LocalizedCredential }
+export { CredentialFormatter, DisplayAttribute, LocalizedCredential }


### PR DESCRIPTION
# Summary of Changes

Previously the credential formatter in the OCA package was filtering attributes by flagged attributes in the capture base. The PR corrects that issue so that all attributes are returned by the credential formatter. This also fixes a secondary issue where attributes were not being returned at all by an additional filter.

# Related Issues

Fixes: https://github.com/bcgov/aries-oca-explorer/issues/3

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [ ] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [ ] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [ ] Updated documentation as needed for changed code and new or modified features;
- [ ] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
