### PR TITLE
fix: long accessibility label

### DIFF
--- a/packages/legacy/core/App/localization/en/index.ts
+++ b/packages/legacy/core/App/localization/en/index.ts
@@ -325,8 +325,6 @@ const translation = {
     "Welcome": "Welcome",
     "Notification": "Notification",
     "Notifications": "Notifications",
-    "OneNotification": "1 Notification",
-    "CountNotifications": "{{ count }} Notifications",
     "NoNewUpdates": "You have no new notifications.",
     "NoCredentials": "You have no credentials in your wallet.",
     "SeeAll": "See all",

--- a/packages/legacy/core/App/localization/fr/index.ts
+++ b/packages/legacy/core/App/localization/fr/index.ts
@@ -324,8 +324,6 @@ const translation = {
         "Welcome": "Bienvenue",
         "Notification": "Notification",
         "Notifications": "Notifications",
-        "OneNotification": "1 Notification",
-        "CountNotifications": "{{ count }} Notification",
         "NoNewUpdates": "Vous n'avez pas de nouvelles notifications.",
         "NoCredentials": "Vous n'avez pas de justificatifs dans votre portefeuille.",
         "SeeAll": "Voir tout",

--- a/packages/legacy/core/App/navigators/TabStack.tsx
+++ b/packages/legacy/core/App/navigators/TabStack.tsx
@@ -78,9 +78,7 @@ const TabStack: React.FC = () => {
               </AttachTourStep>
             ),
             tabBarShowLabel: false,
-            tabBarAccessibilityLabel: `${t('TabStack.Home')} (${
-              total === 1 ? t('Home.OneNotification') : t('Home.CountNotifications', { count: total || 0 })
-            })`,
+            tabBarAccessibilityLabel: `${t('TabStack.Home')} (${total ?? 0})`,
             tabBarTestID: testIdWithKey(t('TabStack.Home')),
             tabBarBadge: total || undefined,
             tabBarBadgeStyle: {


### PR DESCRIPTION
# Summary of Changes

The notifications accessibility label is overly long forcing the user to say "touch Notifications 5 notifications" to activate the tab. This reduces length and what people must speak to "Notifications (5)", now people must speak 'touch Notifications 5"

# Related Issues

bcgov/bc-wallet-mobile#1640

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
