### PR TITLE
feat: allow not caching apple key

### DIFF
--- a/packages/react-native-attestation/src/NativeAttestation.ts
+++ b/packages/react-native-attestation/src/NativeAttestation.ts
@@ -2,9 +2,10 @@ import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
 
 export interface Spec extends TurboModule {
-  generateKey(): Promise<string>;
+  generateKey(cache: boolean): Promise<string>;
   sha256(stringToHash: string): Promise<Buffer>;
   appleAttestation(keyId: string, challenge: string): Promise<Buffer>;
+  appleKeyAttestation(keyId: string, challenge: string): Promise<Buffer>;
   isPlayIntegrityAvailable(): Promise<boolean>;
   googleAttestation(nonce: string): Promise<string>;
 }

--- a/packages/react-native-attestation/src/index.tsx
+++ b/packages/react-native-attestation/src/index.tsx
@@ -25,12 +25,37 @@ const Attestation = AttestationModule
       }
     );
 
-export const generateKey = async (): Promise<string> => {
-  return Attestation.generateKey();
+// TODO: Make available from Android.
+export const sha256 = async (stringToHash: string): Promise<Buffer> => {
+  if (Platform.OS !== 'ios') {
+    throw new Error('sha256 is only available on iOS');
+  }
+
+  const bytes: Uint8Array = await Attestation.sha256(stringToHash);
+  return Buffer.from(bytes);
 };
 
-export const sha256 = async (stringToHash: string): Promise<Buffer> => {
-  const bytes: Uint8Array = await Attestation.sha256(stringToHash);
+export const generateKey = async (cache: boolean = false): Promise<string> => {
+  if (Platform.OS !== 'ios') {
+    throw new Error('generateKey is only available on iOS');
+  }
+
+  return Attestation.generateKey(cache);
+};
+
+export const appleKeyAttestation = async (
+  keyId: string,
+  challenge: string
+): Promise<Buffer> => {
+  if (Platform.OS !== 'ios') {
+    throw new Error('appleKeyAttestation is only available on iOS');
+  }
+
+  const bytes: Uint8Array = await Attestation.appleKeyAttestation(
+    keyId,
+    challenge
+  );
+
   return Buffer.from(bytes);
 };
 
@@ -38,6 +63,10 @@ export const appleAttestation = async (
   keyId: string,
   challenge: string
 ): Promise<Buffer> => {
+  if (Platform.OS !== 'ios') {
+    throw new Error('appleAttestation is only available on iOS');
+  }
+
   const bytes: Uint8Array = await Attestation.appleAttestation(
     keyId,
     challenge
@@ -47,10 +76,18 @@ export const appleAttestation = async (
 };
 
 export const googleAttestation = async (nonce: string): Promise<string> => {
+  if (Platform.OS !== 'android') {
+    throw new Error('googleAttestation is only available on Android');
+  }
+
   const token: string = await Attestation.googleAttestation(nonce);
   return token;
 };
 
 export const isPlayIntegrityAvailable = async (): Promise<boolean> => {
+  if (Platform.OS !== 'android') {
+    throw new Error('isPlayIntegrityAvailable is only available on Android');
+  }
+
   return Attestation.isPlayIntegrityAvailable();
 };


### PR DESCRIPTION
# Summary of Changes

The Apple attestation key may become invalid (no documentation on why this happens). When it does it is no longer accepted by the attestation mechanics resulting in an `DCErrorInvalidInput` input error. This allows a flag to be passed to key generation bypassing caching and forcing a new key to be generated. This will be advanced in future changes for key checking (requires server side logic).

# Related Issues

n/a

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
