### PR TITLE
fix: enable tours without dev mode

### DIFF
--- a/packages/legacy/core/App/screens/CredentialOffer.tsx
+++ b/packages/legacy/core/App/screens/CredentialOffer.tsx
@@ -80,11 +80,7 @@ const CredentialOffer: React.FC<CredentialOfferProps> = ({ navigation, route }) 
   })
 
   useEffect(() => {
-    const shouldShowTour =
-      store.preferences.developerModeEnabled &&
-      enableToursConfig &&
-      store.tours.enableTours &&
-      !store.tours.seenCredentialOfferTour
+    const shouldShowTour = enableToursConfig && store.tours.enableTours && !store.tours.seenCredentialOfferTour
     if (shouldShowTour && screenIsFocused) {
       start(TourID.CredentialOfferTour)
       dispatch({

--- a/packages/legacy/core/App/screens/Home.tsx
+++ b/packages/legacy/core/App/screens/Home.tsx
@@ -63,11 +63,7 @@ const Home: React.FC<HomeProps> = () => {
   }
 
   useEffect(() => {
-    const shouldShowTour =
-      store.preferences.developerModeEnabled &&
-      enableToursConfig &&
-      store.tours.enableTours &&
-      !store.tours.seenHomeTour
+    const shouldShowTour = enableToursConfig && store.tours.enableTours && !store.tours.seenHomeTour
 
     if (shouldShowTour && screenIsFocused) {
       if (store.tours.seenToursPrompt) {

--- a/packages/legacy/core/App/screens/ListCredentials.tsx
+++ b/packages/legacy/core/App/screens/ListCredentials.tsx
@@ -34,11 +34,7 @@ const ListCredentials: React.FC = () => {
   const screenIsFocused = useIsFocused()
 
   useEffect(() => {
-    const shouldShowTour =
-      store.preferences.developerModeEnabled &&
-      enableToursConfig &&
-      store.tours.enableTours &&
-      !store.tours.seenCredentialsTour
+    const shouldShowTour = enableToursConfig && store.tours.enableTours && !store.tours.seenCredentialsTour
 
     if (shouldShowTour && screenIsFocused) {
       start(TourID.CredentialsTour)

--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -127,11 +127,7 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
   })
 
   useEffect(() => {
-    const shouldShowTour =
-      store.preferences.developerModeEnabled &&
-      enableToursConfig &&
-      store.tours.enableTours &&
-      !store.tours.seenProofRequestTour
+    const shouldShowTour = enableToursConfig && store.tours.enableTours && !store.tours.seenProofRequestTour
 
     if (shouldShowTour && screenIsFocused) {
       start(TourID.ProofRequestTour)

--- a/packages/legacy/core/App/screens/Settings.tsx
+++ b/packages/legacy/core/App/screens/Settings.tsx
@@ -164,7 +164,7 @@ const Settings: React.FC<SettingsProps> = ({ navigation }) => {
     ...(settings || []),
   ]
 
-  if (enableTours && store.preferences.developerModeEnabled) {
+  if (enableTours) {
     const section = settingsSections.find((item) => item.header.title === t('Settings.AppSettings'))
     if (section) {
       section.data = [


### PR DESCRIPTION
# Summary of Changes

Removes the gating behind developer mode of in-app tours. Still respects the config value for `enableTours`, so if you don't want to use tours you don't have to.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
