### PR TITLE
fix:disabling going back function on connectionless proof flow

### DIFF
--- a/packages/legacy/core/App/navigators/RootStack.tsx
+++ b/packages/legacy/core/App/navigators/RootStack.tsx
@@ -273,7 +273,7 @@ const RootStack: React.FC = () => {
         />
         <Stack.Screen name={Stacks.ContactStack} component={ContactStack} />
         <Stack.Screen name={Stacks.NotificationStack} component={NotificationStack} />
-        <Stack.Screen name={Stacks.ConnectionStack} component={DeliveryStack} />
+        <Stack.Screen name={Stacks.ConnectionStack} component={DeliveryStack} options={{ gestureEnabled: false }} />
         <Stack.Screen name={Stacks.ProofRequestsStack} component={ProofRequestStack} />
       </Stack.Navigator>
     )

--- a/packages/legacy/core/App/screens/Connection.tsx
+++ b/packages/legacy/core/App/screens/Connection.tsx
@@ -3,7 +3,7 @@ import { CommonActions, useFocusEffect } from '@react-navigation/native'
 import { StackScreenProps } from '@react-navigation/stack'
 import React, { useCallback, useEffect, useMemo, useReducer, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { AccessibilityInfo, Modal, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { AccessibilityInfo, BackHandler, Modal, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import Button, { ButtonType } from '../components/buttons/Button'
@@ -118,6 +118,11 @@ const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
     dispatch({ shouldShowDelayMessage: false, isVisible: false })
     navigation.getParent()?.navigate(TabStacks.HomeStack, { screen: Screens.Home })
   }
+
+  useEffect(() => {
+    const backHandler = BackHandler.addEventListener('hardwareBackPress', () => true)
+    return () => backHandler.remove()
+  }, [])
 
   useEffect(() => {
     if (state.shouldShowDelayMessage && !state.notificationRecord) {


### PR DESCRIPTION
# Summary of Changes

Disabling going back function on connectionless proof flow.

### Expected behavior
Users should not exit this screen using the device's back button, just the home icon.

### Actual behavior
Users can go back and on android it shows up a black screen, on iOS returns to the scan screen.

### To fix
I added `gestureEnabled` for ios (didn't work on android) and `Backhandler API` for android, both already used in the project.
https://reactnavigation.org/docs/stack-navigator/#gestureenabled
https://reactnative.dev/docs/backhandler


https://github.com/hyperledger/aries-mobile-agent-react-native/assets/97122568/7c10d844-e5c3-4190-871e-dc279a89cb4f


# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [X] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [X] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [X] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
