### PR TITLE
feat: disable sharing proof if it is in a bad state

### DIFF
--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -5,7 +5,7 @@ import {
   AnonCredsRequestedAttributeMatch,
   AnonCredsRequestedPredicateMatch,
 } from '@aries-framework/anoncreds'
-import { CredentialExchangeRecord } from '@aries-framework/core'
+import { CredentialExchangeRecord, ProofState } from '@aries-framework/core'
 import { useConnectionById, useProofById } from '@aries-framework/react-hooks'
 import { Attribute, Predicate } from '@hyperledger/aries-oca/build/legacy'
 import { useIsFocused } from '@react-navigation/core'
@@ -500,7 +500,12 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
             testID={testIdWithKey('Share')}
             buttonType={ButtonType.Primary}
             onPress={handleAcceptPress}
-            disabled={!hasAvailableCredentials || !hasSatisfiedPredicates(getCredentialsFields()) || revocationOffense}
+            disabled={
+              !hasAvailableCredentials ||
+              !hasSatisfiedPredicates(getCredentialsFields()) ||
+              revocationOffense ||
+              proof?.state !== ProofState.RequestReceived
+            }
           />
         </View>
         <View style={styles.footerButton}>


### PR DESCRIPTION
# Summary of Changes

If a proof is not in the request-received state then it will error out when sending. I've added functionality to disable the share button if a proof is not in the request received state

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
