### PR TITLE
fix: prevent clipping of buttons on cr modal

### DIFF
--- a/packages/legacy/core/App/components/modals/CommonRemoveModal.tsx
+++ b/packages/legacy/core/App/components/modals/CommonRemoveModal.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Modal, Platform, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { Modal, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import Collapsible from 'react-native-collapsible'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialIcons'
@@ -99,30 +99,32 @@ const CommonRemoveModal: React.FC<CommonRemoveModalProps> = ({ usage, visible, o
   }
 
   const styles = StyleSheet.create({
+    safeAreaView: {
+      backgroundColor: ColorPallet.brand.modalPrimaryBackground,
+      borderTopRightRadius: 10,
+      borderTopLeftRadius: 10,
+    },
     container: {
       height: '100%',
-      backgroundColor: ColorPallet.brand.modalPrimaryBackground,
-      padding: 20,
+      paddingTop: 10,
+      paddingHorizontal: 20,
     },
     controlsContainer: {
       marginTop: 'auto',
       marginHorizontal: 20,
-      marginBottom: Platform.OS === 'ios' ? 108 : 80,
+      marginBottom: 10,
       position: 'relative',
     },
     overlay: {
       flex: 1,
       backgroundColor: 'rgba(0,0,0,0.5)',
+      paddingTop: 65,
     },
     headerView: {
       alignItems: 'flex-end',
-      marginTop: 65,
-      backgroundColor: ColorPallet.brand.modalPrimaryBackground,
       height: 55,
       paddingTop: 10,
       paddingRight: 20,
-      borderTopRightRadius: 10,
-      borderTopLeftRadius: 10,
     },
     bodyText: {
       ...TextTheme.modalNormal,
@@ -291,34 +293,27 @@ const CommonRemoveModal: React.FC<CommonRemoveModalProps> = ({ usage, visible, o
   return (
     <Modal transparent={true} visible={visible} animationType="slide">
       <View style={styles.overlay}>
-        <View style={[styles.headerView]}>
-          <TouchableOpacity
-            accessibilityLabel={t('Global.Close')}
-            accessibilityRole={'button'}
-            testID={testIdWithKey('Close')}
-            onPress={() => onCancel && onCancel()}
-            hitSlop={hitSlop}
-          >
-            <Icon name={'close'} size={42} color={ColorPallet.brand.modalIcon} />
-          </TouchableOpacity>
-        </View>
-        <SafeAreaView
-          edges={['left', 'right', 'bottom']}
-          style={[
-            {
-              backgroundColor: ColorPallet.brand.modalPrimaryBackground,
-            },
-          ]}
-        >
-          <ScrollView style={[styles.container]}>
+        <SafeAreaView edges={['left', 'right', 'bottom']} style={styles.safeAreaView}>
+          <View style={styles.headerView}>
+            <TouchableOpacity
+              accessibilityLabel={t('Global.Close')}
+              accessibilityRole={'button'}
+              testID={testIdWithKey('Close')}
+              onPress={() => onCancel && onCancel()}
+              hitSlop={hitSlop}
+            >
+              <Icon name={'close'} size={42} color={ColorPallet.brand.modalIcon} />
+            </TouchableOpacity>
+          </View>
+          <ScrollView style={styles.container}>
             <>
               {headerImageForType()}
               {contentForType()}
             </>
           </ScrollView>
-          <View style={[styles.controlsContainer]}>
+          <View style={styles.controlsContainer}>
             <ContentGradient backgroundColor={ColorPallet.brand.modalPrimaryBackground} height={30} />
-            <View style={[{ paddingTop: 10 }]}>
+            <View style={{ paddingTop: 10 }}>
               <Button
                 title={titleForConfirmButton()}
                 accessibilityLabel={labelForConfirmButton()}
@@ -329,7 +324,7 @@ const CommonRemoveModal: React.FC<CommonRemoveModalProps> = ({ usage, visible, o
                 }
               />
             </View>
-            <View style={[{ paddingTop: 10 }]}>
+            <View style={{ paddingTop: 10 }}>
               <Button
                 title={t('Global.Cancel')}
                 accessibilityLabel={t('Global.Cancel')}

--- a/packages/legacy/core/__tests__/components/__snapshots__/CommonRemoveModal.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/CommonRemoveModal.test.tsx.snap
@@ -12,93 +12,10 @@ exports[`CommonRemoveModal Component Credential offer decline renders correctly 
       Object {
         "backgroundColor": "rgba(0,0,0,0.5)",
         "flex": 1,
+        "paddingTop": 65,
       }
     }
   >
-    <View
-      style={
-        Array [
-          Object {
-            "alignItems": "flex-end",
-            "backgroundColor": "#000000",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
-            "height": 55,
-            "marginTop": 65,
-            "paddingRight": 20,
-            "paddingTop": 10,
-          },
-        ]
-      }
-    >
-      <View
-        accessibilityLabel="Global.Close"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": undefined,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          Object {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        hitSlop={
-          Object {
-            "bottom": 44,
-            "left": 44,
-            "right": 44,
-            "top": 44,
-          }
-        }
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          Object {
-            "opacity": 1,
-          }
-        }
-        testID="com.ariesbifold:id/Close"
-      >
-        <Text
-          allowFontScaling={false}
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 42,
-              },
-              undefined,
-              Object {
-                "fontFamily": "Material Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          
-        </Text>
-      </View>
-    </View>
     <RNCSafeAreaView
       edges={
         Array [
@@ -108,22 +25,98 @@ exports[`CommonRemoveModal Component Credential offer decline renders correctly 
         ]
       }
       style={
-        Array [
-          Object {
-            "backgroundColor": "#000000",
-          },
-        ]
+        Object {
+          "backgroundColor": "#000000",
+          "borderTopLeftRadius": 10,
+          "borderTopRightRadius": 10,
+        }
       }
     >
+      <View
+        style={
+          Object {
+            "alignItems": "flex-end",
+            "height": 55,
+            "paddingRight": 20,
+            "paddingTop": 10,
+          }
+        }
+      >
+        <View
+          accessibilityLabel="Global.Close"
+          accessibilityRole="button"
+          accessibilityState={
+            Object {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            Object {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 44,
+              "left": 44,
+              "right": 44,
+              "top": 44,
+            }
+          }
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+          testID="com.ariesbifold:id/Close"
+        >
+          <Text
+            allowFontScaling={false}
+            selectable={false}
+            style={
+              Array [
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 42,
+                },
+                undefined,
+                Object {
+                  "fontFamily": "Material Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+        </View>
+      </View>
       <RCTScrollView
         style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": "100%",
-              "padding": 20,
-            },
-          ]
+          Object {
+            "height": "100%",
+            "paddingHorizontal": 20,
+            "paddingTop": 10,
+          }
         }
       >
         <View>
@@ -198,14 +191,12 @@ exports[`CommonRemoveModal Component Credential offer decline renders correctly 
       </RCTScrollView>
       <View
         style={
-          Array [
-            Object {
-              "marginBottom": 108,
-              "marginHorizontal": 20,
-              "marginTop": "auto",
-              "position": "relative",
-            },
-          ]
+          Object {
+            "marginBottom": 10,
+            "marginHorizontal": 20,
+            "marginTop": "auto",
+            "position": "relative",
+          }
         }
       >
         <View
@@ -287,11 +278,9 @@ exports[`CommonRemoveModal Component Credential offer decline renders correctly 
         </View>
         <View
           style={
-            Array [
-              Object {
-                "paddingTop": 10,
-              },
-            ]
+            Object {
+              "paddingTop": 10,
+            }
           }
         >
           <View
@@ -365,11 +354,9 @@ exports[`CommonRemoveModal Component Credential offer decline renders correctly 
         </View>
         <View
           style={
-            Array [
-              Object {
-                "paddingTop": 10,
-              },
-            ]
+            Object {
+              "paddingTop": 10,
+            }
           }
         >
           <View
@@ -460,93 +447,10 @@ exports[`CommonRemoveModal Component Custom notification decline renders correct
       Object {
         "backgroundColor": "rgba(0,0,0,0.5)",
         "flex": 1,
+        "paddingTop": 65,
       }
     }
   >
-    <View
-      style={
-        Array [
-          Object {
-            "alignItems": "flex-end",
-            "backgroundColor": "#000000",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
-            "height": 55,
-            "marginTop": 65,
-            "paddingRight": 20,
-            "paddingTop": 10,
-          },
-        ]
-      }
-    >
-      <View
-        accessibilityLabel="Global.Close"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": undefined,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          Object {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        hitSlop={
-          Object {
-            "bottom": 44,
-            "left": 44,
-            "right": 44,
-            "top": 44,
-          }
-        }
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          Object {
-            "opacity": 1,
-          }
-        }
-        testID="com.ariesbifold:id/Close"
-      >
-        <Text
-          allowFontScaling={false}
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 42,
-              },
-              undefined,
-              Object {
-                "fontFamily": "Material Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          
-        </Text>
-      </View>
-    </View>
     <RNCSafeAreaView
       edges={
         Array [
@@ -556,22 +460,98 @@ exports[`CommonRemoveModal Component Custom notification decline renders correct
         ]
       }
       style={
-        Array [
-          Object {
-            "backgroundColor": "#000000",
-          },
-        ]
+        Object {
+          "backgroundColor": "#000000",
+          "borderTopLeftRadius": 10,
+          "borderTopRightRadius": 10,
+        }
       }
     >
+      <View
+        style={
+          Object {
+            "alignItems": "flex-end",
+            "height": 55,
+            "paddingRight": 20,
+            "paddingTop": 10,
+          }
+        }
+      >
+        <View
+          accessibilityLabel="Global.Close"
+          accessibilityRole="button"
+          accessibilityState={
+            Object {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            Object {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 44,
+              "left": 44,
+              "right": 44,
+              "top": 44,
+            }
+          }
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+          testID="com.ariesbifold:id/Close"
+        >
+          <Text
+            allowFontScaling={false}
+            selectable={false}
+            style={
+              Array [
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 42,
+                },
+                undefined,
+                Object {
+                  "fontFamily": "Material Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+        </View>
+      </View>
       <RCTScrollView
         style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": "100%",
-              "padding": 20,
-            },
-          ]
+          Object {
+            "height": "100%",
+            "paddingHorizontal": 20,
+            "paddingTop": 10,
+          }
         }
       >
         <View>
@@ -651,14 +631,12 @@ exports[`CommonRemoveModal Component Custom notification decline renders correct
       </RCTScrollView>
       <View
         style={
-          Array [
-            Object {
-              "marginBottom": 108,
-              "marginHorizontal": 20,
-              "marginTop": "auto",
-              "position": "relative",
-            },
-          ]
+          Object {
+            "marginBottom": 10,
+            "marginHorizontal": 20,
+            "marginTop": "auto",
+            "position": "relative",
+          }
         }
       >
         <View
@@ -740,11 +718,9 @@ exports[`CommonRemoveModal Component Custom notification decline renders correct
         </View>
         <View
           style={
-            Array [
-              Object {
-                "paddingTop": 10,
-              },
-            ]
+            Object {
+              "paddingTop": 10,
+            }
           }
         >
           <View
@@ -818,11 +794,9 @@ exports[`CommonRemoveModal Component Custom notification decline renders correct
         </View>
         <View
           style={
-            Array [
-              Object {
-                "paddingTop": 10,
-              },
-            ]
+            Object {
+              "paddingTop": 10,
+            }
           }
         >
           <View
@@ -913,93 +887,10 @@ exports[`CommonRemoveModal Component Proof request decline renders correctly 1`]
       Object {
         "backgroundColor": "rgba(0,0,0,0.5)",
         "flex": 1,
+        "paddingTop": 65,
       }
     }
   >
-    <View
-      style={
-        Array [
-          Object {
-            "alignItems": "flex-end",
-            "backgroundColor": "#000000",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
-            "height": 55,
-            "marginTop": 65,
-            "paddingRight": 20,
-            "paddingTop": 10,
-          },
-        ]
-      }
-    >
-      <View
-        accessibilityLabel="Global.Close"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": undefined,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          Object {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        hitSlop={
-          Object {
-            "bottom": 44,
-            "left": 44,
-            "right": 44,
-            "top": 44,
-          }
-        }
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          Object {
-            "opacity": 1,
-          }
-        }
-        testID="com.ariesbifold:id/Close"
-      >
-        <Text
-          allowFontScaling={false}
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 42,
-              },
-              undefined,
-              Object {
-                "fontFamily": "Material Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          
-        </Text>
-      </View>
-    </View>
     <RNCSafeAreaView
       edges={
         Array [
@@ -1009,22 +900,98 @@ exports[`CommonRemoveModal Component Proof request decline renders correctly 1`]
         ]
       }
       style={
-        Array [
-          Object {
-            "backgroundColor": "#000000",
-          },
-        ]
+        Object {
+          "backgroundColor": "#000000",
+          "borderTopLeftRadius": 10,
+          "borderTopRightRadius": 10,
+        }
       }
     >
+      <View
+        style={
+          Object {
+            "alignItems": "flex-end",
+            "height": 55,
+            "paddingRight": 20,
+            "paddingTop": 10,
+          }
+        }
+      >
+        <View
+          accessibilityLabel="Global.Close"
+          accessibilityRole="button"
+          accessibilityState={
+            Object {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            Object {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 44,
+              "left": 44,
+              "right": 44,
+              "top": 44,
+            }
+          }
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+          testID="com.ariesbifold:id/Close"
+        >
+          <Text
+            allowFontScaling={false}
+            selectable={false}
+            style={
+              Array [
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 42,
+                },
+                undefined,
+                Object {
+                  "fontFamily": "Material Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+        </View>
+      </View>
       <RCTScrollView
         style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": "100%",
-              "padding": 20,
-            },
-          ]
+          Object {
+            "height": "100%",
+            "paddingHorizontal": 20,
+            "paddingTop": 10,
+          }
         }
       >
         <View>
@@ -1113,14 +1080,12 @@ exports[`CommonRemoveModal Component Proof request decline renders correctly 1`]
       </RCTScrollView>
       <View
         style={
-          Array [
-            Object {
-              "marginBottom": 108,
-              "marginHorizontal": 20,
-              "marginTop": "auto",
-              "position": "relative",
-            },
-          ]
+          Object {
+            "marginBottom": 10,
+            "marginHorizontal": 20,
+            "marginTop": "auto",
+            "position": "relative",
+          }
         }
       >
         <View
@@ -1202,11 +1167,9 @@ exports[`CommonRemoveModal Component Proof request decline renders correctly 1`]
         </View>
         <View
           style={
-            Array [
-              Object {
-                "paddingTop": 10,
-              },
-            ]
+            Object {
+              "paddingTop": 10,
+            }
           }
         >
           <View
@@ -1280,11 +1243,9 @@ exports[`CommonRemoveModal Component Proof request decline renders correctly 1`]
         </View>
         <View
           style={
-            Array [
-              Object {
-                "paddingTop": 10,
-              },
-            ]
+            Object {
+              "paddingTop": 10,
+            }
           }
         >
           <View
@@ -1375,93 +1336,10 @@ exports[`CommonRemoveModal Component Remove contact renders correctly 1`] = `
       Object {
         "backgroundColor": "rgba(0,0,0,0.5)",
         "flex": 1,
+        "paddingTop": 65,
       }
     }
   >
-    <View
-      style={
-        Array [
-          Object {
-            "alignItems": "flex-end",
-            "backgroundColor": "#000000",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
-            "height": 55,
-            "marginTop": 65,
-            "paddingRight": 20,
-            "paddingTop": 10,
-          },
-        ]
-      }
-    >
-      <View
-        accessibilityLabel="Global.Close"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": undefined,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          Object {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        hitSlop={
-          Object {
-            "bottom": 44,
-            "left": 44,
-            "right": 44,
-            "top": 44,
-          }
-        }
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          Object {
-            "opacity": 1,
-          }
-        }
-        testID="com.ariesbifold:id/Close"
-      >
-        <Text
-          allowFontScaling={false}
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 42,
-              },
-              undefined,
-              Object {
-                "fontFamily": "Material Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          
-        </Text>
-      </View>
-    </View>
     <RNCSafeAreaView
       edges={
         Array [
@@ -1471,22 +1349,98 @@ exports[`CommonRemoveModal Component Remove contact renders correctly 1`] = `
         ]
       }
       style={
-        Array [
-          Object {
-            "backgroundColor": "#000000",
-          },
-        ]
+        Object {
+          "backgroundColor": "#000000",
+          "borderTopLeftRadius": 10,
+          "borderTopRightRadius": 10,
+        }
       }
     >
+      <View
+        style={
+          Object {
+            "alignItems": "flex-end",
+            "height": 55,
+            "paddingRight": 20,
+            "paddingTop": 10,
+          }
+        }
+      >
+        <View
+          accessibilityLabel="Global.Close"
+          accessibilityRole="button"
+          accessibilityState={
+            Object {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            Object {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 44,
+              "left": 44,
+              "right": 44,
+              "top": 44,
+            }
+          }
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+          testID="com.ariesbifold:id/Close"
+        >
+          <Text
+            allowFontScaling={false}
+            selectable={false}
+            style={
+              Array [
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 42,
+                },
+                undefined,
+                Object {
+                  "fontFamily": "Material Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+        </View>
+      </View>
       <RCTScrollView
         style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": "100%",
-              "padding": 20,
-            },
-          ]
+          Object {
+            "height": "100%",
+            "paddingHorizontal": 20,
+            "paddingTop": 10,
+          }
         }
       >
         <View>
@@ -1790,14 +1744,12 @@ exports[`CommonRemoveModal Component Remove contact renders correctly 1`] = `
       </RCTScrollView>
       <View
         style={
-          Array [
-            Object {
-              "marginBottom": 108,
-              "marginHorizontal": 20,
-              "marginTop": "auto",
-              "position": "relative",
-            },
-          ]
+          Object {
+            "marginBottom": 10,
+            "marginHorizontal": 20,
+            "marginTop": "auto",
+            "position": "relative",
+          }
         }
       >
         <View
@@ -1879,11 +1831,9 @@ exports[`CommonRemoveModal Component Remove contact renders correctly 1`] = `
         </View>
         <View
           style={
-            Array [
-              Object {
-                "paddingTop": 10,
-              },
-            ]
+            Object {
+              "paddingTop": 10,
+            }
           }
         >
           <View
@@ -1957,11 +1907,9 @@ exports[`CommonRemoveModal Component Remove contact renders correctly 1`] = `
         </View>
         <View
           style={
-            Array [
-              Object {
-                "paddingTop": 10,
-              },
-            ]
+            Object {
+              "paddingTop": 10,
+            }
           }
         >
           <View
@@ -2052,93 +2000,10 @@ exports[`CommonRemoveModal Component Remove contact renders correctly 2`] = `
       Object {
         "backgroundColor": "rgba(0,0,0,0.5)",
         "flex": 1,
+        "paddingTop": 65,
       }
     }
   >
-    <View
-      style={
-        Array [
-          Object {
-            "alignItems": "flex-end",
-            "backgroundColor": "#000000",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
-            "height": 55,
-            "marginTop": 65,
-            "paddingRight": 20,
-            "paddingTop": 10,
-          },
-        ]
-      }
-    >
-      <View
-        accessibilityLabel="Global.Close"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": undefined,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          Object {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        hitSlop={
-          Object {
-            "bottom": 44,
-            "left": 44,
-            "right": 44,
-            "top": 44,
-          }
-        }
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          Object {
-            "opacity": 1,
-          }
-        }
-        testID="com.ariesbifold:id/Close"
-      >
-        <Text
-          allowFontScaling={false}
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 42,
-              },
-              undefined,
-              Object {
-                "fontFamily": "Material Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          
-        </Text>
-      </View>
-    </View>
     <RNCSafeAreaView
       edges={
         Array [
@@ -2148,22 +2013,98 @@ exports[`CommonRemoveModal Component Remove contact renders correctly 2`] = `
         ]
       }
       style={
-        Array [
-          Object {
-            "backgroundColor": "#000000",
-          },
-        ]
+        Object {
+          "backgroundColor": "#000000",
+          "borderTopLeftRadius": 10,
+          "borderTopRightRadius": 10,
+        }
       }
     >
+      <View
+        style={
+          Object {
+            "alignItems": "flex-end",
+            "height": 55,
+            "paddingRight": 20,
+            "paddingTop": 10,
+          }
+        }
+      >
+        <View
+          accessibilityLabel="Global.Close"
+          accessibilityRole="button"
+          accessibilityState={
+            Object {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            Object {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 44,
+              "left": 44,
+              "right": 44,
+              "top": 44,
+            }
+          }
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+          testID="com.ariesbifold:id/Close"
+        >
+          <Text
+            allowFontScaling={false}
+            selectable={false}
+            style={
+              Array [
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 42,
+                },
+                undefined,
+                Object {
+                  "fontFamily": "Material Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+        </View>
+      </View>
       <RCTScrollView
         style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": "100%",
-              "padding": 20,
-            },
-          ]
+          Object {
+            "height": "100%",
+            "paddingHorizontal": 20,
+            "paddingTop": 10,
+          }
         }
       >
         <View>
@@ -2227,14 +2168,12 @@ exports[`CommonRemoveModal Component Remove contact renders correctly 2`] = `
       </RCTScrollView>
       <View
         style={
-          Array [
-            Object {
-              "marginBottom": 108,
-              "marginHorizontal": 20,
-              "marginTop": "auto",
-              "position": "relative",
-            },
-          ]
+          Object {
+            "marginBottom": 10,
+            "marginHorizontal": 20,
+            "marginTop": "auto",
+            "position": "relative",
+          }
         }
       >
         <View
@@ -2316,11 +2255,9 @@ exports[`CommonRemoveModal Component Remove contact renders correctly 2`] = `
         </View>
         <View
           style={
-            Array [
-              Object {
-                "paddingTop": 10,
-              },
-            ]
+            Object {
+              "paddingTop": 10,
+            }
           }
         >
           <View
@@ -2394,11 +2331,9 @@ exports[`CommonRemoveModal Component Remove contact renders correctly 2`] = `
         </View>
         <View
           style={
-            Array [
-              Object {
-                "paddingTop": 10,
-              },
-            ]
+            Object {
+              "paddingTop": 10,
+            }
           }
         >
           <View
@@ -2489,93 +2424,10 @@ exports[`CommonRemoveModal Component Remove credential renders correctly 1`] = `
       Object {
         "backgroundColor": "rgba(0,0,0,0.5)",
         "flex": 1,
+        "paddingTop": 65,
       }
     }
   >
-    <View
-      style={
-        Array [
-          Object {
-            "alignItems": "flex-end",
-            "backgroundColor": "#000000",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
-            "height": 55,
-            "marginTop": 65,
-            "paddingRight": 20,
-            "paddingTop": 10,
-          },
-        ]
-      }
-    >
-      <View
-        accessibilityLabel="Global.Close"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": undefined,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          Object {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        hitSlop={
-          Object {
-            "bottom": 44,
-            "left": 44,
-            "right": 44,
-            "top": 44,
-          }
-        }
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          Object {
-            "opacity": 1,
-          }
-        }
-        testID="com.ariesbifold:id/Close"
-      >
-        <Text
-          allowFontScaling={false}
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 42,
-              },
-              undefined,
-              Object {
-                "fontFamily": "Material Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          
-        </Text>
-      </View>
-    </View>
     <RNCSafeAreaView
       edges={
         Array [
@@ -2585,22 +2437,98 @@ exports[`CommonRemoveModal Component Remove credential renders correctly 1`] = `
         ]
       }
       style={
-        Array [
-          Object {
-            "backgroundColor": "#000000",
-          },
-        ]
+        Object {
+          "backgroundColor": "#000000",
+          "borderTopLeftRadius": 10,
+          "borderTopRightRadius": 10,
+        }
       }
     >
+      <View
+        style={
+          Object {
+            "alignItems": "flex-end",
+            "height": 55,
+            "paddingRight": 20,
+            "paddingTop": 10,
+          }
+        }
+      >
+        <View
+          accessibilityLabel="Global.Close"
+          accessibilityRole="button"
+          accessibilityState={
+            Object {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            Object {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 44,
+              "left": 44,
+              "right": 44,
+              "top": 44,
+            }
+          }
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+          testID="com.ariesbifold:id/Close"
+        >
+          <Text
+            allowFontScaling={false}
+            selectable={false}
+            style={
+              Array [
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 42,
+                },
+                undefined,
+                Object {
+                  "fontFamily": "Material Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+        </View>
+      </View>
       <RCTScrollView
         style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": "100%",
-              "padding": 20,
-            },
-          ]
+          Object {
+            "height": "100%",
+            "paddingHorizontal": 20,
+            "paddingTop": 10,
+          }
         }
       >
         <View>
@@ -3037,14 +2965,12 @@ exports[`CommonRemoveModal Component Remove credential renders correctly 1`] = `
       </RCTScrollView>
       <View
         style={
-          Array [
-            Object {
-              "marginBottom": 108,
-              "marginHorizontal": 20,
-              "marginTop": "auto",
-              "position": "relative",
-            },
-          ]
+          Object {
+            "marginBottom": 10,
+            "marginHorizontal": 20,
+            "marginTop": "auto",
+            "position": "relative",
+          }
         }
       >
         <View
@@ -3126,11 +3052,9 @@ exports[`CommonRemoveModal Component Remove credential renders correctly 1`] = `
         </View>
         <View
           style={
-            Array [
-              Object {
-                "paddingTop": 10,
-              },
-            ]
+            Object {
+              "paddingTop": 10,
+            }
           }
         >
           <View
@@ -3204,11 +3128,9 @@ exports[`CommonRemoveModal Component Remove credential renders correctly 1`] = `
         </View>
         <View
           style={
-            Array [
-              Object {
-                "paddingTop": 10,
-              },
-            ]
+            Object {
+              "paddingTop": 10,
+            }
           }
         >
           <View
@@ -3299,93 +3221,10 @@ exports[`CommonRemoveModal Component Rerenders correctly when not visible 1`] = 
       Object {
         "backgroundColor": "rgba(0,0,0,0.5)",
         "flex": 1,
+        "paddingTop": 65,
       }
     }
   >
-    <View
-      style={
-        Array [
-          Object {
-            "alignItems": "flex-end",
-            "backgroundColor": "#000000",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
-            "height": 55,
-            "marginTop": 65,
-            "paddingRight": 20,
-            "paddingTop": 10,
-          },
-        ]
-      }
-    >
-      <View
-        accessibilityLabel="Global.Close"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": undefined,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          Object {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        hitSlop={
-          Object {
-            "bottom": 44,
-            "left": 44,
-            "right": 44,
-            "top": 44,
-          }
-        }
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          Object {
-            "opacity": 1,
-          }
-        }
-        testID="com.ariesbifold:id/Close"
-      >
-        <Text
-          allowFontScaling={false}
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 42,
-              },
-              undefined,
-              Object {
-                "fontFamily": "Material Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          
-        </Text>
-      </View>
-    </View>
     <RNCSafeAreaView
       edges={
         Array [
@@ -3395,22 +3234,98 @@ exports[`CommonRemoveModal Component Rerenders correctly when not visible 1`] = 
         ]
       }
       style={
-        Array [
-          Object {
-            "backgroundColor": "#000000",
-          },
-        ]
+        Object {
+          "backgroundColor": "#000000",
+          "borderTopLeftRadius": 10,
+          "borderTopRightRadius": 10,
+        }
       }
     >
+      <View
+        style={
+          Object {
+            "alignItems": "flex-end",
+            "height": 55,
+            "paddingRight": 20,
+            "paddingTop": 10,
+          }
+        }
+      >
+        <View
+          accessibilityLabel="Global.Close"
+          accessibilityRole="button"
+          accessibilityState={
+            Object {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            Object {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 44,
+              "left": 44,
+              "right": 44,
+              "top": 44,
+            }
+          }
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+          testID="com.ariesbifold:id/Close"
+        >
+          <Text
+            allowFontScaling={false}
+            selectable={false}
+            style={
+              Array [
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 42,
+                },
+                undefined,
+                Object {
+                  "fontFamily": "Material Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+        </View>
+      </View>
       <RCTScrollView
         style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": "100%",
-              "padding": 20,
-            },
-          ]
+          Object {
+            "height": "100%",
+            "paddingHorizontal": 20,
+            "paddingTop": 10,
+          }
         }
       >
         <View>
@@ -3714,14 +3629,12 @@ exports[`CommonRemoveModal Component Rerenders correctly when not visible 1`] = 
       </RCTScrollView>
       <View
         style={
-          Array [
-            Object {
-              "marginBottom": 108,
-              "marginHorizontal": 20,
-              "marginTop": "auto",
-              "position": "relative",
-            },
-          ]
+          Object {
+            "marginBottom": 10,
+            "marginHorizontal": 20,
+            "marginTop": "auto",
+            "position": "relative",
+          }
         }
       >
         <View
@@ -3803,11 +3716,9 @@ exports[`CommonRemoveModal Component Rerenders correctly when not visible 1`] = 
         </View>
         <View
           style={
-            Array [
-              Object {
-                "paddingTop": 10,
-              },
-            ]
+            Object {
+              "paddingTop": 10,
+            }
           }
         >
           <View
@@ -3881,11 +3792,9 @@ exports[`CommonRemoveModal Component Rerenders correctly when not visible 1`] = 
         </View>
         <View
           style={
-            Array [
-              Object {
-                "paddingTop": 10,
-              },
-            ]
+            Object {
+              "paddingTop": 10,
+            }
           }
         >
           <View

--- a/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
@@ -2644,93 +2644,10 @@ exports[`displays a credential offer screen declining a credential 1`] = `
         Object {
           "backgroundColor": "rgba(0,0,0,0.5)",
           "flex": 1,
+          "paddingTop": 65,
         }
       }
     >
-      <View
-        style={
-          Array [
-            Object {
-              "alignItems": "flex-end",
-              "backgroundColor": "#000000",
-              "borderTopLeftRadius": 10,
-              "borderTopRightRadius": 10,
-              "height": 55,
-              "marginTop": 65,
-              "paddingRight": 20,
-              "paddingTop": 10,
-            },
-          ]
-        }
-      >
-        <View
-          accessibilityLabel="Global.Close"
-          accessibilityRole="button"
-          accessibilityState={
-            Object {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            Object {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          collapsable={false}
-          focusable={true}
-          hitSlop={
-            Object {
-              "bottom": 44,
-              "left": 44,
-              "right": 44,
-              "top": 44,
-            }
-          }
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Object {
-              "opacity": 1,
-            }
-          }
-          testID="com.ariesbifold:id/Close"
-        >
-          <Text
-            allowFontScaling={false}
-            selectable={false}
-            style={
-              Array [
-                Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 42,
-                },
-                undefined,
-                Object {
-                  "fontFamily": "Material Icons",
-                  "fontStyle": "normal",
-                  "fontWeight": "normal",
-                },
-                Object {},
-              ]
-            }
-          >
-            
-          </Text>
-        </View>
-      </View>
       <RNCSafeAreaView
         edges={
           Array [
@@ -2740,22 +2657,98 @@ exports[`displays a credential offer screen declining a credential 1`] = `
           ]
         }
         style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-            },
-          ]
+          Object {
+            "backgroundColor": "#000000",
+            "borderTopLeftRadius": 10,
+            "borderTopRightRadius": 10,
+          }
         }
       >
+        <View
+          style={
+            Object {
+              "alignItems": "flex-end",
+              "height": 55,
+              "paddingRight": 20,
+              "paddingTop": 10,
+            }
+          }
+        >
+          <View
+            accessibilityLabel="Global.Close"
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              Object {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            hitSlop={
+              Object {
+                "bottom": 44,
+                "left": 44,
+                "right": 44,
+                "top": 44,
+              }
+            }
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+            testID="com.ariesbifold:id/Close"
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                Array [
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 42,
+                  },
+                  undefined,
+                  Object {
+                    "fontFamily": "Material Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  Object {},
+                ]
+              }
+            >
+              
+            </Text>
+          </View>
+        </View>
         <RCTScrollView
           style={
-            Array [
-              Object {
-                "backgroundColor": "#000000",
-                "height": "100%",
-                "padding": 20,
-              },
-            ]
+            Object {
+              "height": "100%",
+              "paddingHorizontal": 20,
+              "paddingTop": 10,
+            }
           }
         >
           <View>
@@ -2830,14 +2823,12 @@ exports[`displays a credential offer screen declining a credential 1`] = `
         </RCTScrollView>
         <View
           style={
-            Array [
-              Object {
-                "marginBottom": 108,
-                "marginHorizontal": 20,
-                "marginTop": "auto",
-                "position": "relative",
-              },
-            ]
+            Object {
+              "marginBottom": 10,
+              "marginHorizontal": 20,
+              "marginTop": "auto",
+              "position": "relative",
+            }
           }
         >
           <View
@@ -2919,11 +2910,9 @@ exports[`displays a credential offer screen declining a credential 1`] = `
           </View>
           <View
             style={
-              Array [
-                Object {
-                  "paddingTop": 10,
-                },
-              ]
+              Object {
+                "paddingTop": 10,
+              }
             }
           >
             <View
@@ -2997,11 +2986,9 @@ exports[`displays a credential offer screen declining a credential 1`] = `
           </View>
           <View
             style={
-              Array [
-                Object {
-                  "paddingTop": 10,
-                },
-              ]
+              Object {
+                "paddingTop": 10,
+              }
             }
           >
             <View


### PR DESCRIPTION
# Summary of Changes

Previously, the button container was positioned with a constant value that sometimes caused clipping on certain devices. Now it's positioned dynamically and doesn't get clipped regardless of screen size. I also removed some unnecessary array wrapping of stylesheets for faster rendering.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
