### PR TITLE
feat: make proof requests reactive to creds and expose agent type

### DIFF
--- a/packages/legacy/core/App/hooks/proofs.ts
+++ b/packages/legacy/core/App/hooks/proofs.ts
@@ -23,5 +23,5 @@ export const useAllCredentialsForProof = (proofId: string) => {
       return
     }
     return retrieveCredentialsForProof(agent, proof, fullCredentials, t)
-  }, [proofId])
+  }, [proofId, fullCredentials])
 }

--- a/packages/legacy/core/App/index.ts
+++ b/packages/legacy/core/App/index.ts
@@ -81,6 +81,7 @@ export type {
   ITheme,
 } from './theme'
 export type { ConfigurationContext } from './contexts/configuration'
+export type { BifoldAgent } from './utils/agent'
 export type { TourStep } from './contexts/tour/tour-context'
 export type { GenericFn } from './types/fn'
 export type { AuthenticateStackParams, OnboardingStackParams } from './types/navigators'

--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -272,7 +272,7 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
         )
         DeviceEventEmitter.emit(EventTypes.ERROR_ADDED, error)
       })
-  }, [selectedCredentials])
+  }, [selectedCredentials, credProofPromise])
 
   const toggleDeclineModalVisible = () => setDeclineModalVisible(!declineModalVisible)
 


### PR DESCRIPTION
# Summary of Changes

Preliminary update for proof request attestation flow in BC Wallet. Exposes a type and makes proof request screen reactive to new credentials.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [ ] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
