### PR TITLE
fix: handle multi use invitations

### DIFF
--- a/packages/legacy/core/App/index.ts
+++ b/packages/legacy/core/App/index.ts
@@ -64,6 +64,7 @@ export { BifoldError } from './types/error'
 export { EventTypes } from './constants'
 export { didMigrateToAskar, migrateToAskar } from './utils/migration'
 export { createLinkSecretIfRequired, getAgentModules } from './utils/agent'
+export { removeExistingInvitationIfRequired } from './utils/helpers'
 
 export type { AnimatedComponents } from './animated-components'
 export type {

--- a/packages/legacy/core/App/screens/Connection.tsx
+++ b/packages/legacy/core/App/screens/Connection.tsx
@@ -1,3 +1,4 @@
+import { DidExchangeState } from '@aries-framework/core'
 import { useConnectionById } from '@aries-framework/react-hooks'
 import { CommonActions, useFocusEffect } from '@react-navigation/native'
 import { StackScreenProps } from '@react-navigation/stack'
@@ -136,6 +137,11 @@ const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
   }, [state.shouldShowDelayMessage])
 
   useEffect(() => {
+    // for non-connectionless, invalid connections stay in the below state
+    if (connection && connection.state === DidExchangeState.RequestSent) {
+      return
+    }
+
     if (
       !connectionId &&
       !oobRecord &&

--- a/packages/legacy/core/App/utils/helpers.ts
+++ b/packages/legacy/core/App/utils/helpers.ts
@@ -811,7 +811,7 @@ export const receiveMessageFromDeepLink = async (url: string, agent: Agent | und
 }
 
 /**
- *
+ * Useful for multi use invitations
  * @param agent an Agent instance
  * @param invitationId id of invitation
  */
@@ -820,15 +820,13 @@ export const removeExistingInvitationIfRequired = async (
   invitationId: string
 ): Promise<void> => {
   try {
-    // If something fails before we get the credential we need to
-    // cleanup the old invitation before it can be used again.
     const oobRecord = await agent?.oob.findByReceivedInvitationId(invitationId)
     if (oobRecord) {
       await agent?.oob.deleteById(oobRecord.id)
     }
   } catch (error) {
-    // findByInvitationId with throw if unsuccessful but that's not a problem.
-    // It just means there is nothing to delete.
+    // findByReceivedInvitationId will throw if unsuccessful but that's not a problem
+    // it just means there is nothing to delete
   }
 }
 

--- a/packages/legacy/core/__tests__/fixtures/connection-v1-response-received.json
+++ b/packages/legacy/core/__tests__/fixtures/connection-v1-response-received.json
@@ -1,0 +1,18 @@
+{
+  "_tags": {},
+  "metadata": {},
+  "connectionTypes": [],
+  "id": "43be26c3-4b24-4915-9a84-367c5aac5bca",
+  "createdAt": "2023-06-30T18:44:29.268Z",
+  "did": "did:peer:1zQmYDZQFXdHuZam9e1kNtEevQjL9boEBGszBDGX2N8X8xeQ",
+  "invitationDid": "did:peer:2.SeyJzIjoiaHR0cHM6Ly90cmFjdGlvbi1kdHMtYWNhcHktZGV2LmFwcHMuc2lsdmVyLmRldm9wcy5nb3YuYmMuY2EiLCJ0IjoiZGlkLWNvbW11bmljYXRpb24iLCJwcmlvcml0eSI6MCwicmVjaXBpZW50S2V5cyI6WyJkaWQ6a2V5Ono2TWtuY3B2aG9GUXdnendyQTNRQXk3a1ZkYlB5d0I5c1FzUjFuTGszN3VKVmltSCN6Nk1rbmNwdmhvRlF3Z3p3ckEzUUF5N2tWZGJQeXdCOXNRc1IxbkxrMzd1SlZpbUgiXX0",
+  "theirLabel": "BestBC College",
+  "state": "response-received",
+  "role": "requester",
+  "autoAcceptConnection": true,
+  "threadId": "5f35f941-854a-4f76-ad51-5ef7f16b238c",
+  "mediatorId": "5497adc9-01d4-4f39-a9a8-b947dc662d5d",
+  "protocol": "https://didcomm.org/connections/1.0",
+  "outOfBandId": "99c18620-ec05-4b81-b569-a8065d62263f",
+  "updatedAt": "2023-06-30T18:44:29.272Z"
+}

--- a/packages/legacy/core/__tests__/screens/Connection.test.tsx
+++ b/packages/legacy/core/__tests__/screens/Connection.test.tsx
@@ -19,6 +19,8 @@ const proofNotifPath = path.join(__dirname, '../fixtures/proof-notif.json')
 const proofNotif = JSON.parse(fs.readFileSync(proofNotifPath, 'utf8'))
 const connectionPath = path.join(__dirname, '../fixtures/connection-v1.json')
 const connection = JSON.parse(fs.readFileSync(connectionPath, 'utf8'))
+const connectionResponseReceivedPath = path.join(__dirname, '../fixtures/connection-v1-response-received.json')
+const connectionResponseReceived = JSON.parse(fs.readFileSync(connectionResponseReceivedPath, 'utf8'))
 const outOfBandInvitation = { goalCode: 'aries.vc.verify.once' }
 const props = { params: { connectionId: connection.id } }
 
@@ -134,7 +136,7 @@ describe('ConnectionModal Component', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('Connection with no goal code', async () => {
+  test('Connection with no goal code, request-sent state', async () => {
     const navigation = useNavigation()
     // @ts-ignore-next-line
     useNotifications.mockReturnValue({ total: 1, notifications: [proofNotif] })
@@ -153,10 +155,32 @@ describe('ConnectionModal Component', () => {
     const tree = render(element)
 
     expect(tree).toMatchSnapshot()
+    expect(navigation.getParent()?.dispatch).not.toBeCalled()
+  })
+
+  test('Connection with no goal code, response-received state', async () => {
+    const navigation = useNavigation()
+    // @ts-ignore-next-line
+    useNotifications.mockReturnValue({ total: 1, notifications: [proofNotif] })
+    // @ts-ignore-next-line
+    useOutOfBandByConnectionId.mockReturnValue({ outOfBandInvitation: {} })
+    // @ts-ignore-next-line
+    useConnectionById.mockReturnValue(connectionResponseReceived)
+    // @ts-ignore-next-line
+    useProofById.mockReturnValue(proofNotif)
+    const element = (
+      <ConfigurationContext.Provider value={configurationContext}>
+        <ConnectionModal navigation={useNavigation()} route={props as any} />
+      </ConfigurationContext.Provider>
+    )
+
+    const tree = render(element)
+
+    expect(tree).toMatchSnapshot()
     expect(navigation.getParent()?.dispatch).toBeCalledTimes(1)
     expect(CommonActions.reset).toBeCalledWith({
       index: 1,
-      routes: [{ name: 'Tab Stack' }, { name: 'Chat', params: { connectionId: connection.id } }],
+      routes: [{ name: 'Tab Stack' }, { name: 'Chat', params: { connectionId: connectionResponseReceived.id } }],
     })
   })
 

--- a/packages/legacy/core/__tests__/screens/__snapshots__/Connection.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/Connection.test.tsx.snap
@@ -1,6 +1,195 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ConnectionModal Component Connection with no goal code 1`] = `
+exports[`ConnectionModal Component Connection with no goal code, request-sent state 1`] = `
+<Modal
+  animationType="slide"
+  hardwareAccelerated={false}
+  onRequestClose={[Function]}
+  transparent={true}
+  visible={true}
+>
+  <RNCSafeAreaView
+    style={
+      Object {
+        "backgroundColor": "#000000",
+      }
+    }
+  >
+    <RCTScrollView
+      style={
+        Array [
+          Object {
+            "backgroundColor": "#000000",
+            "height": "100%",
+            "padding": 20,
+          },
+        ]
+      }
+    >
+      <View>
+        <View
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+              },
+            ]
+          }
+        >
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 26,
+                  "fontWeight": "bold",
+                },
+                Object {
+                  "fontWeight": "normal",
+                  "marginTop": 30,
+                  "textAlign": "center",
+                },
+              ]
+            }
+            testID="com.ariesbifold:id/CredentialOnTheWay"
+          >
+            Connection.JustAMoment
+          </Text>
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "marginTop": 20,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <
+              fill="#FFFFFF"
+              height={130}
+              style={
+                Object {
+                  "position": "absolute",
+                }
+              }
+              width={130}
+            />
+            <View
+              collapsable={false}
+              style={
+                Object {
+                  "transform": Array [
+                    Object {
+                      "rotate": "0deg",
+                    },
+                  ],
+                }
+              }
+            >
+              <
+                fill="#FFFFFF"
+                height={250}
+                width={250}
+              />
+            </View>
+          </View>
+        </View>
+      </View>
+    </RCTScrollView>
+    <View
+      style={
+        Array [
+          Object {
+            "margin": 20,
+            "marginTop": "auto",
+          },
+        ]
+      }
+    >
+      <View
+        accessibilityLabel="Loading.BackToHome"
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          Object {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "borderColor": "#42803E",
+            "borderRadius": 4,
+            "borderWidth": 2,
+            "opacity": 1,
+            "padding": 16,
+          }
+        }
+        testID="com.ariesbifold:id/BackToHome"
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#42803E",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                  "textAlign": "center",
+                },
+                false,
+                false,
+                false,
+              ]
+            }
+          >
+            Loading.BackToHome
+          </Text>
+        </View>
+      </View>
+    </View>
+  </RNCSafeAreaView>
+</Modal>
+`;
+
+exports[`ConnectionModal Component Connection with no goal code, response-received state 1`] = `
 <Modal
   animationType="slide"
   hardwareAccelerated={false}

--- a/packages/legacy/core/__tests__/utils/helpers.test.ts
+++ b/packages/legacy/core/__tests__/utils/helpers.test.ts
@@ -12,6 +12,8 @@ import {
   formatIfDate,
   formatTime,
   getConnectionName,
+  removeExistingInvitationIfRequired,
+  connectFromInvitation,
 } from '../../App/utils/helpers'
 
 const proofCredentialPath = path.join(__dirname, '../fixtures/proof-credential.json')
@@ -99,7 +101,6 @@ describe('formatTime', () => {
 })
 
 describe('formatIfDate', () => {
-
   afterEach(() => {
     jest.clearAllMocks()
   })
@@ -111,12 +112,12 @@ describe('formatIfDate', () => {
 
   test('with format and string date', () => {
     const result = formatIfDate('YYYYMMDD', '20020523')
-    expect(result).toEqual("May 23, 2002")
+    expect(result).toEqual('May 23, 2002')
   })
 
   test('with format and number date', () => {
     const result = formatIfDate('YYYYMMDD', 20020523)
-    expect(result).toEqual("May 23, 2002")
+    expect(result).toEqual('May 23, 2002')
   })
 
   test('with format but invalid string date', () => {
@@ -150,6 +151,49 @@ describe('createConnectionInvitation', () => {
     const { agent } = useAgent()
 
     await expect(createConnectionInvitation(agent, 'aries.foo')).rejects.toThrow()
+  })
+})
+
+describe('removeExistingInvitationIfRequired', () => {
+  test('without an existing oobRecord', async () => {
+    const { agent } = useAgent()
+    const invitationId = '1'
+    agent!.oob.findByReceivedInvitationId = jest
+      .fn()
+      .mockReturnValueOnce(Promise.reject('No received invitation with this id exists'))
+    const deleteById = jest.fn()
+    agent!.oob.deleteById = deleteById
+
+    await removeExistingInvitationIfRequired(agent, invitationId)
+
+    expect(deleteById).not.toBeCalled()
+  })
+  test('with an existing oobRecord', async () => {
+    const { agent } = useAgent()
+    const invitationId = '1'
+    agent!.oob.findByReceivedInvitationId = jest.fn().mockReturnValueOnce(Promise.resolve({ id: '123' }))
+    const deleteById = jest.fn()
+    agent!.oob.deleteById = deleteById
+
+    await removeExistingInvitationIfRequired(agent, invitationId)
+
+    expect(deleteById).toBeCalledWith('123')
+  })
+})
+
+describe('connectFromInvitation', () => {
+  test('ordinary connection, default options', async () => {
+    const { agent } = useAgent()
+    const uri = ''
+    const parseInvitation = jest.fn().mockReturnValueOnce(Promise.resolve({ id: '123' }))
+    agent!.oob.parseInvitation = parseInvitation
+    const record = {}
+    const receiveInvitation = jest.fn().mockReturnValueOnce(Promise.resolve(record))
+    agent!.oob.receiveInvitation = receiveInvitation
+    const result = await connectFromInvitation(uri, agent)
+    expect(parseInvitation).toBeCalled()
+    expect(receiveInvitation).toBeCalled()
+    expect(result).toBe(record)
   })
 })
 


### PR DESCRIPTION
# Summary of Changes

Previously, scanning multi use invitations more than once would cause an error on the scan screen. Now scanning an multi use invitation will work as expected. Single use invitations that are attempted to be used more than once will stay on the `Connection` screen

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
