### PR TITLE
feat: remove explicit headerShown value in onboarding stack

### DIFF
--- a/packages/legacy/core/App/navigators/RootStack.tsx
+++ b/packages/legacy/core/App/navigators/RootStack.tsx
@@ -283,19 +283,14 @@ const RootStack: React.FC = () => {
     const Stack = createStackNavigator()
     const carousel = createCarouselStyle(OnboardingTheme)
     return (
-      <Stack.Navigator initialRouteName={Screens.Splash} screenOptions={{ ...defaultStackOptions, headerShown: false }}>
+      <Stack.Navigator initialRouteName={Screens.Splash} screenOptions={{ ...defaultStackOptions }}>
         <Stack.Screen name={Screens.Splash} component={splash} />
-        <Stack.Screen
-          name={Screens.Preface}
-          component={preface}
-          options={{ title: t('Screens.Preface'), headerShown: true }}
-        />
+        <Stack.Screen name={Screens.Preface} component={preface} options={{ title: t('Screens.Preface') }} />
         <Stack.Screen
           name={Screens.Onboarding}
           options={() => ({
             title: t('Screens.Onboarding'),
             headerTintColor: OnboardingTheme.headerTintColor,
-            headerShown: true,
             gestureEnabled: false,
             headerLeft: () => false,
           })}
@@ -316,7 +311,6 @@ const RootStack: React.FC = () => {
           options={() => ({
             title: t('Screens.Terms'),
             headerTintColor: OnboardingTheme.headerTintColor,
-            headerShown: true,
             headerLeft: () => false,
             rightLeft: () => false,
           })}
@@ -326,7 +320,6 @@ const RootStack: React.FC = () => {
           name={Screens.CreatePIN}
           options={() => ({
             title: t('Screens.CreatePIN'),
-            headerShown: true,
             headerLeft: () => false,
             rightLeft: () => false,
           })}
@@ -338,7 +331,6 @@ const RootStack: React.FC = () => {
           options={() => ({
             title: t('Screens.NameWallet'),
             headerTintColor: OnboardingTheme.headerTintColor,
-            headerShown: true,
             headerLeft: () => false,
             rightLeft: () => false,
           })}
@@ -349,7 +341,6 @@ const RootStack: React.FC = () => {
           options={() => ({
             title: t('Screens.Biometry'),
             headerTintColor: OnboardingTheme.headerTintColor,
-            headerShown: true,
             headerLeft: () => false,
             rightLeft: () => false,
           })}


### PR DESCRIPTION
# Summary of Changes

Remove the explicit value of "headerShown" in onboarding stack in favour of global screen options default value which is "true" by default

# Related Issues


- [X] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.
