### PR TITLE
fix: prevent scan function from running multiple times for single scan

### DIFF
--- a/packages/legacy/core/App/components/misc/ScanCamera.tsx
+++ b/packages/legacy/core/App/components/misc/ScanCamera.tsx
@@ -34,25 +34,28 @@ const ScanCamera: React.FC<Props> = ({ handleCodeScan, error, enableCameraOnErro
     setOrientation(orientationType)
   })
 
-  const onCodeScanned = useCallback((codes: Code[]) => {
-    const value = codes[0].value
-    if (!value || invalidQrCodes.has(value)) {
-      return
-    }
-
-    if (error?.data === value) {
-      invalidQrCodes.add(value)
-      if (enableCameraOnError) {
-        return setCameraActive(true)
+  const onCodeScanned = useCallback(
+    (codes: Code[]) => {
+      const value = codes[0].value
+      if (!value || invalidQrCodes.has(value)) {
+        return
       }
-    }
 
-    if (cameraActive) {
-      Vibration.vibrate()
-      handleCodeScan(value)
-      return setCameraActive(false)
-    }
-  }, [])
+      if (error?.data === value) {
+        invalidQrCodes.add(value)
+        if (enableCameraOnError) {
+          return setCameraActive(true)
+        }
+      }
+
+      if (cameraActive) {
+        Vibration.vibrate()
+        handleCodeScan(value)
+        return setCameraActive(false)
+      }
+    },
+    [cameraActive]
+  )
 
   const codeScanner = useCodeScanner({
     codeTypes: ['qr'],

--- a/packages/legacy/core/App/screens/Connection.tsx
+++ b/packages/legacy/core/App/screens/Connection.tsx
@@ -176,7 +176,7 @@ const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
     if (state.notificationRecord && goalCode) {
       goalCodeAction(goalCode)()
     }
-  }, [connection, oobRecord, goalCode, state.notificationRecord])
+  }, [connection, connection?.state, oobRecord, goalCode, state.notificationRecord])
 
   useMemo(() => {
     startTimer()


### PR DESCRIPTION
# Summary of Changes

There was a missing dependency in a `useCallback` function that caused the `handleCodeScan` function to sometimes run more than once per scan. After the recent change to remove old invitations, this caused brand new invitations (first scan fn run) to be deleted (second scan fn run). This change prevents the `handleCodeScan` function from running more than once per scan

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [ ] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
