### PR TITLE
feat:implement hide lists for credentials and contacts

### DIFF
--- a/packages/legacy/core/App/contexts/configuration.tsx
+++ b/packages/legacy/core/App/contexts/configuration.tsx
@@ -59,6 +59,8 @@ export interface ConfigurationContext {
   globalScreenOptions?: StackNavigationOptions
   showDetailsInfo?: boolean
   getCredentialHelpDictionary?: GetCredentialHelpEntry[]
+  contactHideList?: string[]
+  credentialHideList?: string[]
 }
 
 export const ConfigurationContext = createContext<ConfigurationContext>(null as unknown as ConfigurationContext)

--- a/packages/legacy/core/App/screens/ListContacts.tsx
+++ b/packages/legacy/core/App/screens/ListContacts.tsx
@@ -8,6 +8,7 @@ import { FlatList, StyleSheet, View } from 'react-native'
 import HeaderButton, { ButtonLocation } from '../components/buttons/HeaderButton'
 import ContactListItem from '../components/listItems/ContactListItem'
 import EmptyListContacts from '../components/misc/EmptyListContacts'
+import { useConfiguration } from '../contexts/configuration'
 import { useStore } from '../contexts/store'
 import { useTheme } from '../contexts/theme'
 import { ContactStackParams, Screens, Stacks } from '../types/navigators'
@@ -32,10 +33,16 @@ const ListContacts: React.FC<ListContactsProps> = ({ navigation }) => {
   })
   const { records } = useConnections()
   const [store] = useStore()
-  // Filter out mediator agents
+  const { contactHideList } = useConfiguration()
+  // Filter out mediator agents and hidden contacts when not in dev mode
   let connections: ConnectionRecord[] = records
   if (!store.preferences.developerModeEnabled) {
-    connections = records.filter((r) => !r.connectionTypes.includes(ConnectionType.Mediator))
+    connections = records.filter((r) => {
+      return (
+        !r.connectionTypes.includes(ConnectionType.Mediator) &&
+        !contactHideList?.includes((r.theirLabel || r.alias) ?? '')
+      )
+    })
   }
 
   const onPressAddContact = () => {

--- a/packages/legacy/core/App/screens/ListCredentials.tsx
+++ b/packages/legacy/core/App/screens/ListCredentials.tsx
@@ -1,3 +1,4 @@
+import { AnonCredsCredentialMetadataKey } from '@aries-framework/anoncreds/build/utils/metadata'
 import { CredentialState } from '@aries-framework/core'
 import { useCredentialByState } from '@aries-framework/react-hooks'
 import { useNavigation } from '@react-navigation/core'
@@ -18,18 +19,29 @@ import { TourID } from '../types/tour'
 
 const ListCredentials: React.FC = () => {
   const { t } = useTranslation()
+  const [store, dispatch] = useStore()
   const {
     credentialListOptions: CredentialListOptions,
     credentialEmptyList: CredentialEmptyList,
     enableTours: enableToursConfig,
+    credentialHideList,
   } = useConfiguration()
-  const credentials = [
+
+  let credentials = [
     ...useCredentialByState(CredentialState.CredentialReceived),
     ...useCredentialByState(CredentialState.Done),
   ]
+
+  // Filter out hidden credentials when not in dev mode
+  if (!store.preferences.developerModeEnabled) {
+    credentials = credentials.filter((r) => {
+      const credDefId = r.metadata.get(AnonCredsCredentialMetadataKey)?.credentialDefinitionId
+      return !credentialHideList?.includes(credDefId)
+    })
+  }
+
   const navigation = useNavigation<StackNavigationProp<CredentialStackParams>>()
   const { ColorPallet } = useTheme()
-  const [store, dispatch] = useStore()
   const { start, stop } = useTour()
   const screenIsFocused = useIsFocused()
 

--- a/packages/legacy/core/__tests__/screens/ListContacts.test.tsx
+++ b/packages/legacy/core/__tests__/screens/ListContacts.test.tsx
@@ -5,6 +5,7 @@ import { act, fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
 
 import { ConfigurationContext } from '../../App/contexts/configuration'
+import { StoreProvider, defaultState } from '../../App/contexts/store'
 import ListContacts from '../../App/screens/ListContacts'
 import configurationContext from '../contexts/configuration'
 
@@ -82,5 +83,57 @@ describe('ListContacts Component', () => {
         },
       })
     })
+  })
+
+  test('Hide list filters out specific contacts', async () => {
+    const navigation = useNavigation()
+    const tree = render(
+      <StoreProvider
+        initialState={{
+          ...defaultState,
+          preferences: {
+            ...defaultState.preferences,
+            developerModeEnabled: false,
+          },
+        }}
+      >
+        <ConfigurationContext.Provider value={{ ...configurationContext, contactHideList: ['Faber'] }}>
+          <ListContacts navigation={navigation as any} />
+        </ConfigurationContext.Provider>
+      </StoreProvider>
+    )
+    await act(async () => {})
+
+    const faberContact = await tree.queryByText('Faber', { exact: false })
+    const bobContact = await tree.queryByText('Bob', { exact: false })
+
+    expect(faberContact).toBe(null)
+    expect(bobContact).not.toBe(null)
+  })
+
+  test('Hide list does not filter out specific contacts when developer mode is enabled', async () => {
+    const navigation = useNavigation()
+    const tree = render(
+      <StoreProvider
+        initialState={{
+          ...defaultState,
+          preferences: {
+            ...defaultState.preferences,
+            developerModeEnabled: true,
+          },
+        }}
+      >
+        <ConfigurationContext.Provider value={{ ...configurationContext, contactHideList: ['Faber'] }}>
+          <ListContacts navigation={navigation as any} />
+        </ConfigurationContext.Provider>
+      </StoreProvider>
+    )
+    await act(async () => {})
+
+    const faberContact = await tree.queryByText('Faber', { exact: false })
+    const bobContact = await tree.queryByText('Bob', { exact: false })
+
+    expect(faberContact).not.toBe(null)
+    expect(bobContact).not.toBe(null)
   })
 })


### PR DESCRIPTION
# Summary of Changes

This PR introduces the feature of credential and contact hide lists. Supply a contact hide list with your configuration and when developer mode is not enabled, all contacts with that `alias` or `theirLabel` will be hidden. Same goes for credentials, using cred def IDs.

Here's what it looks like:
![hide_lists](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/32586431/3f164488-c898-4cb3-8883-c14efd1595f0)

# Related Issues

Please reference here any issue #'s that are relevant to this PR, or simply enter "N/A" if this PR does not relate to any existing issues.N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
