### PR TITLE
feat: add loading info box during attestation

### DIFF
--- a/packages/legacy/core/App/localization/en/index.ts
+++ b/packages/legacy/core/App/localization/en/index.ts
@@ -419,6 +419,7 @@ const translation = {
     "DeleteOfferDescription": "Don't recognize the organization? Check your Contacts list. You only receive notifications from Contacts you've initiated",
   },
   "ProofRequest": {
+    "JustAMoment": "Just a moment while we prepare things for you...",
     "FromYourWallet": "From your wallet",
     "MissingCredentials": "Missing credentials",
     "PredicateGeDate": "is after",

--- a/packages/legacy/core/App/localization/fr/index.ts
+++ b/packages/legacy/core/App/localization/fr/index.ts
@@ -416,6 +416,7 @@ const translation = {
         "CustomOfferParagraph2": "Vous ne reconnaissez pas l'organisation? Vérifiez votre liste de Contacts. Vous ne recevez des notifications que des Contacts que vous avez initiés."
     },
     "ProofRequest": {
+        "JustAMoment": "Just a moment while we prepare things for you... (FR)",
         "FromYourWallet": "From your wallet (FR)",
         "MissingCredentials": "Missing credentials (FR)",
         "PredicateGeDate": "is after (FR)",

--- a/packages/legacy/core/App/localization/pt-br/index.ts
+++ b/packages/legacy/core/App/localization/pt-br/index.ts
@@ -400,6 +400,7 @@ const translation = {
     "CustomOfferParagraph2": "Não reconhece a organização. Verifique sua lista de Contatos. Você só recebe notificões de Contatos que você tenha adicionado.",
   },
   "ProofRequest": {
+    "JustAMoment": "Just a moment while we prepare things for you... (PT-BR)",
     "FromYourWallet": "From your wallet (PB)",
     "MissingCredentials": "Missing credentials (PB)",
     "PredicateGeDate": "é posterior a",

--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -21,6 +21,7 @@ import { CredentialCard } from '../components/misc'
 import ConnectionAlert from '../components/misc/ConnectionAlert'
 import ConnectionImage from '../components/misc/ConnectionImage'
 import CommonRemoveModal from '../components/modals/CommonRemoveModal'
+import InfoTextBox from '../components/texts/InfoTextBox'
 import { EventTypes } from '../constants'
 import { useAnimatedComponents } from '../contexts/animated-components'
 import { useConfiguration } from '../contexts/configuration'
@@ -393,6 +394,11 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
   const proofPageHeader = () => {
     return (
       <View style={styles.pageMargin}>
+        {attestationLoading && (
+          <View style={{ paddingTop: 20 }}>
+            <InfoTextBox>{t('ProofRequest.JustAMoment')}</InfoTextBox>
+          </View>
+        )}
         {loading || attestationLoading ? (
           <View style={styles.cardLoading}>
             <RecordLoading />


### PR DESCRIPTION
# Summary of Changes

Adds an info box to communicate WIP during attestation proof request. Here's what it looks like:
![attestation_info_box](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/32586431/aaf566c8-375a-47cd-a290-c439c9295bbc)

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [ ] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
