### PR TITLE
fix: add missing scan screen features in new scan screen

### DIFF
--- a/packages/legacy/core/App/components/misc/NewQRView.tsx
+++ b/packages/legacy/core/App/components/misc/NewQRView.tsx
@@ -3,10 +3,12 @@ import { useAgent } from '@aries-framework/react-hooks'
 import { StackScreenProps } from '@react-navigation/stack'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { View, StyleSheet, Text, ScrollView, useWindowDimensions } from 'react-native'
+import { View, Modal, StyleSheet, Text, ScrollView, useWindowDimensions, Pressable } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import Icon from 'react-native-vector-icons/MaterialIcons'
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
+import { hitSlop } from '../../constants'
+import { useConfiguration } from '../../contexts/configuration'
 import { useStore } from '../../contexts/store'
 import { useTheme } from '../../contexts/theme'
 import { useConnectionByOutOfBandId } from '../../hooks/connections'
@@ -16,6 +18,7 @@ import { createConnectionInvitation } from '../../utils/helpers'
 import { testIdWithKey } from '../../utils/testable'
 import LoadingIndicator from '../animated/LoadingIndicator'
 import HeaderButton, { ButtonLocation } from '../buttons/HeaderButton'
+import InfoBox, { InfoBoxType } from '../misc/InfoBox'
 
 import QRRenderer from './QRRenderer'
 import QRScannerTorch from './QRScannerTorch'
@@ -35,6 +38,8 @@ const NewQRView: React.FC<Props> = ({ defaultToConnect, handleCodeScan, error, e
   const { width } = useWindowDimensions()
   const qrSize = width - 40
   const [store] = useStore()
+  const { showScanHelp, showScanButton } = useConfiguration()
+  const [showInfoBox, setShowInfoBox] = useState(false)
   const [torchActive, setTorchActive] = useState(false)
   const [firstTabActive, setFirstTabActive] = useState(!defaultToConnect)
   const [invitation, setInvitation] = useState<string | undefined>(undefined)
@@ -44,9 +49,13 @@ const NewQRView: React.FC<Props> = ({ defaultToConnect, handleCodeScan, error, e
   const { agent } = useAgent()
 
   const styles = StyleSheet.create({
-    container: {
+    mainSafeArea: {
       flex: 1,
       backgroundColor: ColorPallet.brand.secondaryBackground,
+    },
+    bottomSafeArea: {
+      flex: 0,
+      backgroundColor: ColorPallet.brand.primaryBackground,
     },
     camera: {
       flex: 1,
@@ -66,16 +75,16 @@ const NewQRView: React.FC<Props> = ({ defaultToConnect, handleCodeScan, error, e
       borderColor: ColorPallet.grayscale.white,
     },
     viewFinderContainer: {
-      flex: 1,
-      width: '100%',
+      flexGrow: 1,
       justifyContent: 'center',
       alignItems: 'center',
     },
-    errorContainer: {
+    messageContainer: {
+      marginHorizontal: 40,
       flexDirection: 'row',
       alignItems: 'center',
-      marginTop: 20,
-      paddingHorizontal: 20,
+      alignSelf: 'center',
+      paddingTop: 30,
     },
     icon: {
       color: ColorPallet.grayscale.white,
@@ -98,7 +107,18 @@ const NewQRView: React.FC<Props> = ({ defaultToConnect, handleCodeScan, error, e
       marginTop: 20,
       textAlign: 'center',
     },
-    editButton: { ...TextTheme.headingTwo, marginBottom: 20, marginLeft: 10, color: ColorPallet.brand.primary },
+    textStyle: {
+      ...TextTheme.title,
+      color: 'white',
+      marginHorizontal: 10,
+      textAlign: 'center',
+    },
+    editButton: {
+      ...TextTheme.headingTwo,
+      marginBottom: 20,
+      marginLeft: 10,
+      color: ColorPallet.brand.primary,
+    },
   })
 
   const createInvitation = useCallback(async () => {
@@ -132,89 +152,143 @@ const NewQRView: React.FC<Props> = ({ defaultToConnect, handleCodeScan, error, e
     }
   }, [record])
 
+  const styleForState = ({ pressed }: { pressed: boolean }) => [{ opacity: pressed ? 0.2 : 1 }]
+
+  const toggleShowInfoBox = () => setShowInfoBox(!showInfoBox)
+
   return (
-    <SafeAreaView edges={['bottom', 'left', 'right']} style={styles.container}>
-      {firstTabActive ? (
-        <>
-          <ScanCamera
-            handleCodeScan={handleCodeScan}
-            enableCameraOnError={enableCameraOnError}
-            error={error}
-            torchActive={torchActive}
-          />
-          <View style={styles.cameraViewContainer}>
-            <View style={styles.errorContainer}>
-              {error ? (
-                <>
-                  <Icon style={styles.icon} name="cancel" size={30}></Icon>
-                  <Text
-                    testID={testIdWithKey('ErrorMessage')}
-                    style={[TextTheme.normal, { color: ColorPallet.grayscale.white }]}
-                  >
-                    {error.message}
-                  </Text>
-                </>
-              ) : (
-                <Text style={[TextTheme.normal, { color: ColorPallet.grayscale.white }]}>
-                  {t('Scan.WillScanAutomatically')}
-                </Text>
-              )}
-            </View>
-            <View style={styles.viewFinderContainer}>
-              <View style={styles.viewFinder} />
-            </View>
-            <QRScannerTorch active={torchActive} onPress={() => setTorchActive(!torchActive)} />
-          </View>
-        </>
-      ) : (
-        <ScrollView>
-          <View style={{ alignItems: 'center' }}>
-            <View style={styles.qrContainer}>
-              {!invitation && <LoadingIndicator />}
-              {invitation && <QRRenderer value={invitation} size={qrSize} />}
-            </View>
-            <View style={{ paddingHorizontal: 20, flex: 1 }}>
+    <>
+      <SafeAreaView edges={['left', 'right']} style={styles.mainSafeArea}>
+        {firstTabActive ? (
+          <>
+            <Modal visible={showInfoBox} animationType="fade" transparent>
               <View
                 style={{
-                  display: 'flex',
-                  flexDirection: 'row',
-                  alignItems: 'center',
+                  flex: 1,
+                  paddingHorizontal: 10,
                   justifyContent: 'center',
+                  alignItems: 'center',
+                  backgroundColor: 'rgba(0,0,0,0.6)',
                 }}
               >
-                <Text testID={testIdWithKey('WalletName')} style={[styles.walletName, { paddingHorizontal: 20 }]}>
-                  {store.preferences.walletName}
-                </Text>
-                <HeaderButton
-                  buttonLocation={ButtonLocation.Right}
-                  accessibilityLabel={t('NameWallet.EditWalletName')}
-                  testID={testIdWithKey('EditWalletName')}
-                  onPress={handleEdit}
-                  icon={'pencil'}
-                  iconTintColor={styles.walletName.color}
+                <InfoBox
+                  notificationType={InfoBoxType.Info}
+                  title={t('Scan.BadQRCode')}
+                  description={t('Scan.BadQRCodeDescription')}
+                  onCallToActionPressed={toggleShowInfoBox}
                 />
               </View>
-              <Text style={styles.secondaryText}>{t('Connection.ShareQR')}</Text>
-            </View>
-          </View>
-        </ScrollView>
-      )}
+            </Modal>
+            <ScanCamera
+              handleCodeScan={handleCodeScan}
+              enableCameraOnError={enableCameraOnError}
+              error={error}
+              torchActive={torchActive}
+            />
+            <View style={styles.cameraViewContainer}>
+              <View style={styles.messageContainer}>
+                {error ? (
+                  <>
+                    <Icon style={styles.icon} name="cancel" size={40} />
+                    <Text testID={testIdWithKey('ErrorMessage')} style={styles.textStyle}>
+                      {error.message}
+                    </Text>
+                  </>
+                ) : (
+                  <>
+                    <Icon name="qrcode-scan" size={40} style={styles.icon} />
+                    <Text style={styles.textStyle}>{t('Scan.WillScanAutomatically')}</Text>
+                  </>
+                )}
+              </View>
+              <View style={styles.viewFinderContainer}>
+                <View style={styles.viewFinder} />
+              </View>
+              {showScanButton && (
+                <View style={{ justifyContent: 'center', alignItems: 'center' }}>
+                  <Pressable
+                    accessibilityLabel={t('Scan.ScanNow')}
+                    accessibilityRole={'button'}
+                    testID={testIdWithKey('ScanNow')}
+                    onPress={toggleShowInfoBox}
+                    style={styleForState}
+                    hitSlop={hitSlop}
+                  >
+                    <Icon name="circle-outline" size={60} style={{ color: 'white', marginBottom: -15 }} />
+                  </Pressable>
+                </View>
+              )}
 
-      <View style={styles.tabContainer}>
-        <ScanTab
-          title={t('Scan.ScanQRCode')}
-          iconName={'crop-free'}
-          onPress={() => setFirstTabActive(true)}
-          active={firstTabActive}
-        />
-        <ScanTab
-          title={t('Scan.MyQRCode')}
-          iconName={'qr-code'}
-          onPress={() => setFirstTabActive(false)}
-          active={!firstTabActive}
-        />
-      </View>
-    </SafeAreaView>
+              <View style={{ width: '90%', marginHorizontal: 24, height: 24, marginBottom: 60, flexDirection: 'row' }}>
+                {showScanHelp && (
+                  <Pressable
+                    accessibilityLabel={t('Scan.ScanHelp')}
+                    accessibilityRole={'button'}
+                    testID={testIdWithKey('ScanHelp')}
+                    onPress={() => navigation.navigate(Screens.ScanHelp)}
+                    style={styleForState}
+                    hitSlop={hitSlop}
+                  >
+                    <Icon name="help-circle" size={24} style={{ color: 'white' }} />
+                  </Pressable>
+                )}
+
+                <View style={{ width: 10, marginLeft: 'auto' }} />
+                <QRScannerTorch active={torchActive} onPress={() => setTorchActive(!torchActive)} />
+              </View>
+            </View>
+          </>
+        ) : (
+          <ScrollView>
+            <View style={{ alignItems: 'center' }}>
+              <View style={styles.qrContainer}>
+                {!invitation && <LoadingIndicator />}
+                {invitation && <QRRenderer value={invitation} size={qrSize} />}
+              </View>
+              <View style={{ paddingHorizontal: 20, flex: 1 }}>
+                <View
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <Text testID={testIdWithKey('WalletName')} style={[styles.walletName, { paddingHorizontal: 20 }]}>
+                    {store.preferences.walletName}
+                  </Text>
+                  <HeaderButton
+                    buttonLocation={ButtonLocation.Right}
+                    accessibilityLabel={t('NameWallet.EditWalletName')}
+                    testID={testIdWithKey('EditWalletName')}
+                    onPress={handleEdit}
+                    icon={'pencil'}
+                    iconTintColor={styles.walletName.color}
+                  />
+                </View>
+                <Text style={styles.secondaryText}>{t('Connection.ShareQR')}</Text>
+              </View>
+            </View>
+          </ScrollView>
+        )}
+
+        <View style={styles.tabContainer}>
+          <ScanTab
+            title={t('Scan.ScanQRCode')}
+            iconName={'crop-free'}
+            onPress={() => setFirstTabActive(true)}
+            active={firstTabActive}
+          />
+          <ScanTab
+            title={t('Scan.MyQRCode')}
+            iconName={'qr-code'}
+            onPress={() => setFirstTabActive(false)}
+            active={!firstTabActive}
+          />
+        </View>
+      </SafeAreaView>
+      <SafeAreaView edges={['bottom']} style={styles.bottomSafeArea} />
+    </>
   )
 }
 

--- a/packages/legacy/core/__tests__/components/__snapshots__/NewQRView.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/NewQRView.test.tsx.snap
@@ -1,83 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NewQRView Component Renders correctly on first tab 1`] = `
-<RNCSafeAreaView
-  edges={
-    Array [
-      "bottom",
-      "left",
-      "right",
-    ]
-  }
-  style={
-    Object {
-      "backgroundColor": "#313132",
-      "flex": 1,
-    }
-  }
->
-  <View
-    style={
+Array [
+  <RNCSafeAreaView
+    edges={
       Array [
-        Object {
-          "bottom": 0,
-          "left": 0,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-        },
-        Object {
-          "transform": Array [
-            Object {
-              "rotate": "0deg",
-            },
-          ],
-        },
+        "left",
+        "right",
       ]
     }
-  />
-  <View
     style={
       Object {
-        "alignItems": "center",
+        "backgroundColor": "#313132",
         "flex": 1,
-        "width": "100%",
       }
     }
   >
+    <Modal
+      animationType="fade"
+      hardwareAccelerated={false}
+      transparent={true}
+      visible={false}
+    />
     <View
       style={
-        Object {
-          "alignItems": "center",
-          "flexDirection": "row",
-          "marginTop": 20,
-          "paddingHorizontal": 20,
-        }
+        Array [
+          Object {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          Object {
+            "transform": Array [
+              Object {
+                "rotate": "0deg",
+              },
+            ],
+          },
+        ]
       }
-    >
-      <Text
-        style={
-          Array [
-            Object {
-              "color": "#FFFFFF",
-              "fontSize": 18,
-              "fontWeight": "normal",
-            },
-            Object {
-              "color": "#FFFFFF",
-            },
-          ]
-        }
-      >
-        Scan.WillScanAutomatically
-      </Text>
-    </View>
+    />
     <View
       style={
         Object {
           "alignItems": "center",
           "flex": 1,
-          "justifyContent": "center",
           "width": "100%",
         }
       }
@@ -85,586 +54,692 @@ exports[`NewQRView Component Renders correctly on first tab 1`] = `
       <View
         style={
           Object {
-            "borderColor": "#FFFFFF",
-            "borderRadius": 24,
-            "borderWidth": 2,
-            "height": 250,
-            "width": 250,
+            "alignItems": "center",
+            "alignSelf": "center",
+            "flexDirection": "row",
+            "marginHorizontal": 40,
+            "paddingTop": 30,
           }
         }
-      />
-    </View>
-    <View
-      accessibilityLabel="Scan.Torch"
-      accessibilityRole="button"
-      accessibilityState={
-        Object {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": undefined,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        Object {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      hitSlop={
-        Object {
-          "bottom": 44,
-          "left": 44,
-          "right": 44,
-          "top": 44,
-        }
-      }
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        Object {
-          "alignItems": "center",
-          "backgroundColor": undefined,
-          "borderColor": "#FFFFFF",
-          "borderRadius": 24,
-          "borderWidth": 1,
-          "height": 24,
-          "justifyContent": "center",
-          "marginBottom": 50,
-          "opacity": 1,
-          "width": 24,
-        }
-      }
-      testID="com.ariesbifold:id/ScanTorch"
-    >
-      <Text
-        allowFontScaling={false}
-        selectable={false}
-        style={
-          Array [
-            Object {
-              "color": "#FFFFFF",
-              "fontSize": 24,
-            },
-            Object {
-              "alignItems": "center",
-            },
-            Object {
-              "fontFamily": "Material Icons",
-              "fontStyle": "normal",
-              "fontWeight": "normal",
-            },
-            Object {},
-          ]
-        }
       >
-        
-      </Text>
-    </View>
-  </View>
-  <View
-    style={
-      Object {
-        "backgroundColor": "#313132",
-        "borderTopWidth": 0,
-        "flexDirection": "row",
-        "height": 60,
-        "paddingBottom": 0,
-        "shadowColor": "#000000",
-        "shadowOffset": Object {
-          "height": -3,
-          "width": 0,
-        },
-        "shadowOpacity": 0.1,
-        "shadowRadius": 6,
-      }
-    }
-  >
-    <View
-      accessibilityLabel="Scan.ScanQRCode"
-      accessibilityState={
-        Object {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": undefined,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        Object {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        Object {
-          "alignItems": "center",
-          "flex": 1,
-          "justifyContent": "center",
-          "opacity": 1,
-        }
-      }
-      testID="com.ariesbifold:id/Scan.ScanQRCode"
-    >
-      <Text
-        allowFontScaling={false}
-        selectable={false}
-        style={
-          Array [
+        <Text
+          allowFontScaling={false}
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "color": undefined,
+                "fontSize": 40,
+              },
+              Object {
+                "color": "#FFFFFF",
+                "padding": 4,
+              },
+              Object {
+                "fontFamily": "Material Design Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          󰐳
+        </Text>
+        <Text
+          style={
             Object {
-              "color": "#42803E",
-              "fontSize": 30,
-            },
-            undefined,
-            Object {
-              "fontFamily": "Material Icons",
-              "fontStyle": "normal",
-              "fontWeight": "normal",
-            },
-            Object {},
-          ]
-        }
-      >
-        
-      </Text>
-    </View>
-    <View
-      accessibilityLabel="Scan.MyQRCode"
-      accessibilityState={
-        Object {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": undefined,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        Object {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        Object {
-          "alignItems": "center",
-          "flex": 1,
-          "justifyContent": "center",
-          "opacity": 1,
-        }
-      }
-      testID="com.ariesbifold:id/Scan.MyQRCode"
-    >
-      <Text
-        allowFontScaling={false}
-        selectable={false}
-        style={
-          Array [
-            Object {
-              "color": "#FFFFFF",
-              "fontSize": 30,
-            },
-            undefined,
-            Object {
-              "fontFamily": "Material Icons",
-              "fontStyle": "normal",
-              "fontWeight": "normal",
-            },
-            Object {},
-          ]
-        }
-      >
-        
-      </Text>
-    </View>
-  </View>
-</RNCSafeAreaView>
-`;
-
-exports[`NewQRView Component Renders correctly on second tab 1`] = `
-<RNCSafeAreaView
-  edges={
-    Array [
-      "bottom",
-      "left",
-      "right",
-    ]
-  }
-  style={
-    Object {
-      "backgroundColor": "#313132",
-      "flex": 1,
-    }
-  }
->
-  <RCTScrollView>
-    <View>
+              "color": "white",
+              "fontSize": 20,
+              "fontWeight": "bold",
+              "marginHorizontal": 10,
+              "textAlign": "center",
+            }
+          }
+        >
+          Scan.WillScanAutomatically
+        </Text>
+      </View>
       <View
         style={
           Object {
             "alignItems": "center",
+            "flexGrow": 1,
+            "justifyContent": "center",
           }
         }
       >
         <View
           style={
             Object {
-              "flex": 1,
-              "marginTop": 10,
+              "borderColor": "#FFFFFF",
+              "borderRadius": 24,
+              "borderWidth": 2,
+              "height": 250,
+              "width": 250,
             }
           }
-        >
-          <View
-            style={
-              Object {
-                "alignItems": "center",
-                "justifyContent": "center",
-              }
-            }
-            testID="com.ariesbifold:id/LoadingActivityIndicator"
-          >
-            <Image
-              source={
-                Object {
-                  "default": "",
-                }
-              }
-              style={
-                Object {
-                  "height": "33%",
-                  "width": "33%",
-                }
-              }
-              testID="com.ariesbifold:id/LoadingActivityIndicatorImage"
-            />
-            <View
-              collapsable={false}
-              style={
-                Object {
-                  "position": "absolute",
-                  "transform": Array [
-                    Object {
-                      "rotate": "360deg",
-                    },
-                  ],
-                }
-              }
-            >
-              <
-                fill="#FFFFFF"
-                height={200}
-                width={200}
-              />
-            </View>
-          </View>
-        </View>
+        />
+      </View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+            "height": 24,
+            "marginBottom": 60,
+            "marginHorizontal": 24,
+            "width": "90%",
+          }
+        }
+      >
         <View
           style={
             Object {
-              "flex": 1,
-              "paddingHorizontal": 20,
+              "marginLeft": "auto",
+              "width": 10,
             }
           }
+        />
+        <View
+          accessibilityLabel="Scan.Torch"
+          accessibilityRole="button"
+          accessibilityState={
+            Object {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            Object {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 44,
+              "left": 44,
+              "right": 44,
+              "top": 44,
+            }
+          }
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "backgroundColor": undefined,
+              "borderColor": "#FFFFFF",
+              "borderRadius": 24,
+              "borderWidth": 1,
+              "height": 24,
+              "justifyContent": "center",
+              "marginBottom": 50,
+              "opacity": 1,
+              "width": 24,
+            }
+          }
+          testID="com.ariesbifold:id/ScanTorch"
         >
-          <View
-            style={
-              Object {
-                "alignItems": "center",
-                "display": "flex",
-                "flexDirection": "row",
-                "justifyContent": "center",
-              }
-            }
-          >
-            <Text
-              style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 32,
-                    "fontWeight": "bold",
-                    "textAlign": "center",
-                  },
-                  Object {
-                    "paddingHorizontal": 20,
-                  },
-                ]
-              }
-              testID="com.ariesbifold:id/WalletName"
-            >
-              My Wallet - 1234
-            </Text>
-            <View
-              accessibilityLabel="NameWallet.EditWalletName"
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "busy": undefined,
-                  "checked": undefined,
-                  "disabled": undefined,
-                  "expanded": undefined,
-                  "selected": undefined,
-                }
-              }
-              accessibilityValue={
-                Object {
-                  "max": undefined,
-                  "min": undefined,
-                  "now": undefined,
-                  "text": undefined,
-                }
-              }
-              accessible={true}
-              collapsable={false}
-              focusable={true}
-              hitSlop={
-                Object {
-                  "bottom": 44,
-                  "left": 44,
-                  "right": 44,
-                  "top": 44,
-                }
-              }
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              testID="com.ariesbifold:id/EditWalletName"
-            >
-              <View
-                style={
-                  Object {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                    "marginLeft": 0,
-                    "marginRight": 15,
-                    "minHeight": 26,
-                    "minWidth": 26,
-                  }
-                }
-              >
-                <Text
-                  allowFontScaling={false}
-                  selectable={false}
-                  style={
-                    Array [
-                      Object {
-                        "color": "#FFFFFF",
-                        "fontSize": 26,
-                      },
-                      undefined,
-                      Object {
-                        "fontFamily": "Material Design Icons",
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
-                      },
-                      Object {},
-                    ]
-                  }
-                >
-                  󰏫
-                </Text>
-              </View>
-            </View>
-          </View>
           <Text
+            allowFontScaling={false}
+            selectable={false}
             style={
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 18,
-                "fontWeight": "normal",
-                "marginTop": 20,
-                "textAlign": "center",
-              }
+              Array [
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 24,
+                },
+                Object {
+                  "alignItems": "center",
+                },
+                Object {
+                  "fontFamily": "Material Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
             }
           >
-            Connection.ShareQR
+            
           </Text>
         </View>
       </View>
     </View>
-  </RCTScrollView>
-  <View
+    <View
+      style={
+        Object {
+          "backgroundColor": "#313132",
+          "borderTopWidth": 0,
+          "flexDirection": "row",
+          "height": 60,
+          "paddingBottom": 0,
+          "shadowColor": "#000000",
+          "shadowOffset": Object {
+            "height": -3,
+            "width": 0,
+          },
+          "shadowOpacity": 0.1,
+          "shadowRadius": 6,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Scan.ScanQRCode"
+        accessibilityState={
+          Object {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          Object {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "justifyContent": "center",
+            "opacity": 1,
+          }
+        }
+        testID="com.ariesbifold:id/Scan.ScanQRCode"
+      >
+        <Text
+          allowFontScaling={false}
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "color": "#42803E",
+                "fontSize": 30,
+              },
+              undefined,
+              Object {
+                "fontFamily": "Material Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+      <View
+        accessibilityLabel="Scan.MyQRCode"
+        accessibilityState={
+          Object {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          Object {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "justifyContent": "center",
+            "opacity": 1,
+          }
+        }
+        testID="com.ariesbifold:id/Scan.MyQRCode"
+      >
+        <Text
+          allowFontScaling={false}
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 30,
+              },
+              undefined,
+              Object {
+                "fontFamily": "Material Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </RNCSafeAreaView>,
+  <RNCSafeAreaView
+    edges={
+      Array [
+        "bottom",
+      ]
+    }
+    style={
+      Object {
+        "backgroundColor": "#000000",
+        "flex": 0,
+      }
+    }
+  />,
+]
+`;
+
+exports[`NewQRView Component Renders correctly on second tab 1`] = `
+Array [
+  <RNCSafeAreaView
+    edges={
+      Array [
+        "left",
+        "right",
+      ]
+    }
     style={
       Object {
         "backgroundColor": "#313132",
-        "borderTopWidth": 0,
-        "flexDirection": "row",
-        "height": 60,
-        "paddingBottom": 0,
-        "shadowColor": "#000000",
-        "shadowOffset": Object {
-          "height": -3,
-          "width": 0,
-        },
-        "shadowOpacity": 0.1,
-        "shadowRadius": 6,
+        "flex": 1,
       }
     }
   >
+    <RCTScrollView>
+      <View>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "flex": 1,
+                "marginTop": 10,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "justifyContent": "center",
+                }
+              }
+              testID="com.ariesbifold:id/LoadingActivityIndicator"
+            >
+              <Image
+                source={
+                  Object {
+                    "default": "",
+                  }
+                }
+                style={
+                  Object {
+                    "height": "33%",
+                    "width": "33%",
+                  }
+                }
+                testID="com.ariesbifold:id/LoadingActivityIndicatorImage"
+              />
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "position": "absolute",
+                    "transform": Array [
+                      Object {
+                        "rotate": "360deg",
+                      },
+                    ],
+                  }
+                }
+              >
+                <
+                  fill="#FFFFFF"
+                  height={200}
+                  width={200}
+                />
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "flex": 1,
+                "paddingHorizontal": 20,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                }
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    Object {
+                      "color": "#FFFFFF",
+                      "fontSize": 32,
+                      "fontWeight": "bold",
+                      "textAlign": "center",
+                    },
+                    Object {
+                      "paddingHorizontal": 20,
+                    },
+                  ]
+                }
+                testID="com.ariesbifold:id/WalletName"
+              >
+                My Wallet - 1234
+              </Text>
+              <View
+                accessibilityLabel="NameWallet.EditWalletName"
+                accessibilityRole="button"
+                accessibilityState={
+                  Object {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  Object {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                hitSlop={
+                  Object {
+                    "bottom": 44,
+                    "left": 44,
+                    "right": 44,
+                    "top": 44,
+                  }
+                }
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                testID="com.ariesbifold:id/EditWalletName"
+              >
+                <View
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "marginLeft": 0,
+                      "marginRight": 15,
+                      "minHeight": 26,
+                      "minWidth": 26,
+                    }
+                  }
+                >
+                  <Text
+                    allowFontScaling={false}
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "#FFFFFF",
+                          "fontSize": 26,
+                        },
+                        undefined,
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰏫
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                  "marginTop": 20,
+                  "textAlign": "center",
+                }
+              }
+            >
+              Connection.ShareQR
+            </Text>
+          </View>
+        </View>
+      </View>
+    </RCTScrollView>
     <View
-      accessibilityLabel="Scan.ScanQRCode"
-      accessibilityState={
-        Object {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": undefined,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        Object {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
         Object {
-          "alignItems": "center",
-          "flex": 1,
-          "justifyContent": "center",
-          "opacity": 1,
+          "backgroundColor": "#313132",
+          "borderTopWidth": 0,
+          "flexDirection": "row",
+          "height": 60,
+          "paddingBottom": 0,
+          "shadowColor": "#000000",
+          "shadowOffset": Object {
+            "height": -3,
+            "width": 0,
+          },
+          "shadowOpacity": 0.1,
+          "shadowRadius": 6,
         }
       }
-      testID="com.ariesbifold:id/Scan.ScanQRCode"
     >
-      <Text
-        allowFontScaling={false}
-        selectable={false}
+      <View
+        accessibilityLabel="Scan.ScanQRCode"
+        accessibilityState={
+          Object {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          Object {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
-          Array [
-            Object {
-              "color": "#FFFFFF",
-              "fontSize": 30,
-            },
-            undefined,
-            Object {
-              "fontFamily": "Material Icons",
-              "fontStyle": "normal",
-              "fontWeight": "normal",
-            },
-            Object {},
-          ]
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "justifyContent": "center",
+            "opacity": 1,
+          }
         }
+        testID="com.ariesbifold:id/Scan.ScanQRCode"
       >
-        
-      </Text>
-    </View>
-    <View
-      accessibilityLabel="Scan.MyQRCode"
-      accessibilityState={
-        Object {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": undefined,
-          "expanded": undefined,
-          "selected": undefined,
+        <Text
+          allowFontScaling={false}
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 30,
+              },
+              undefined,
+              Object {
+                "fontFamily": "Material Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+      <View
+        accessibilityLabel="Scan.MyQRCode"
+        accessibilityState={
+          Object {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
         }
-      }
-      accessibilityValue={
-        Object {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
+        accessibilityValue={
+          Object {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
         }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        Object {
-          "alignItems": "center",
-          "flex": 1,
-          "justifyContent": "center",
-          "opacity": 1,
-        }
-      }
-      testID="com.ariesbifold:id/Scan.MyQRCode"
-    >
-      <Text
-        allowFontScaling={false}
-        selectable={false}
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
-          Array [
-            Object {
-              "color": "#42803E",
-              "fontSize": 30,
-            },
-            undefined,
-            Object {
-              "fontFamily": "Material Icons",
-              "fontStyle": "normal",
-              "fontWeight": "normal",
-            },
-            Object {},
-          ]
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "justifyContent": "center",
+            "opacity": 1,
+          }
         }
+        testID="com.ariesbifold:id/Scan.MyQRCode"
       >
-        
-      </Text>
+        <Text
+          allowFontScaling={false}
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "color": "#42803E",
+                "fontSize": 30,
+              },
+              undefined,
+              Object {
+                "fontFamily": "Material Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
     </View>
-  </View>
-</RNCSafeAreaView>
+  </RNCSafeAreaView>,
+  <RNCSafeAreaView
+    edges={
+      Array [
+        "bottom",
+      ]
+    }
+    style={
+      Object {
+        "backgroundColor": "#000000",
+        "flex": 0,
+      }
+    }
+  />,
+]
 `;


### PR DESCRIPTION
# Summary of Changes

This PR adds some features from the original scan screen to the new scan screen. The reason I didn't make them into a common component is that there are many small styling / positioning differences and in the future the original scan screen will just be removed entirely. 
Here's what it looked like before:
![scan_screen_old](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/32586431/68d14421-381a-4c91-8958-42b067b61c2d)


Here's what the functionality looks like now, pressing the various buttons etc:
![updated_scan_screen](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/32586431/26f026f7-8316-465d-83a3-80f20fa3f2a1)

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [ ] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
