### PR TITLE
feat: hide non-active connections from Contact List

### DIFF
--- a/packages/legacy/core/App/screens/ListContacts.tsx
+++ b/packages/legacy/core/App/screens/ListContacts.tsx
@@ -1,4 +1,4 @@
-import { ConnectionRecord, ConnectionType } from '@aries-framework/core'
+import { ConnectionRecord, ConnectionType, DidExchangeState } from '@aries-framework/core'
 import { useConnections } from '@aries-framework/react-hooks'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React, { useEffect } from 'react'
@@ -40,7 +40,8 @@ const ListContacts: React.FC<ListContactsProps> = ({ navigation }) => {
     connections = records.filter((r) => {
       return (
         !r.connectionTypes.includes(ConnectionType.Mediator) &&
-        !contactHideList?.includes((r.theirLabel || r.alias) ?? '')
+        !contactHideList?.includes((r.theirLabel || r.alias) ?? '') &&
+        r.state === DidExchangeState.Completed
       )
     })
   }


### PR DESCRIPTION
# Summary of Changes

If the connection is not active (status: completed), the contact isn't ready yet to receive messages, for example. So, the status of the connection must be checked when retrieving the connection list to avoid listing connections that are not ready yet.

# Related Issues

N/A.

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [X] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [X] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [X] Updated documentation as needed for changed code and new or modified features;
- [X] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
