### PR TITLE
feat: common component for all verifier templates and presentations

### DIFF
--- a/packages/legacy/core/App/components/misc/SharedProofData.tsx
+++ b/packages/legacy/core/App/components/misc/SharedProofData.tsx
@@ -1,24 +1,17 @@
 import { useAgent } from '@aries-framework/react-hooks'
 import {
-  GroupedSharedProofData,
   GroupedSharedProofDataItem,
   getProofData,
   groupSharedProofDataByCredential,
 } from '@hyperledger/aries-bifold-verifier'
-import { BrandingOverlay } from '@hyperledger/aries-oca'
-import { Attribute, CredentialOverlay, Field, Predicate } from '@hyperledger/aries-oca/build/legacy'
+import { Field } from '@hyperledger/aries-oca/build/legacy'
 import React, { useEffect, useState } from 'react'
-import { useTranslation } from 'react-i18next'
-import { useWindowDimensions, Image, StyleSheet, Text, View } from 'react-native'
+import { StyleSheet, View } from 'react-native'
 
+import VerifierCredentialCard from '../../components/misc/VerifierCredentialCard'
 import { useAnimatedComponents } from '../../contexts/animated-components'
-import { useConfiguration } from '../../contexts/configuration'
 import { useTheme } from '../../contexts/theme'
-import { toImageSource } from '../../utils/credential'
-import { formatIfDate, pTypeToText } from '../../utils/helpers'
 import { buildFieldsFromSharedAnonCredsProof } from '../../utils/oca'
-import { testIdWithKey } from '../../utils/testable'
-import { AttributeValue } from '../record/RecordField'
 
 interface SharedProofDataProps {
   recordId: string
@@ -26,165 +19,24 @@ interface SharedProofDataProps {
 }
 
 const SharedDataCard: React.FC<{ sharedData: GroupedSharedProofDataItem }> = ({ sharedData }) => {
-  const { ColorPallet, TextTheme } = useTheme()
-  const { OCABundleResolver } = useConfiguration()
-  const { i18n } = useTranslation()
-  const { width } = useWindowDimensions()
-  const logoHeight = width * 0.12
-  const padding = width * 0.05
-  const borderRadius = 10
-  const styles = StyleSheet.create({
-    container: {
-      marginBottom: 20,
-      backgroundColor: ColorPallet.grayscale.white,
-      borderRadius: borderRadius,
-    },
-    cardContainer: {
-      flexDirection: 'row',
-      minHeight: 0.33 * width,
-    },
-    cardColorContainer: {
-      width: logoHeight,
-      borderTopLeftRadius: borderRadius,
-      borderBottomLeftRadius: borderRadius,
-    },
-    logoContainer: {
-      top: padding,
-      left: -1 * logoHeight + padding,
-      width: logoHeight,
-      height: logoHeight,
-      backgroundColor: ColorPallet.grayscale.white,
-      borderRadius: 8,
-      justifyContent: 'center',
-      alignItems: 'center',
-      elevation: 5,
-    },
-    cardAttributes: {
-      width: '65%',
-      paddingTop: 20,
-      paddingBottom: 10,
-    },
-    attributeContainer: {
-      marginBottom: 10,
-    },
-    attributeName: {
-      fontSize: 16,
-      fontWeight: TextTheme.normal.fontWeight,
-      color: ColorPallet.grayscale.black,
-    },
-    attributeValue: {
-      fontSize: 18,
-      fontWeight: TextTheme.bold.fontWeight,
-      color: ColorPallet.grayscale.black,
-    },
-  })
-
-  const [overlay, setOverlay] = useState<CredentialOverlay<BrandingOverlay> | undefined>(undefined)
-
-  const attributeTypes = overlay?.bundle?.captureBase.attributes
-  const attributeFormats: Record<string, string | undefined> = (overlay?.bundle as any)?.bundle.attributes
-    .map((attr: any) => {
-      return { name: attr.name, format: attr.format }
-    })
-    .reduce((prev: { [key: string]: string }, curr: { name: string; format?: string }) => {
-      return { ...prev, [curr.name]: curr.format }
-    }, {})
-
+  const { ColorPallet } = useTheme()
+  const [attributes, setAttributes] = useState<Field[]>([])
   useEffect(() => {
     const attributes = buildFieldsFromSharedAnonCredsProof(sharedData.data)
-    const params = {
-      identifiers: {
-        credentialDefinitionId: sharedData.identifiers.cred_def_id,
-        schemaId: sharedData.identifiers.schema_id,
-      },
-      language: i18n.language,
-      attributes,
-    }
-    OCABundleResolver.resolveAllBundles(params).then((bundle) => {
-      setOverlay(bundle as CredentialOverlay<BrandingOverlay>)
-    })
+    setAttributes(attributes)
   }, [sharedData])
 
-  const CardField: React.FC<{ item: Field }> = ({ item }) => {
-    const { t } = useTranslation()
-    let parsedPredicate: Predicate | undefined = undefined
-    if (item instanceof Predicate) {
-      parsedPredicate = pTypeToText(item, t, attributeTypes) as Predicate
-      parsedPredicate.pValue = formatIfDate(attributeFormats[item.name ?? ''], parsedPredicate.pValue)
-    } else {
-      ;(item as Attribute).value = formatIfDate(attributeFormats[item.name ?? ''], (item as Attribute).value)
-    }
-
-    return (
-      <View key={item.name} style={[styles.attributeContainer]}>
-        <Text style={styles.attributeName}>{item.label || item.name}</Text>
-        {item instanceof Attribute && <AttributeValue style={styles.attributeValue} field={item} shown={true} />}
-        {item instanceof Predicate && (
-          <Text style={styles.attributeValue}>{`${parsedPredicate?.pType} ${parsedPredicate?.pValue}`}</Text>
-        )}
-      </View>
-    )
-  }
-
-  const CardBody: React.FC<{ overlay: CredentialOverlay<BrandingOverlay> }> = ({ overlay }) => {
-    return (
-      <View style={styles.cardAttributes}>
-        {overlay.presentationFields?.map((item) => (
-          <CardField item={item} key={item.name || item.toString()} />
-        ))}
-      </View>
-    )
-  }
-
-  const CardColor: React.FC<{ overlay: CredentialOverlay<BrandingOverlay> }> = ({ overlay }) => {
-    return (
-      <View
-        testID={testIdWithKey('CardColor')}
-        style={[{ backgroundColor: overlay.brandingOverlay?.primaryBackgroundColor }, styles.cardColorContainer]}
+  return (
+    <View style={{ marginBottom: 15 }}>
+      <VerifierCredentialCard
+        displayItems={attributes}
+        style={{ backgroundColor: ColorPallet.brand.secondaryBackground }}
+        credDefId={sharedData.identifiers.cred_def_id}
+        schemaId={sharedData.identifiers.schema_id}
+        elevated
       />
-    )
-  }
-
-  const CardLogo: React.FC<{ overlay: CredentialOverlay<BrandingOverlay> }> = ({ overlay }) => {
-    return (
-      <View style={styles.logoContainer}>
-        {overlay.brandingOverlay?.logo ? (
-          <Image
-            source={toImageSource(overlay.brandingOverlay?.logo)}
-            style={{
-              resizeMode: 'cover',
-              width: logoHeight,
-              height: logoHeight,
-              borderRadius: 8,
-            }}
-          />
-        ) : (
-          <Text
-            style={[
-              TextTheme.bold,
-              {
-                fontSize: 0.5 * logoHeight,
-                alignSelf: 'center',
-                color: ColorPallet.grayscale.black,
-              },
-            ]}
-          >
-            {(overlay.metaOverlay?.issuer ?? overlay.metaOverlay?.name ?? 'C')?.charAt(0).toUpperCase()}
-          </Text>
-        )}
-      </View>
-    )
-  }
-
-  return overlay ? (
-    <View style={styles.container}>
-      <View key={sharedData.identifiers.cred_def_id} style={styles.cardContainer}>
-        <CardColor overlay={overlay} />
-        <CardLogo overlay={overlay} />
-        <CardBody overlay={overlay} />
-      </View>
     </View>
-  ) : null
+  )
 }
 
 const SharedProofData: React.FC<SharedProofDataProps> = ({ recordId, onSharedProofDataLoad }: SharedProofDataProps) => {
@@ -205,16 +57,17 @@ const SharedProofData: React.FC<SharedProofDataProps> = ({ recordId, onSharedPro
   }
 
   const [loading, setLoading] = useState<boolean>(true)
-  const [sharedData, setSharedData] = useState<GroupedSharedProofData | undefined>(undefined)
+  const [sharedData, setSharedData] = useState<GroupedSharedProofDataItem[] | undefined>(undefined)
 
   useEffect(() => {
     getProofData(agent, recordId)
       .then((data) => {
         if (data) {
           const groupedSharedProofData = groupSharedProofDataByCredential(data)
-          setSharedData(groupedSharedProofData)
+          const sharedData = Array.from(groupedSharedProofData.values())
+          setSharedData(sharedData)
           if (!onSharedProofDataLoad) return
-          onSharedProofDataLoad(Array.from(groupedSharedProofData.values()))
+          onSharedProofDataLoad(sharedData)
         }
       })
       .finally(() => {
@@ -224,16 +77,17 @@ const SharedProofData: React.FC<SharedProofDataProps> = ({ recordId, onSharedPro
 
   return (
     <View style={styles.container}>
-      {loading && (
+      {loading || !sharedData ? (
         <View style={styles.loaderContainer}>
           <LoadingIndicator />
         </View>
+      ) : (
+        <View>
+          {sharedData.map((item) => (
+            <SharedDataCard key={item.identifiers.cred_def_id} sharedData={item} />
+          ))}
+        </View>
       )}
-      {!loading &&
-        sharedData?.size &&
-        Array.from(sharedData.values()).map((item) => (
-          <SharedDataCard sharedData={item} key={item.identifiers.cred_def_id} />
-        ))}
     </View>
   )
 }

--- a/packages/legacy/core/App/screens/ProofRequestDetails.tsx
+++ b/packages/legacy/core/App/screens/ProofRequestDetails.tsx
@@ -11,11 +11,11 @@ import { OverlayType } from '@hyperledger/aries-oca/build/types/TypeEnums'
 import { StackScreenProps } from '@react-navigation/stack'
 import React, { memo, useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { FlatList, StyleSheet, Text, View } from 'react-native'
+import { ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import Button, { ButtonType } from '../components/buttons/Button'
-import CredentialCardPreview from '../components/misc/CredentialCardPreview'
+import VerifierCredentialCard from '../components/misc/VerifierCredentialCard'
 import AlertModal from '../components/modals/AlertModal'
 import { useConfiguration } from '../contexts/configuration'
 import { useStore } from '../contexts/store'
@@ -59,13 +59,14 @@ const ProofRequestAttributesCard: React.FC<ProofRequestAttributesCardProps> = ({
   }, [data.requestedAttributes, data.requestedPredicates])
 
   return (
-    <View style={{ marginTop: 15 }}>
-      <CredentialCardPreview
+    <View style={{ marginBottom: 15 }}>
+      <VerifierCredentialCard
         onChangeValue={onChangeValue}
         displayItems={attributes}
         style={{ backgroundColor: ColorPallet.brand.secondaryBackground }}
         credDefId={credDefId}
         schemaId={data.schema}
+        preview
         elevated
       />
     </View>
@@ -79,14 +80,9 @@ interface ProofRequestCardsProps {
 
 // memo'd to prevent rerendering when onChangeValue is called from child and updates parent
 const ProofRequestCards: React.FC<ProofRequestCardsProps> = memo(({ attributes = [], onChangeValue }) => {
-  return (
-    <FlatList
-      data={attributes}
-      keyExtractor={(item) => item.schema}
-      renderItem={({ item }) => <ProofRequestAttributesCard data={item} onChangeValue={onChangeValue} />}
-      contentContainerStyle={{ flexGrow: 1 }}
-    />
-  )
+  return attributes.map((item) => (
+    <ProofRequestAttributesCard key={item.schema} data={item} onChangeValue={onChangeValue} />
+  ))
 })
 
 const ProofRequestDetails: React.FC<ProofRequestDetailsProps> = ({ route, navigation }) => {
@@ -258,9 +254,11 @@ const ProofRequestDetails: React.FC<ProofRequestDetailsProps> = ({ route, naviga
           submit={() => setInvalidPredicate({ visible: false, predicate: invalidPredicate.predicate })}
         />
       )}
-      <Header />
-      <ProofRequestCards attributes={attributes} onChangeValue={onChangeValue} />
-      <Footer />
+      <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
+        <Header />
+        <ProofRequestCards attributes={attributes} onChangeValue={onChangeValue} />
+        <Footer />
+      </ScrollView>
     </SafeAreaView>
   )
 }

--- a/packages/legacy/core/__tests__/components/VerifierCredentialCard.test.tsx
+++ b/packages/legacy/core/__tests__/components/VerifierCredentialCard.test.tsx
@@ -1,7 +1,7 @@
 import { act, render } from '@testing-library/react-native'
 import React from 'react'
 
-import CredentialCardPreview from '../../App/components/misc/CredentialCardPreview'
+import VerifierCredentialCard from '../../App/components/misc/VerifierCredentialCard'
 import { ConfigurationContext } from '../../App/contexts/configuration'
 import configurationContext from '../contexts/configuration'
 
@@ -28,11 +28,11 @@ const displayItems = [
   },
 ]
 
-describe('CredentialCardPreview Component', () => {
+describe('VerifierCredentialCard Component', () => {
   test('Renders correctly', async () => {
     const tree = render(
       <ConfigurationContext.Provider value={configurationContext}>
-        <CredentialCardPreview
+        <VerifierCredentialCard
           schemaId={'4eCXHS79ykiMv2PoBxPK23:2:unverified_person:0.1.0'}
           onChangeValue={jest.fn()}
           displayItems={displayItems}

--- a/packages/legacy/core/__tests__/components/__snapshots__/VerifierCredentialCard.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/VerifierCredentialCard.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CredentialCardPreview Component Renders correctly 1`] = `
+exports[`VerifierCredentialCard Component Renders correctly 1`] = `
 <View
   onLayout={[Function]}
   style={
@@ -21,7 +21,7 @@ exports[`CredentialCardPreview Component Renders correctly 1`] = `
     testID="com.ariesbifold:id/CredentialCard"
   >
     <View
-      accessibilityLabel="Credentials.IssuedBy Unknown Contact,  Unverified Person Credentials.Credential. given_names, family_name"
+      accessibilityLabel="Credentials.IssuedBy Unknown Contact,  Unverified Person Credentials.Credential. given_names, undefined null, family_name, undefined null"
       accessible={true}
       style={
         Object {

--- a/packages/legacy/core/__tests__/screens/ProofDetails.test.tsx
+++ b/packages/legacy/core/__tests__/screens/ProofDetails.test.tsx
@@ -1,20 +1,23 @@
-import { INDY_PROOF_REQUEST_ATTACHMENT_ID, V1RequestPresentationMessage } from '@aries-framework/anoncreds'
+import {
+  INDY_PROOF_REQUEST_ATTACHMENT_ID,
+  V1RequestPresentationMessage,
+  AnonCredsProof,
+} from '@aries-framework/anoncreds'
 import { ProofExchangeRecord, ProofState } from '@aries-framework/core'
 import { Attachment, AttachmentData } from '@aries-framework/core/build/decorators/attachment/Attachment'
 import { useProofById } from '@aries-framework/react-hooks'
+import * as verifier from '@hyperledger/aries-bifold-verifier'
 import mockRNCNetInfo from '@react-native-community/netinfo/jest/netinfo-mock'
 import { useNavigation } from '@react-navigation/core'
 import '@testing-library/jest-native/extend-expect'
-import { act, cleanup, fireEvent, render, RenderAPI } from '@testing-library/react-native'
+import { cleanup, fireEvent, render, RenderAPI } from '@testing-library/react-native'
 import React from 'react'
 
-import { testIdWithKey } from '../../App/utils/testable'
-import ProofDetails from '../../App/screens/ProofDetails'
-import * as verifier from '@hyperledger/aries-bifold-verifier'
-import { AnonCredsProof } from '@aries-framework/anoncreds'
-import configurationContext from '../contexts/configuration'
-import { NetworkProvider } from '../../App/contexts/network'
 import { ConfigurationContext } from '../../App/contexts/configuration'
+import { NetworkProvider } from '../../App/contexts/network'
+import ProofDetails from '../../App/screens/ProofDetails'
+import { testIdWithKey } from '../../App/utils/testable'
+import configurationContext from '../contexts/configuration'
 
 jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter')
 jest.mock('@react-native-community/netinfo', () => mockRNCNetInfo)
@@ -24,12 +27,12 @@ jest.mock('@react-navigation/core', () => {
 jest.mock('@react-navigation/native', () => {
   return require('../../__mocks__/custom/@react-navigation/native')
 })
-jest.mock('@hyperledger/aries-bifold-verifier',() => {
-  const original = jest. requireActual('@hyperledger/aries-bifold-verifier')
+jest.mock('@hyperledger/aries-bifold-verifier', () => {
+  const original = jest.requireActual('@hyperledger/aries-bifold-verifier')
   return {
     ...original,
-     __esModule: true,
-     getProofData: jest.fn(original.getProofData)
+    __esModule: true,
+    getProofData: jest.fn(original.getProofData),
   }
 })
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -133,9 +136,9 @@ describe('ProofDetails Component', () => {
     })
 
     const checkAttributes = async (tree: RenderAPI) => {
-      const firstNameAttribute = await tree.findByText('first_name', { exact: true })
+      const firstNameAttribute = await tree.findByText('First Name', { exact: true })
       const firstNameAttributeValue = await tree.findByText('Aries', { exact: true })
-      const secondNameAttribute = await tree.findByText('second_name', { exact: true })
+      const secondNameAttribute = await tree.findByText('Second Name', { exact: true })
       const secondNameAttributeValue = await tree.findByText('Bifold', { exact: true })
 
       expect(firstNameAttribute).not.toBe(null)

--- a/packages/legacy/core/__tests__/screens/__snapshots__/ProofDetails.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/ProofDetails.test.tsx.snap
@@ -329,146 +329,316 @@ exports[`ProofDetails Component with a verified proof record renders correctly w
               }
             }
           >
-            <View
-              style={
-                Object {
-                  "backgroundColor": "#FFFFFF",
-                  "borderRadius": 10,
-                  "marginBottom": 20,
-                }
-              }
-            >
+            <View>
               <View
                 style={
                   Object {
-                    "flexDirection": "row",
-                    "minHeight": 247.5,
+                    "marginBottom": 15,
                   }
                 }
               >
                 <View
+                  onLayout={[Function]}
                   style={
                     Array [
                       Object {
                         "backgroundColor": "#5f0f7b",
+                        "borderRadius": 10,
                       },
                       Object {
-                        "borderBottomLeftRadius": 10,
-                        "borderTopLeftRadius": 10,
-                        "width": 90,
+                        "backgroundColor": "#313132",
+                      },
+                      Object {
+                        "elevation": 5,
+                        "overflow": "hidden",
                       },
                     ]
                   }
-                  testID="com.ariesbifold:id/CardColor"
-                />
-                <View
-                  style={
-                    Object {
-                      "alignItems": "center",
-                      "backgroundColor": "#FFFFFF",
-                      "borderRadius": 8,
-                      "elevation": 5,
-                      "height": 90,
-                      "justifyContent": "center",
-                      "left": -52.5,
-                      "top": 37.5,
-                      "width": 90,
-                    }
-                  }
-                >
-                  <Text
-                    style={
-                      Array [
-                        Object {
-                          "color": "#FFFFFF",
-                          "fontSize": 18,
-                          "fontWeight": "bold",
-                        },
-                        Object {
-                          "alignSelf": "center",
-                          "color": "#000000",
-                          "fontSize": 45,
-                        },
-                      ]
-                    }
-                  >
-                    U
-                  </Text>
-                </View>
-                <View
-                  style={
-                    Object {
-                      "paddingBottom": 10,
-                      "paddingTop": 20,
-                      "width": "65%",
-                    }
-                  }
                 >
                   <View
-                    style={
-                      Array [
-                        Object {
-                          "marginBottom": 10,
-                        },
-                      ]
-                    }
+                    testID="com.ariesbifold:id/CredentialCard"
                   >
-                    <Text
+                    <View
+                      accessibilityLabel="Credentials.IssuedBy Unknown Contact,  Latest Credentials.Credential. first_name, Aries, second_name, Bifold"
+                      accessible={true}
                       style={
                         Object {
-                          "color": "#000000",
-                          "fontSize": 16,
-                          "fontWeight": "normal",
+                          "flexDirection": "row",
+                          "minHeight": 247.5,
                         }
                       }
                     >
-                      first_name
-                    </Text>
-                    <Text
-                      style={
-                        Object {
-                          "color": "#000000",
-                          "fontSize": 18,
-                          "fontWeight": "bold",
+                      <View
+                        style={
+                          Object {
+                            "backgroundColor": "#5f0f7b",
+                            "borderBottomLeftRadius": 10,
+                            "borderTopLeftRadius": 10,
+                            "width": 90,
+                          }
                         }
-                      }
-                      testID="com.ariesbifold:id/AttributeValue"
-                    >
-                      Aries
-                    </Text>
-                  </View>
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "marginBottom": 10,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      style={
-                        Object {
-                          "color": "#000000",
-                          "fontSize": 16,
-                          "fontWeight": "normal",
+                        testID="com.ariesbifold:id/CredentialCardSecondaryBody"
+                      />
+                      <View
+                        style={
+                          Array [
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "#ffffff",
+                              "borderRadius": 8,
+                              "height": 90,
+                              "justifyContent": "center",
+                              "left": -52.5,
+                              "shadowColor": "#000",
+                              "shadowOffset": Object {
+                                "height": 1,
+                                "width": 1,
+                              },
+                              "shadowOpacity": 0.3,
+                              "top": 37.5,
+                              "width": 90,
+                            },
+                            Object {
+                              "elevation": 5,
+                            },
+                          ]
                         }
-                      }
-                    >
-                      second_name
-                    </Text>
-                    <Text
-                      style={
-                        Object {
-                          "color": "#000000",
-                          "fontSize": 18,
-                          "fontWeight": "bold",
+                      >
+                        <Text
+                          style={
+                            Array [
+                              Object {
+                                "color": "#FFFFFF",
+                                "fontSize": 18,
+                                "fontWeight": "bold",
+                              },
+                              Object {
+                                "alignSelf": "center",
+                                "color": "#000",
+                                "fontSize": 45,
+                              },
+                            ]
+                          }
+                        >
+                          L
+                        </Text>
+                      </View>
+                      <View
+                        style={
+                          Object {
+                            "flex": 1,
+                            "marginLeft": -52.5,
+                            "padding": 37.5,
+                          }
                         }
-                      }
-                      testID="com.ariesbifold:id/AttributeValue"
-                    >
-                      Bifold
-                    </Text>
+                        testID="com.ariesbifold:id/CredentialCardPrimaryBody"
+                      >
+                        <View>
+                          <View
+                            style={
+                              Object {
+                                "flexDirection": "row",
+                              }
+                            }
+                          >
+                            <Text
+                              style={
+                                Array [
+                                  Object {
+                                    "color": "#FFFFFF",
+                                    "fontSize": 18,
+                                    "fontWeight": "bold",
+                                  },
+                                  Object {
+                                    "color": "#FFFFFF",
+                                    "flexShrink": 1,
+                                  },
+                                  Object {
+                                    "color": "#FFFFFF",
+                                    "flex": 1,
+                                    "flexWrap": "wrap",
+                                    "lineHeight": 24,
+                                  },
+                                ]
+                              }
+                              testID="com.ariesbifold:id/CredentialName"
+                            >
+                              Latest
+                            </Text>
+                          </View>
+                        </View>
+                        <RCTScrollView
+                          data={
+                            Array [
+                              Attribute {
+                                "credentialId": undefined,
+                                "encoding": undefined,
+                                "format": undefined,
+                                "label": undefined,
+                                "mimeType": undefined,
+                                "name": "first_name",
+                                "nonRevoked": undefined,
+                                "restrictions": undefined,
+                                "revealed": undefined,
+                                "revoked": undefined,
+                                "type": undefined,
+                                "value": "Aries",
+                              },
+                              Attribute {
+                                "credentialId": undefined,
+                                "encoding": undefined,
+                                "format": undefined,
+                                "label": undefined,
+                                "mimeType": undefined,
+                                "name": "second_name",
+                                "nonRevoked": undefined,
+                                "restrictions": undefined,
+                                "revealed": undefined,
+                                "revoked": undefined,
+                                "type": undefined,
+                                "value": "Bifold",
+                              },
+                            ]
+                          }
+                          getItem={[Function]}
+                          getItemCount={[Function]}
+                          initialNumToRender={2}
+                          keyExtractor={[Function]}
+                          onContentSizeChange={[Function]}
+                          onLayout={[Function]}
+                          onMomentumScrollBegin={[Function]}
+                          onMomentumScrollEnd={[Function]}
+                          onScroll={[Function]}
+                          onScrollBeginDrag={[Function]}
+                          onScrollEndDrag={[Function]}
+                          removeClippedSubviews={false}
+                          renderItem={[Function]}
+                          scrollEnabled={false}
+                          scrollEventThrottle={50}
+                          stickyHeaderIndices={Array []}
+                          viewabilityConfigCallbackPairs={Array []}
+                        >
+                          <View>
+                            <View
+                              onFocusCapture={[Function]}
+                              onLayout={[Function]}
+                              style={null}
+                            >
+                              <View
+                                style={
+                                  Object {
+                                    "marginTop": 15,
+                                  }
+                                }
+                              >
+                                <View>
+                                  <Text
+                                    style={
+                                      Array [
+                                        Object {
+                                          "color": "#FFFFFF",
+                                          "fontSize": 14,
+                                          "fontWeight": "normal",
+                                        },
+                                        Object {
+                                          "color": "#FFFFFF",
+                                          "flexShrink": 1,
+                                        },
+                                        Object {
+                                          "lineHeight": 19,
+                                          "opacity": 0.8,
+                                        },
+                                      ]
+                                    }
+                                    testID="com.ariesbifold:id/AttributeName"
+                                  >
+                                    First Name
+                                  </Text>
+                                  <View>
+                                    <Text
+                                      style={
+                                        Array [
+                                          Object {
+                                            "color": "#FFFFFF",
+                                            "fontSize": 18,
+                                            "fontWeight": "bold",
+                                          },
+                                          Object {
+                                            "color": "#FFFFFF",
+                                            "flexShrink": 1,
+                                          },
+                                        ]
+                                      }
+                                      testID="com.ariesbifold:id/AttributeValue"
+                                    >
+                                      Aries
+                                    </Text>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                            <View
+                              onFocusCapture={[Function]}
+                              onLayout={[Function]}
+                              style={null}
+                            >
+                              <View
+                                style={
+                                  Object {
+                                    "marginTop": 15,
+                                  }
+                                }
+                              >
+                                <View>
+                                  <Text
+                                    style={
+                                      Array [
+                                        Object {
+                                          "color": "#FFFFFF",
+                                          "fontSize": 14,
+                                          "fontWeight": "normal",
+                                        },
+                                        Object {
+                                          "color": "#FFFFFF",
+                                          "flexShrink": 1,
+                                        },
+                                        Object {
+                                          "lineHeight": 19,
+                                          "opacity": 0.8,
+                                        },
+                                      ]
+                                    }
+                                    testID="com.ariesbifold:id/AttributeName"
+                                  >
+                                    Second Name
+                                  </Text>
+                                  <View>
+                                    <Text
+                                      style={
+                                        Array [
+                                          Object {
+                                            "color": "#FFFFFF",
+                                            "fontSize": 18,
+                                            "fontWeight": "bold",
+                                          },
+                                          Object {
+                                            "color": "#FFFFFF",
+                                            "flexShrink": 1,
+                                          },
+                                        ]
+                                      }
+                                      testID="com.ariesbifold:id/AttributeValue"
+                                    >
+                                      Bifold
+                                    </Text>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                        </RCTScrollView>
+                      </View>
+                    </View>
                   </View>
                 </View>
               </View>
@@ -709,146 +879,316 @@ exports[`ProofDetails Component with a verified proof record renders correctly w
               }
             }
           >
-            <View
-              style={
-                Object {
-                  "backgroundColor": "#FFFFFF",
-                  "borderRadius": 10,
-                  "marginBottom": 20,
-                }
-              }
-            >
+            <View>
               <View
                 style={
                   Object {
-                    "flexDirection": "row",
-                    "minHeight": 247.5,
+                    "marginBottom": 15,
                   }
                 }
               >
                 <View
+                  onLayout={[Function]}
                   style={
                     Array [
                       Object {
                         "backgroundColor": "#5f0f7b",
+                        "borderRadius": 10,
                       },
                       Object {
-                        "borderBottomLeftRadius": 10,
-                        "borderTopLeftRadius": 10,
-                        "width": 90,
+                        "backgroundColor": "#313132",
+                      },
+                      Object {
+                        "elevation": 5,
+                        "overflow": "hidden",
                       },
                     ]
                   }
-                  testID="com.ariesbifold:id/CardColor"
-                />
-                <View
-                  style={
-                    Object {
-                      "alignItems": "center",
-                      "backgroundColor": "#FFFFFF",
-                      "borderRadius": 8,
-                      "elevation": 5,
-                      "height": 90,
-                      "justifyContent": "center",
-                      "left": -52.5,
-                      "top": 37.5,
-                      "width": 90,
-                    }
-                  }
-                >
-                  <Text
-                    style={
-                      Array [
-                        Object {
-                          "color": "#FFFFFF",
-                          "fontSize": 18,
-                          "fontWeight": "bold",
-                        },
-                        Object {
-                          "alignSelf": "center",
-                          "color": "#000000",
-                          "fontSize": 45,
-                        },
-                      ]
-                    }
-                  >
-                    U
-                  </Text>
-                </View>
-                <View
-                  style={
-                    Object {
-                      "paddingBottom": 10,
-                      "paddingTop": 20,
-                      "width": "65%",
-                    }
-                  }
                 >
                   <View
-                    style={
-                      Array [
-                        Object {
-                          "marginBottom": 10,
-                        },
-                      ]
-                    }
+                    testID="com.ariesbifold:id/CredentialCard"
                   >
-                    <Text
+                    <View
+                      accessibilityLabel="Credentials.IssuedBy Unknown Contact,  Latest Credentials.Credential. first_name, Aries, second_name, Bifold"
+                      accessible={true}
                       style={
                         Object {
-                          "color": "#000000",
-                          "fontSize": 16,
-                          "fontWeight": "normal",
+                          "flexDirection": "row",
+                          "minHeight": 247.5,
                         }
                       }
                     >
-                      first_name
-                    </Text>
-                    <Text
-                      style={
-                        Object {
-                          "color": "#000000",
-                          "fontSize": 18,
-                          "fontWeight": "bold",
+                      <View
+                        style={
+                          Object {
+                            "backgroundColor": "#5f0f7b",
+                            "borderBottomLeftRadius": 10,
+                            "borderTopLeftRadius": 10,
+                            "width": 90,
+                          }
                         }
-                      }
-                      testID="com.ariesbifold:id/AttributeValue"
-                    >
-                      Aries
-                    </Text>
-                  </View>
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "marginBottom": 10,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      style={
-                        Object {
-                          "color": "#000000",
-                          "fontSize": 16,
-                          "fontWeight": "normal",
+                        testID="com.ariesbifold:id/CredentialCardSecondaryBody"
+                      />
+                      <View
+                        style={
+                          Array [
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "#ffffff",
+                              "borderRadius": 8,
+                              "height": 90,
+                              "justifyContent": "center",
+                              "left": -52.5,
+                              "shadowColor": "#000",
+                              "shadowOffset": Object {
+                                "height": 1,
+                                "width": 1,
+                              },
+                              "shadowOpacity": 0.3,
+                              "top": 37.5,
+                              "width": 90,
+                            },
+                            Object {
+                              "elevation": 5,
+                            },
+                          ]
                         }
-                      }
-                    >
-                      second_name
-                    </Text>
-                    <Text
-                      style={
-                        Object {
-                          "color": "#000000",
-                          "fontSize": 18,
-                          "fontWeight": "bold",
+                      >
+                        <Text
+                          style={
+                            Array [
+                              Object {
+                                "color": "#FFFFFF",
+                                "fontSize": 18,
+                                "fontWeight": "bold",
+                              },
+                              Object {
+                                "alignSelf": "center",
+                                "color": "#000",
+                                "fontSize": 45,
+                              },
+                            ]
+                          }
+                        >
+                          L
+                        </Text>
+                      </View>
+                      <View
+                        style={
+                          Object {
+                            "flex": 1,
+                            "marginLeft": -52.5,
+                            "padding": 37.5,
+                          }
                         }
-                      }
-                      testID="com.ariesbifold:id/AttributeValue"
-                    >
-                      Bifold
-                    </Text>
+                        testID="com.ariesbifold:id/CredentialCardPrimaryBody"
+                      >
+                        <View>
+                          <View
+                            style={
+                              Object {
+                                "flexDirection": "row",
+                              }
+                            }
+                          >
+                            <Text
+                              style={
+                                Array [
+                                  Object {
+                                    "color": "#FFFFFF",
+                                    "fontSize": 18,
+                                    "fontWeight": "bold",
+                                  },
+                                  Object {
+                                    "color": "#FFFFFF",
+                                    "flexShrink": 1,
+                                  },
+                                  Object {
+                                    "color": "#FFFFFF",
+                                    "flex": 1,
+                                    "flexWrap": "wrap",
+                                    "lineHeight": 24,
+                                  },
+                                ]
+                              }
+                              testID="com.ariesbifold:id/CredentialName"
+                            >
+                              Latest
+                            </Text>
+                          </View>
+                        </View>
+                        <RCTScrollView
+                          data={
+                            Array [
+                              Attribute {
+                                "credentialId": undefined,
+                                "encoding": undefined,
+                                "format": undefined,
+                                "label": undefined,
+                                "mimeType": undefined,
+                                "name": "first_name",
+                                "nonRevoked": undefined,
+                                "restrictions": undefined,
+                                "revealed": undefined,
+                                "revoked": undefined,
+                                "type": undefined,
+                                "value": "Aries",
+                              },
+                              Attribute {
+                                "credentialId": undefined,
+                                "encoding": undefined,
+                                "format": undefined,
+                                "label": undefined,
+                                "mimeType": undefined,
+                                "name": "second_name",
+                                "nonRevoked": undefined,
+                                "restrictions": undefined,
+                                "revealed": undefined,
+                                "revoked": undefined,
+                                "type": undefined,
+                                "value": "Bifold",
+                              },
+                            ]
+                          }
+                          getItem={[Function]}
+                          getItemCount={[Function]}
+                          initialNumToRender={2}
+                          keyExtractor={[Function]}
+                          onContentSizeChange={[Function]}
+                          onLayout={[Function]}
+                          onMomentumScrollBegin={[Function]}
+                          onMomentumScrollEnd={[Function]}
+                          onScroll={[Function]}
+                          onScrollBeginDrag={[Function]}
+                          onScrollEndDrag={[Function]}
+                          removeClippedSubviews={false}
+                          renderItem={[Function]}
+                          scrollEnabled={false}
+                          scrollEventThrottle={50}
+                          stickyHeaderIndices={Array []}
+                          viewabilityConfigCallbackPairs={Array []}
+                        >
+                          <View>
+                            <View
+                              onFocusCapture={[Function]}
+                              onLayout={[Function]}
+                              style={null}
+                            >
+                              <View
+                                style={
+                                  Object {
+                                    "marginTop": 15,
+                                  }
+                                }
+                              >
+                                <View>
+                                  <Text
+                                    style={
+                                      Array [
+                                        Object {
+                                          "color": "#FFFFFF",
+                                          "fontSize": 14,
+                                          "fontWeight": "normal",
+                                        },
+                                        Object {
+                                          "color": "#FFFFFF",
+                                          "flexShrink": 1,
+                                        },
+                                        Object {
+                                          "lineHeight": 19,
+                                          "opacity": 0.8,
+                                        },
+                                      ]
+                                    }
+                                    testID="com.ariesbifold:id/AttributeName"
+                                  >
+                                    First Name
+                                  </Text>
+                                  <View>
+                                    <Text
+                                      style={
+                                        Array [
+                                          Object {
+                                            "color": "#FFFFFF",
+                                            "fontSize": 18,
+                                            "fontWeight": "bold",
+                                          },
+                                          Object {
+                                            "color": "#FFFFFF",
+                                            "flexShrink": 1,
+                                          },
+                                        ]
+                                      }
+                                      testID="com.ariesbifold:id/AttributeValue"
+                                    >
+                                      Aries
+                                    </Text>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                            <View
+                              onFocusCapture={[Function]}
+                              onLayout={[Function]}
+                              style={null}
+                            >
+                              <View
+                                style={
+                                  Object {
+                                    "marginTop": 15,
+                                  }
+                                }
+                              >
+                                <View>
+                                  <Text
+                                    style={
+                                      Array [
+                                        Object {
+                                          "color": "#FFFFFF",
+                                          "fontSize": 14,
+                                          "fontWeight": "normal",
+                                        },
+                                        Object {
+                                          "color": "#FFFFFF",
+                                          "flexShrink": 1,
+                                        },
+                                        Object {
+                                          "lineHeight": 19,
+                                          "opacity": 0.8,
+                                        },
+                                      ]
+                                    }
+                                    testID="com.ariesbifold:id/AttributeName"
+                                  >
+                                    Second Name
+                                  </Text>
+                                  <View>
+                                    <Text
+                                      style={
+                                        Array [
+                                          Object {
+                                            "color": "#FFFFFF",
+                                            "fontSize": 18,
+                                            "fontWeight": "bold",
+                                          },
+                                          Object {
+                                            "color": "#FFFFFF",
+                                            "flexShrink": 1,
+                                          },
+                                        ]
+                                      }
+                                      testID="com.ariesbifold:id/AttributeValue"
+                                    >
+                                      Bifold
+                                    </Text>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                        </RCTScrollView>
+                      </View>
+                    </View>
                   </View>
                 </View>
               </View>

--- a/packages/legacy/core/__tests__/screens/__snapshots__/ProofRequestDetails.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/ProofRequestDetails.test.tsx.snap
@@ -16,306 +16,272 @@ exports[`ProofRequestDetails Component Renders correctly 1`] = `
     }
   }
 >
-  <View
-    style={
-      Object {
-        "marginBottom": 36,
-        "marginTop": 12,
-      }
-    }
-  >
-    <Text
-      style={
-        Object {
-          "color": "#FFFFFF",
-          "fontSize": 28,
-          "fontWeight": "bold",
-        }
-      }
-    >
-      Student full name
-    </Text>
-    <Text
-      style={
-        Object {
-          "color": "#FFFFFF",
-          "fontSize": 20,
-          "marginTop": 10,
-        }
-      }
-    >
-      Verify the full name of a student
-    </Text>
-  </View>
   <RCTScrollView
     contentContainerStyle={
       Object {
         "flexGrow": 1,
       }
     }
-    data={
-      Array [
-        Object {
-          "requestedAttributes": Array [
-            Object {
-              "devRestrictions": Array [
-                Object {
-                  "schema_name": "student_card",
-                },
-              ],
-              "names": Array [
-                "student_first_name",
-                "student_last_name",
-              ],
-              "non_revoked": Object {
-                "to": "@{now}",
-              },
-              "restrictions": Array [
-                Object {
-                  "cred_def_id": "XUxBrVSALWHLeycAUhrNr9:3:CL:26293:student_card",
-                },
-              ],
-            },
-          ],
-          "requestedPredicates": Array [
-            Object {
-              "devRestrictions": Array [
-                Object {
-                  "schema_name": "student_card",
-                },
-              ],
-              "name": "expiry_date",
-              "predicateType": ">=",
-              "predicateValue": "@{currentDate(0)}",
-              "restrictions": Array [
-                Object {
-                  "cred_def_id": "XUxBrVSALWHLeycAUhrNr9:3:CL:26293:student_card",
-                },
-              ],
-            },
-          ],
-          "schema": "XUxBrVSALWHLeycAUhrNr9:3:CL:26293:Student Card",
-        },
-      ]
-    }
-    getItem={[Function]}
-    getItemCount={[Function]}
-    keyExtractor={[Function]}
-    onContentSizeChange={[Function]}
-    onLayout={[Function]}
-    onMomentumScrollBegin={[Function]}
-    onMomentumScrollEnd={[Function]}
-    onScroll={[Function]}
-    onScrollBeginDrag={[Function]}
-    onScrollEndDrag={[Function]}
-    removeClippedSubviews={false}
-    renderItem={[Function]}
-    scrollEventThrottle={50}
-    stickyHeaderIndices={Array []}
-    viewabilityConfigCallbackPairs={Array []}
   >
     <View>
       <View
-        onFocusCapture={[Function]}
-        onLayout={[Function]}
-        style={null}
+        style={
+          Object {
+            "marginBottom": 36,
+            "marginTop": 12,
+          }
+        }
       >
-        <View
+        <Text
           style={
             Object {
-              "marginTop": 15,
+              "color": "#FFFFFF",
+              "fontSize": 28,
+              "fontWeight": "bold",
             }
           }
         >
-          <View
-            onLayout={[Function]}
-            style={
-              Array [
-                Object {
-                  "backgroundColor": undefined,
-                  "borderRadius": 10,
-                },
-                Object {
-                  "backgroundColor": "#313132",
-                },
-                Object {
-                  "elevation": 5,
-                  "overflow": "hidden",
-                },
-              ]
+          Student full name
+        </Text>
+        <Text
+          style={
+            Object {
+              "color": "#FFFFFF",
+              "fontSize": 20,
+              "marginTop": 10,
             }
+          }
+        >
+          Verify the full name of a student
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "marginBottom": 15,
+          }
+        }
+      >
+        <View
+          onLayout={[Function]}
+          style={
+            Array [
+              Object {
+                "backgroundColor": undefined,
+                "borderRadius": 10,
+              },
+              Object {
+                "backgroundColor": "#313132",
+              },
+              Object {
+                "elevation": 5,
+                "overflow": "hidden",
+              },
+            ]
+          }
+        >
+          <View
+            testID="com.ariesbifold:id/CredentialCard"
           >
             <View
-              testID="com.ariesbifold:id/CredentialCard"
+              accessibilityLabel=",  Student Credentials.Credential. First Name, undefined null, Last Name, undefined null"
+              accessible={true}
+              style={
+                Object {
+                  "flexDirection": "row",
+                  "minHeight": 247.5,
+                }
+              }
             >
               <View
-                accessibilityLabel=",  Student Credentials.Credential. First Name, Last Name"
-                accessible={true}
                 style={
                   Object {
-                    "flexDirection": "row",
-                    "minHeight": 247.5,
+                    "backgroundColor": undefined,
+                    "borderBottomLeftRadius": 10,
+                    "borderTopLeftRadius": 10,
+                    "width": 90,
                   }
                 }
-              >
-                <View
-                  style={
+                testID="com.ariesbifold:id/CredentialCardSecondaryBody"
+              />
+              <View
+                style={
+                  Array [
                     Object {
-                      "backgroundColor": undefined,
-                      "borderBottomLeftRadius": 10,
-                      "borderTopLeftRadius": 10,
+                      "alignItems": "center",
+                      "backgroundColor": "#ffffff",
+                      "borderRadius": 8,
+                      "height": 90,
+                      "justifyContent": "center",
+                      "left": -52.5,
+                      "shadowColor": "#000",
+                      "shadowOffset": Object {
+                        "height": 1,
+                        "width": 1,
+                      },
+                      "shadowOpacity": 0.3,
+                      "top": 37.5,
                       "width": 90,
-                    }
-                  }
-                  testID="com.ariesbifold:id/CredentialCardSecondaryBody"
-                />
-                <View
+                    },
+                    Object {
+                      "elevation": 5,
+                    },
+                  ]
+                }
+              >
+                <Text
                   style={
                     Array [
                       Object {
-                        "alignItems": "center",
-                        "backgroundColor": "#ffffff",
-                        "borderRadius": 8,
-                        "height": 90,
-                        "justifyContent": "center",
-                        "left": -52.5,
-                        "shadowColor": "#000",
-                        "shadowOffset": Object {
-                          "height": 1,
-                          "width": 1,
-                        },
-                        "shadowOpacity": 0.3,
-                        "top": 37.5,
-                        "width": 90,
+                        "color": "#FFFFFF",
+                        "fontSize": 18,
+                        "fontWeight": "bold",
                       },
                       Object {
-                        "elevation": 5,
+                        "alignSelf": "center",
+                        "color": "#000",
+                        "fontSize": 45,
                       },
                     ]
                   }
                 >
-                  <Text
+                  S
+                </Text>
+              </View>
+              <View
+                style={
+                  Object {
+                    "flex": 1,
+                    "marginLeft": -52.5,
+                    "padding": 37.5,
+                  }
+                }
+                testID="com.ariesbifold:id/CredentialCardPrimaryBody"
+              >
+                <View>
+                  <View
                     style={
-                      Array [
-                        Object {
-                          "color": "#FFFFFF",
-                          "fontSize": 18,
-                          "fontWeight": "bold",
-                        },
-                        Object {
-                          "alignSelf": "center",
-                          "color": "#000",
-                          "fontSize": 45,
-                        },
-                      ]
+                      Object {
+                        "flexDirection": "row",
+                      }
                     }
                   >
-                    S
-                  </Text>
-                </View>
-                <View
-                  style={
-                    Object {
-                      "flex": 1,
-                      "marginLeft": -52.5,
-                      "padding": 37.5,
-                    }
-                  }
-                  testID="com.ariesbifold:id/CredentialCardPrimaryBody"
-                >
-                  <View>
-                    <View
+                    <Text
                       style={
-                        Object {
-                          "flexDirection": "row",
-                        }
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 14,
+                            "fontWeight": "bold",
+                          },
+                          Object {
+                            "color": "#FFFFFF",
+                            "flexShrink": 1,
+                          },
+                          Object {
+                            "flex": 1,
+                            "flexWrap": "wrap",
+                            "lineHeight": 19,
+                            "opacity": 0.8,
+                          },
+                        ]
                       }
-                    >
-                      <Text
-                        style={
-                          Array [
-                            Object {
-                              "color": "#FFFFFF",
-                              "fontSize": 18,
-                              "fontWeight": "bold",
-                            },
-                            Object {
-                              "color": "#FFFFFF",
-                              "flexShrink": 1,
-                            },
-                            Object {
-                              "color": "#FFFFFF",
-                              "flex": 1,
-                              "flexWrap": "wrap",
-                              "lineHeight": 24,
-                            },
-                          ]
-                        }
-                        testID="com.ariesbifold:id/CredentialName"
-                      >
-                        Student
-                      </Text>
-                    </View>
+                      testID="com.ariesbifold:id/CredentialIssuer"
+                    />
                   </View>
                   <View
-                    data={
-                      Array [
-                        Attribute {
-                          "credentialId": undefined,
-                          "encoding": undefined,
-                          "format": undefined,
-                          "label": "First Name",
-                          "mimeType": undefined,
-                          "name": "student_first_name",
-                          "nonRevoked": undefined,
-                          "restrictions": Array [
-                            Object {
-                              "cred_def_id": "XUxBrVSALWHLeycAUhrNr9:3:CL:26293:student_card",
-                            },
-                          ],
-                          "revealed": undefined,
-                          "revoked": undefined,
-                          "type": "Text",
-                          "value": null,
-                        },
-                        Attribute {
-                          "credentialId": undefined,
-                          "encoding": undefined,
-                          "format": undefined,
-                          "label": "Last Name",
-                          "mimeType": undefined,
-                          "name": "student_last_name",
-                          "nonRevoked": undefined,
-                          "restrictions": Array [
-                            Object {
-                              "cred_def_id": "XUxBrVSALWHLeycAUhrNr9:3:CL:26293:student_card",
-                            },
-                          ],
-                          "revealed": undefined,
-                          "revoked": undefined,
-                          "type": "Text",
-                          "value": null,
-                        },
-                      ]
+                    style={
+                      Object {
+                        "flexDirection": "row",
+                      }
                     }
-                    getItem={[Function]}
-                    getItemCount={[Function]}
-                    initialNumToRender={2}
-                    keyExtractor={[Function]}
-                    onContentSizeChange={[Function]}
-                    onLayout={[Function]}
-                    onMomentumScrollBegin={[Function]}
-                    onMomentumScrollEnd={[Function]}
-                    onScroll={[Function]}
-                    onScrollBeginDrag={[Function]}
-                    onScrollEndDrag={[Function]}
-                    removeClippedSubviews={false}
-                    renderItem={[Function]}
-                    scrollEnabled={false}
-                    scrollEventThrottle={50}
-                    stickyHeaderIndices={Array []}
-                    viewabilityConfigCallbackPairs={Array []}
                   >
+                    <Text
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 18,
+                            "fontWeight": "bold",
+                          },
+                          Object {
+                            "color": "#FFFFFF",
+                            "flexShrink": 1,
+                          },
+                          Object {
+                            "color": "#FFFFFF",
+                            "flex": 1,
+                            "flexWrap": "wrap",
+                            "lineHeight": 24,
+                          },
+                        ]
+                      }
+                      testID="com.ariesbifold:id/CredentialName"
+                    >
+                      Student
+                    </Text>
+                  </View>
+                </View>
+                <RCTScrollView
+                  data={
+                    Array [
+                      Attribute {
+                        "credentialId": undefined,
+                        "encoding": undefined,
+                        "format": undefined,
+                        "label": "First Name",
+                        "mimeType": undefined,
+                        "name": "student_first_name",
+                        "nonRevoked": undefined,
+                        "restrictions": Array [
+                          Object {
+                            "cred_def_id": "XUxBrVSALWHLeycAUhrNr9:3:CL:26293:student_card",
+                          },
+                        ],
+                        "revealed": undefined,
+                        "revoked": undefined,
+                        "type": "Text",
+                        "value": null,
+                      },
+                      Attribute {
+                        "credentialId": undefined,
+                        "encoding": undefined,
+                        "format": undefined,
+                        "label": "Last Name",
+                        "mimeType": undefined,
+                        "name": "student_last_name",
+                        "nonRevoked": undefined,
+                        "restrictions": Array [
+                          Object {
+                            "cred_def_id": "XUxBrVSALWHLeycAUhrNr9:3:CL:26293:student_card",
+                          },
+                        ],
+                        "revealed": undefined,
+                        "revoked": undefined,
+                        "type": "Text",
+                        "value": null,
+                      },
+                    ]
+                  }
+                  getItem={[Function]}
+                  getItemCount={[Function]}
+                  initialNumToRender={2}
+                  keyExtractor={[Function]}
+                  onContentSizeChange={[Function]}
+                  onLayout={[Function]}
+                  onMomentumScrollBegin={[Function]}
+                  onMomentumScrollEnd={[Function]}
+                  onScroll={[Function]}
+                  onScrollBeginDrag={[Function]}
+                  onScrollEndDrag={[Function]}
+                  removeClippedSubviews={false}
+                  renderItem={[Function]}
+                  scrollEnabled={false}
+                  scrollEventThrottle={50}
+                  stickyHeaderIndices={Array []}
+                  viewabilityConfigCallbackPairs={Array []}
+                >
+                  <View>
                     <View
                       onFocusCapture={[Function]}
                       onLayout={[Function]}
@@ -328,13 +294,7 @@ exports[`ProofRequestDetails Component Renders correctly 1`] = `
                           }
                         }
                       >
-                        <View
-                          style={
-                            Object {
-                              "flexDirection": "row",
-                            }
-                          }
-                        >
+                        <View>
                           <Text
                             style={
                               Array [
@@ -357,29 +317,6 @@ exports[`ProofRequestDetails Component Renders correctly 1`] = `
                           >
                             First Name
                           </Text>
-                          <Text
-                            style={
-                              Array [
-                                Object {
-                                  "color": "#FFFFFF",
-                                  "fontSize": 14,
-                                  "fontWeight": "normal",
-                                },
-                                Object {
-                                  "color": "#FFFFFF",
-                                  "flexShrink": 1,
-                                },
-                                Object {
-                                  "color": "#FFFFFF",
-                                  "fontSize": 18,
-                                  "fontWeight": "normal",
-                                  "minHeight": 18,
-                                  "paddingVertical": 4,
-                                },
-                              ]
-                            }
-                            testID="com.ariesbifold:id/AttributeValue"
-                          />
                         </View>
                       </View>
                     </View>
@@ -395,13 +332,7 @@ exports[`ProofRequestDetails Component Renders correctly 1`] = `
                           }
                         }
                       >
-                        <View
-                          style={
-                            Object {
-                              "flexDirection": "row",
-                            }
-                          }
-                        >
+                        <View>
                           <Text
                             style={
                               Array [
@@ -424,197 +355,174 @@ exports[`ProofRequestDetails Component Renders correctly 1`] = `
                           >
                             Last Name
                           </Text>
-                          <Text
-                            style={
-                              Array [
-                                Object {
-                                  "color": "#FFFFFF",
-                                  "fontSize": 14,
-                                  "fontWeight": "normal",
-                                },
-                                Object {
-                                  "color": "#FFFFFF",
-                                  "flexShrink": 1,
-                                },
-                                Object {
-                                  "color": "#FFFFFF",
-                                  "fontSize": 18,
-                                  "fontWeight": "normal",
-                                  "minHeight": 18,
-                                  "paddingVertical": 4,
-                                },
-                              ]
-                            }
-                            testID="com.ariesbifold:id/AttributeValue"
-                          />
                         </View>
                       </View>
                     </View>
                   </View>
-                </View>
+                </RCTScrollView>
               </View>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "marginBottom": 10,
+              "marginTop": "auto",
+            }
+          }
+        >
+          <View
+            accessibilityLabel="Verifier.UseProofRequest"
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              Object {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "backgroundColor": "#42803E",
+                "borderRadius": 4,
+                "opacity": 1,
+                "padding": 16,
+              }
+            }
+            testID="com.ariesbifold:id/UseProofRequest"
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                }
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    Object {
+                      "color": "#FFFFFF",
+                      "fontSize": 18,
+                      "fontWeight": "bold",
+                      "textAlign": "center",
+                    },
+                    false,
+                    false,
+                    false,
+                  ]
+                }
+              >
+                Verifier.UseProofRequest
+              </Text>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            Object {
+              "marginBottom": 10,
+              "marginTop": "auto",
+            }
+          }
+        >
+          <View
+            accessibilityLabel="Verifier.ShowTemplateUsageHistory"
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              Object {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "borderColor": "#42803E",
+                "borderRadius": 4,
+                "borderWidth": 2,
+                "opacity": 1,
+                "padding": 16,
+              }
+            }
+            testID="com.ariesbifold:id/ShowTemplateUsageHistory"
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                }
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    Object {
+                      "color": "#42803E",
+                      "fontSize": 18,
+                      "fontWeight": "bold",
+                      "textAlign": "center",
+                    },
+                    false,
+                    false,
+                    false,
+                  ]
+                }
+              >
+                Verifier.ShowTemplateUsageHistory
+              </Text>
             </View>
           </View>
         </View>
       </View>
     </View>
   </RCTScrollView>
-  <View>
-    <View
-      style={
-        Object {
-          "marginBottom": 10,
-          "marginTop": "auto",
-        }
-      }
-    >
-      <View
-        accessibilityLabel="Verifier.UseProofRequest"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": false,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          Object {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          Object {
-            "backgroundColor": "#42803E",
-            "borderRadius": 4,
-            "opacity": 1,
-            "padding": 16,
-          }
-        }
-        testID="com.ariesbifold:id/UseProofRequest"
-      >
-        <View
-          style={
-            Object {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "justifyContent": "center",
-            }
-          }
-        >
-          <Text
-            style={
-              Array [
-                Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
-                  "textAlign": "center",
-                },
-                false,
-                false,
-                false,
-              ]
-            }
-          >
-            Verifier.UseProofRequest
-          </Text>
-        </View>
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "marginBottom": 10,
-          "marginTop": "auto",
-        }
-      }
-    >
-      <View
-        accessibilityLabel="Verifier.ShowTemplateUsageHistory"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": false,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          Object {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          Object {
-            "borderColor": "#42803E",
-            "borderRadius": 4,
-            "borderWidth": 2,
-            "opacity": 1,
-            "padding": 16,
-          }
-        }
-        testID="com.ariesbifold:id/ShowTemplateUsageHistory"
-      >
-        <View
-          style={
-            Object {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "justifyContent": "center",
-            }
-          }
-        >
-          <Text
-            style={
-              Array [
-                Object {
-                  "color": "#42803E",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
-                  "textAlign": "center",
-                },
-                false,
-                false,
-                false,
-              ]
-            }
-          >
-            Verifier.ShowTemplateUsageHistory
-          </Text>
-        </View>
-      </View>
-    </View>
-  </View>
 </RNCSafeAreaView>
 `;


### PR DESCRIPTION
# Summary of Changes

This PR creates a common verifier credential card component for all proof template previews, proof presentations, and proof presentation histories. It also enables zooming into picture attributes on presentations. Here's what it looks like:
![verifier_presentation](https://github.com/openwallet-foundation/bifold-wallet/assets/32586431/471fd2e4-6b69-4f34-9e8c-bbfaf8a67ee0)

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
