### PR TITLE
fix: Button export

### DIFF
--- a/packages/legacy/core/App/index.ts
+++ b/packages/legacy/core/App/index.ts
@@ -6,7 +6,7 @@ import AgentProvider from '@aries-framework/react-hooks'
 
 import App from './App'
 import * as components from './components'
-import { Button, ButtonType } from './components/buttons/Button'
+import { Button as IButton, ButtonImpl as Button, ButtonType } from './components/buttons/Button'
 import HeaderButton, { ButtonLocation } from './components/buttons/HeaderButton'
 import CheckBoxRow from './components/inputs/CheckBoxRow'
 import ContentGradient from './components/misc/ContentGradient'
@@ -149,5 +149,6 @@ export {
   contexts,
   Text,
   loadLoginAttempt,
+  Button,
 }
-export type { Button }
+export type { IButton }


### PR DESCRIPTION
Restore previous export semantic (Implementation vs Interface) to preserve backward compatibility

# Summary of Changes

PR #1075 broke compatibility for exporting `Button` element. This PR restores the previous semantic where `Button` is the implementation/element, and added `IButton` as the exported interface.

# Related Issues

Please reference here any issue #'s that are relevant to this PR, or simply enter "N/A" if this PR does not relate to any existing issues.

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
