### PR TITLE
fix: missing svg image in settings

### DIFF
--- a/packages/legacy/core/App/screens/Settings.tsx
+++ b/packages/legacy/core/App/screens/Settings.tsx
@@ -68,12 +68,6 @@ const Settings: React.FC<SettingsProps> = ({ navigation }) => {
       borderBottomColor: ColorPallet.brand.primaryBackground,
       marginHorizontal: 25,
     },
-    logo: {
-      height: 64,
-      width: '100%',
-      marginVertical: 16,
-      backgroundColor: 'orange',
-    },
     footer: {
       marginVertical: 25,
       alignItems: 'center',
@@ -366,7 +360,6 @@ const Settings: React.FC<SettingsProps> = ({ navigation }) => {
                 <Text style={TextTheme.normal} testID={testIdWithKey('Version')}>
                   {`${t('Settings.Version')} ${getVersion()} ${t('Settings.Build')} (${getBuildNumber()})`}
                 </Text>
-                {/* <Assets.svg.logo {...styles.logo} /> */}
                 <Assets.svg.logo style={{ alignSelf: 'center' }} width={150} height={75} />
               </View>
             </TouchableWithoutFeedback>

--- a/packages/legacy/core/App/screens/Settings.tsx
+++ b/packages/legacy/core/App/screens/Settings.tsx
@@ -70,8 +70,9 @@ const Settings: React.FC<SettingsProps> = ({ navigation }) => {
     },
     logo: {
       height: 64,
-      width: '50%',
+      width: '100%',
       marginVertical: 16,
+      backgroundColor: 'orange',
     },
     footer: {
       marginVertical: 25,
@@ -365,7 +366,8 @@ const Settings: React.FC<SettingsProps> = ({ navigation }) => {
                 <Text style={TextTheme.normal} testID={testIdWithKey('Version')}>
                   {`${t('Settings.Version')} ${getVersion()} ${t('Settings.Build')} (${getBuildNumber()})`}
                 </Text>
-                <Assets.svg.logo {...styles.logo} />
+                {/* <Assets.svg.logo {...styles.logo} /> */}
+                <Assets.svg.logo style={{ alignSelf: 'center' }} width={150} height={75} />
               </View>
             </TouchableWithoutFeedback>
           </View>

--- a/packages/legacy/core/__tests__/screens/__snapshots__/Settings.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/Settings.test.tsx.snap
@@ -1002,9 +1002,13 @@ exports[`Settings Screen Renders correctly 1`] = `
               Settings.Version 1 Settings.Build (1)
             </Text>
             <
-              height={64}
-              marginVertical={16}
-              width="50%"
+              height={75}
+              style={
+                Object {
+                  "alignSelf": "center",
+                }
+              }
+              width={150}
             />
           </View>
         </View>


### PR DESCRIPTION
# Summary of Changes
Previously the logo svg wasn't showing up on the settings page because it was missing dimensions, this PR fixes that. Here's what it looks like:
![bc_logo](https://github.com/openwallet-foundation/bifold-wallet/assets/32586431/681fc1c0-0a84-46e9-a8d2-8b6909fc5eef)

# Related Issues
N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
