### PR TITLE
fix: credential watermark in wallet and verifier

### DIFF
--- a/packages/legacy/core/App/components/misc/CredentialCard11.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard11.tsx
@@ -225,16 +225,19 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
     },
   })
 
-  const colorIfErrorState = () =>
-    error || predicateError || isProofRevoked
-      ? ColorPallet.notification.errorBorder
-      : styles.secondaryBodyContainer.backgroundColor
+  const backgroundColorIfErrorState = (backgroundColor?: string) =>
+    error || predicateError || isProofRevoked ? ColorPallet.notification.errorBorder : backgroundColor
 
   const fontColorWithHighContrast = () => {
-    const c = colorIfErrorState() ?? ColorPallet.grayscale.lightGrey
+    if (proof) {
+      return ColorPallet.grayscale.mediumGrey
+    }
+
+    const c =
+      backgroundColorIfErrorState(overlay.brandingOverlay?.primaryBackgroundColor) ?? ColorPallet.grayscale.lightGrey
     const shade = shadeIsLightOrDark(c)
 
-    return shade == Shade.Light ? ColorPallet.grayscale.darkGrey : ColorPallet.grayscale.mediumGrey
+    return shade == Shade.Light ? ColorPallet.grayscale.darkGrey : ColorPallet.grayscale.lightGrey
   }
 
   const parseAttribute = (item: (Attribute & Predicate) | undefined) => {
@@ -522,19 +525,11 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
         style={[
           styles.secondaryBodyContainer,
           {
-            backgroundColor: colorIfErrorState(),
+            backgroundColor: backgroundColorIfErrorState(styles.secondaryBodyContainer.backgroundColor),
             overflow: 'hidden',
           },
         ]}
       >
-        {overlay.metaOverlay?.watermark && (
-          <CardWatermark
-            width={dimensions.cardWidth}
-            height={dimensions.cardHeight}
-            style={{ color: fontColorWithHighContrast() }}
-            watermark={overlay.metaOverlay?.watermark}
-          />
-        )}
         {overlay.brandingOverlay?.backgroundImageSlice && !displayItems ? (
           <ImageBackground
             source={toImageSource(overlay.brandingOverlay?.backgroundImageSlice)}

--- a/packages/legacy/core/App/components/misc/VerifierCredentialCard.tsx
+++ b/packages/legacy/core/App/components/misc/VerifierCredentialCard.tsx
@@ -53,8 +53,9 @@ const VerifierCredentialCard: React.FC<VerifierCredentialCardProps> = ({
   const borderRadius = 10
   const padding = width * 0.05
   const logoHeight = width * 0.12
+  const [dimensions, setDimensions] = useState({ cardWidth: 0, cardHeight: 0 })
   const { i18n, t } = useTranslation()
-  const { TextTheme } = useTheme()
+  const { ColorPallet, TextTheme } = useTheme()
   const { OCABundleResolver } = useConfiguration()
   const [overlay, setOverlay] = useState<CredentialOverlay<BrandingOverlay>>({})
 
@@ -66,8 +67,6 @@ const VerifierCredentialCard: React.FC<VerifierCredentialCardProps> = ({
     .reduce((prev: { [key: string]: string }, curr: { name: string; format?: string }) => {
       return { ...prev, [curr.name]: curr.format }
     }, {})
-
-  const [dimensions, setDimensions] = useState({ cardWidth: 0, cardHeight: 0 })
 
   const styles = StyleSheet.create({
     container: {
@@ -114,11 +113,6 @@ const VerifierCredentialCard: React.FC<VerifierCredentialCardProps> = ({
     textContainer: {
       color: TextTheme.normal.color,
       flexShrink: 1,
-    },
-    watermark: {
-      opacity: 0.16,
-      fontSize: 22,
-      transform: [{ rotate: '-30deg' }],
     },
   })
 
@@ -422,7 +416,7 @@ const VerifierCredentialCard: React.FC<VerifierCredentialCardProps> = ({
           <CardWatermark
             width={dimensions.cardWidth}
             height={dimensions.cardHeight}
-            style={styles.watermark}
+            style={{ color: ColorPallet.grayscale.mediumGrey }}
             watermark={overlay.metaOverlay?.watermark}
           />
         )}


### PR DESCRIPTION
# Summary of Changes

Unifies the watermarking in the verifier and credential card, and removes some duplicated code that caused there to be two watermarks that would overlap. Also fixes the shading of the watermark so that it's properly visible on all background colours and in proofs. Sidenote: The reason the Demo Person credential is fully covered by the watermark is that it doesn't have a secondary background defined in OCA, so it's transparent. 

Here's the before:
![watermark_before](https://github.com/openwallet-foundation/bifold-wallet/assets/32586431/ef2d8983-6ee1-463f-881d-e714bcc9a806)

Here's the after:
![watermark_after](https://github.com/openwallet-foundation/bifold-wallet/assets/32586431/6eed1e69-68a8-4a5c-9b77-3095fa4a5dcc)

And here's the verifier being presented with watermarked credentials:
<img width="313" alt="verifier_watermark" src="https://github.com/openwallet-foundation/bifold-wallet/assets/32586431/e0b8df69-14a5-4d96-a594-4a318da177d1">


# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [ ] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
