### PR TITLE
fix: bug on lockout

### DIFF
--- a/packages/legacy/core/App/navigators/RootStack.tsx
+++ b/packages/legacy/core/App/navigators/RootStack.tsx
@@ -67,8 +67,12 @@ const RootStack: React.FC = () => {
     if (agent && state.authentication.didAuthenticate) {
       // make sure agent is shutdown so wallet isn't still open
       removeSavedWalletSecret()
-      await agent.wallet.close()
-      await agent.shutdown()
+      try {
+        await agent.wallet.close()
+        await agent.shutdown()
+      } catch (error) {
+        agent?.config?.logger?.error(`Error shutting down agent: ${error}`)
+      }
       dispatch({
         type: DispatchAction.DID_AUTHENTICATE,
         payload: [{ didAuthenticate: false }],

--- a/packages/legacy/core/App/screens/Splash.tsx
+++ b/packages/legacy/core/App/screens/Splash.tsx
@@ -105,6 +105,8 @@ const Splash: React.FC = () => {
     },
   })
 
+  // navigation calls that occur before the screen is fully mounted will fail
+  // this useeffect prevents that race condition
   useEffect(() => {
     setMounted(true)
   }, [])

--- a/packages/legacy/core/App/screens/Splash.tsx
+++ b/packages/legacy/core/App/screens/Splash.tsx
@@ -3,7 +3,7 @@ import { useAgent } from '@credo-ts/react-hooks'
 import { agentDependencies } from '@credo-ts/react-native'
 import { useNavigation } from '@react-navigation/core'
 import { CommonActions } from '@react-navigation/native'
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { DeviceEventEmitter, StyleSheet } from 'react-native'
 import { Config } from 'react-native-config'
@@ -94,6 +94,7 @@ const Splash: React.FC = () => {
   const { ColorPallet } = useTheme()
   const { LoadingIndicator } = useAnimatedComponents()
   const container = useContainer()
+  const [mounted, setMounted] = useState(false)
   const { version: TermsVersion } = container.resolve(TOKENS.SCREEN_TERMS)
   const styles = StyleSheet.create({
     container: {
@@ -105,7 +106,11 @@ const Splash: React.FC = () => {
   })
 
   useEffect(() => {
-    if (store.authentication.didAuthenticate) {
+    setMounted(true)
+  }, [])
+
+  useEffect(() => {
+    if (!mounted || store.authentication.didAuthenticate) {
       return
     }
 
@@ -190,10 +195,10 @@ const Splash: React.FC = () => {
     }
 
     initOnboarding()
-  }, [store.authentication.didAuthenticate, store.stateLoaded])
+  }, [mounted, store.authentication.didAuthenticate, store.stateLoaded])
 
   useEffect(() => {
-    if (!store.authentication.didAuthenticate || !store.onboarding.didConsiderBiometry) {
+    if (!mounted || !store.authentication.didAuthenticate || !store.onboarding.didConsiderBiometry) {
       return
     }
 
@@ -264,7 +269,7 @@ const Splash: React.FC = () => {
     }
 
     initAgent()
-  }, [store.authentication.didAuthenticate, store.onboarding.didConsiderBiometry])
+  }, [mounted, store.authentication.didAuthenticate, store.onboarding.didConsiderBiometry])
 
   return (
     <SafeAreaView style={styles.container}>


### PR DESCRIPTION
# Summary of Changes

There are two fixes in this PR. One is to ensure the splash screen is fully mounted before navigation takes place, as navigation calls that occur before then won't work and the app will just stay stuck on the splash screen. The second fix is for the agent shutdown occasionally failing during lockout. The wallet closes properly but then one of the agent shutdown processes fail, seemingly harmlessly. I added error handling here to prevent the app from staying open when that happens. More investigation is needed as to why that shutdown fails sometimes but it can be difficult to reproduce so this fix addresses the immediate problem.

# Related Issues
N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [ ] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
