### PR TITLE
feat: added ability to group proofs by referent instead of cred name

### DIFF
--- a/packages/legacy/core/App/container-api.ts
+++ b/packages/legacy/core/App/container-api.ts
@@ -8,6 +8,9 @@ import Onboarding from './screens/Onboarding'
 import { GenericFn } from './types/fn'
 import { AuthenticateStackParams, ScreenOptionsType } from './types/navigators'
 
+export enum PROOF_TOKENS {
+  GROUP_BY_REFERENT = 'proof.groupByReferant',
+}
 export enum SCREEN_TOKENS {
   SCREEN_PREFACE = 'screen.preface',
   SCREEN_TERMS = 'screen.terms',
@@ -39,6 +42,7 @@ export enum OBJECT_TOKENS {
 }
 
 export const TOKENS = {
+  ...PROOF_TOKENS,
   ...SCREEN_TOKENS,
   ...SERVICE_TOKENS,
   ...STACK_TOKENS,
@@ -56,6 +60,7 @@ export type FN_ONBOARDING_DONE = (
 type FN_LOADSTATE = (dispatch: React.Dispatch<ReducerAction<unknown>>) => Promise<void>
 
 export interface TokenMapping {
+  [TOKENS.GROUP_BY_REFERENT]: boolean
   [TOKENS.SCREEN_PREFACE]: React.FC
   [TOKENS.STACK_ONBOARDING]: React.FC
   [TOKENS.SCREEN_TERMS]: { screen: React.FC; version: boolean | string }

--- a/packages/legacy/core/App/container-impl.ts
+++ b/packages/legacy/core/App/container-impl.ts
@@ -40,6 +40,7 @@ export class MainContainer implements Container {
     this.container.registerInstance(TOKENS.STACK_ONBOARDING, OnboardingStack)
     this.container.registerInstance(TOKENS.COMP_BUTTON, Button)
     this.container.registerInstance(TOKENS.OBJECT_ONBOARDINGCONFIG, DefaultScreenOptionsDictionary)
+    this.container.registerInstance(TOKENS.GROUP_BY_REFERENT, false)
 
     this.container.registerInstance(
       TOKENS.FN_ONBOARDING_DONE,

--- a/packages/legacy/core/App/hooks/proofs.ts
+++ b/packages/legacy/core/App/hooks/proofs.ts
@@ -3,6 +3,7 @@ import { useAgent, useCredentials, useProofById, useProofs } from '@credo-ts/rea
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { TOKENS, useContainer } from '../container-api'
 import { retrieveCredentialsForProof } from '../utils/helpers'
 
 export const useProofsByConnectionId = (connectionId: string): ProofExchangeRecord[] => {
@@ -18,10 +19,12 @@ export const useAllCredentialsForProof = (proofId: string) => {
   const { agent } = useAgent()
   const fullCredentials = useCredentials().records
   const proof = useProofById(proofId)
+  const container = useContainer()
+  const groupByReferent = container.resolve(TOKENS.GROUP_BY_REFERENT)
   return useMemo(() => {
     if (!proof || !agent) {
       return
     }
-    return retrieveCredentialsForProof(agent, proof, fullCredentials, t)
+    return retrieveCredentialsForProof(agent, proof, fullCredentials, t, groupByReferent)
   }, [proofId, fullCredentials])
 }

--- a/packages/legacy/core/__mocks__/custom/container-api.ts
+++ b/packages/legacy/core/__mocks__/custom/container-api.ts
@@ -1,0 +1,11 @@
+export enum TOKENS {
+    GROUP_BY_REFERENT = 'proof.groupByReferant',
+}
+
+export const useContainer = () => {
+    return {
+        resolve: (token: TOKENS) => {
+            return false
+        }
+    }
+}

--- a/packages/legacy/core/__tests__/screens/ProofChangeCredential.test.tsx
+++ b/packages/legacy/core/__tests__/screens/ProofChangeCredential.test.tsx
@@ -22,6 +22,9 @@ import { testIdWithKey } from '../../App/utils/testable'
 import configurationContext from '../contexts/configuration'
 import timeTravel from '../helpers/timetravel'
 
+jest.mock("../../App/container-api", ()=>{
+  return require("../../__mocks__/custom/container-api")
+});
 jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter')
 jest.mock('@react-native-community/netinfo', () => mockRNCNetInfo)
 jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper')

--- a/packages/legacy/core/__tests__/screens/ProofRequest.test.tsx
+++ b/packages/legacy/core/__tests__/screens/ProofRequest.test.tsx
@@ -24,6 +24,9 @@ import configurationContext from '../contexts/configuration'
 import networkContext from '../contexts/network'
 import timeTravel from '../helpers/timetravel'
 
+jest.mock("../../App/container-api", ()=>{
+  return require("../../__mocks__/custom/container-api")
+});
 jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter')
 jest.mock('@react-native-community/netinfo', () => mockRNCNetInfo)
 jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper')

--- a/packages/legacy/core/__tests__/screens/W3cProofRequest.test.tsx
+++ b/packages/legacy/core/__tests__/screens/W3cProofRequest.test.tsx
@@ -32,6 +32,9 @@ import {
   testW3cCredentialRecord,
 } from './fixtures/w3c-proof-request'
 
+jest.mock("../../App/container-api", ()=>{
+  return require("../../__mocks__/custom/container-api")
+});
 jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter')
 jest.mock('@react-native-community/netinfo', () => mockRNCNetInfo)
 jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper')


### PR DESCRIPTION
# Summary of Changes

A few months ago I added a patch to the way the wallet handles proof requests because sometimes proofs would ask for attributes and predicates in separate groups (referents). This resulted in the proof being split up across multiple credential cards and could be a bit of a confusing UI for users. The patch I added 6 months ago addressed this by grouping based of credential name so that any proof asking for data from the same credential would be grouped into the same card. @CarolineLCa and her team need the old functionality where credentials are grouped by referent rather than by cred name. This PR adds support for grouping by referent. To use this feature in your project, override the `container-impl.ts` file and set `this.container.registerInstance(TOKENS.GROUP_BY_REFERENT, false)` to true

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
