### PR TITLE
fix: add checks for unqualified schema and cred def id

### DIFF
--- a/packages/oca/__tests__/__snapshots__/remote.test.ts.snap
+++ b/packages/oca/__tests__/__snapshots__/remote.test.ts.snap
@@ -84,6 +84,10 @@ exports[`RemoteOCABundleResolver should check fetch updated bundles 1`] = `
     "path": "OCABundles/schema/bcgov-digital-trust/student-card/OCABundle.json",
     "sha256": "e65625acad0f1baab8e05b6cd1a5619b22e1f20cb47768616680a0fb2e8dc21d",
   },
+  "RGjWbW1eycP7FrMf4QJvX8:2:Person:1.0": {
+    "path": "OCABundles/schema/bcgov-digital-trust/person/OCABundle.json",
+    "sha256": "9187f651eab59811d8ec1c1257628c08f6daa1eb520bf379f022425f3a9701cf",
+  },
   "RGjWbW1eycP7FrMf4QJvX8:3:CL:13:Person": {
     "path": "OCABundles/schema/bcgov-digital-trust/person/OCABundle.json",
     "sha256": "9187f651eab59811d8ec1c1257628c08f6daa1eb520bf379f022425f3a9701cf",
@@ -224,6 +228,10 @@ exports[`RemoteOCABundleResolver should update demand 1`] = `
   "QEquAHkM35w4XVT3Ku5yat:2:student_card:1.4": {
     "path": "OCABundles/schema/bcgov-digital-trust/student-card/OCABundle.json",
     "sha256": "e65625acad0f1baab8e05b6cd1a5619b22e1f20cb47768616680a0fb2e8dc21d",
+  },
+  "RGjWbW1eycP7FrMf4QJvX8:2:Person:1.0": {
+    "path": "OCABundles/schema/bcgov-digital-trust/person/OCABundle.json",
+    "sha256": "9187f651eab59811d8ec1c1257628c08f6daa1eb520bf379f022425f3a9701cf",
   },
   "RGjWbW1eycP7FrMf4QJvX8:3:CL:13:Person": {
     "path": "OCABundles/schema/bcgov-digital-trust/person/OCABundle.json",

--- a/packages/oca/__tests__/fixtures/ocabundles.json
+++ b/packages/oca/__tests__/fixtures/ocabundles.json
@@ -79,6 +79,10 @@
     "path": "OCABundles/schema/bcgov-digital-trust/person/OCABundle.json",
     "sha256": "9187f651eab59811d8ec1c1257628c08f6daa1eb520bf379f022425f3a9701cf"
   },
+  "RGjWbW1eycP7FrMf4QJvX8:2:Person:1.0": {
+    "path": "OCABundles/schema/bcgov-digital-trust/person/OCABundle.json",
+    "sha256": "9187f651eab59811d8ec1c1257628c08f6daa1eb520bf379f022425f3a9701cf"
+  },
   "L6ASjmDDbDH7yPL1t2yFj9:2:Person:1.2": {
     "path": "OCABundles/schema/bcgov-digital-trust/person-showcase/OCABundle.json",
     "sha256": "84d27be5680762f5d2d59b9cc95a49874ce73dc67af6f854bc246ed7fa8e6dfb"

--- a/packages/oca/src/legacy/resolver/remote-oca.ts
+++ b/packages/oca/src/legacy/resolver/remote-oca.ts
@@ -506,12 +506,10 @@ export class RemoteOCABundleResolver extends DefaultOCABundleResolver {
   private matchBundleIndexEntry = (identifiers: Identifiers): string | undefined => {
     const { schemaId, credentialDefinitionId, templateId } = identifiers
     // also check unqualified schema and cred def id's if qualified versions exist
-    const unqualifiedSchemaId =
-      schemaId && schemaId.startsWith('did:indy:') ? getUnQualifiedDidIndyDid(schemaId) : undefined
-    const unqualifiedCredDefId =
-      credentialDefinitionId && credentialDefinitionId.startsWith('did:indy:')
-        ? getUnQualifiedDidIndyDid(credentialDefinitionId)
-        : undefined
+    const unqualifiedSchemaId = schemaId?.startsWith('did:indy:') ? getUnQualifiedDidIndyDid(schemaId) : undefined
+    const unqualifiedCredDefId = credentialDefinitionId?.startsWith('did:indy:')
+      ? getUnQualifiedDidIndyDid(credentialDefinitionId)
+      : undefined
 
     // If more than one candidate identifier exists in the index file then
     // order matters here.

--- a/packages/oca/src/legacy/resolver/remote-oca.ts
+++ b/packages/oca/src/legacy/resolver/remote-oca.ts
@@ -1,3 +1,4 @@
+import { getUnQualifiedDidIndyDid } from '@credo-ts/anoncreds'
 import axios from 'axios'
 import { CachesDirectoryPath, readFile, writeFile, exists, mkdir, unlink } from 'react-native-fs'
 
@@ -504,9 +505,17 @@ export class RemoteOCABundleResolver extends DefaultOCABundleResolver {
    */
   private matchBundleIndexEntry = (identifiers: Identifiers): string | undefined => {
     const { schemaId, credentialDefinitionId, templateId } = identifiers
+    // also check unqualified schema and cred def id's if qualified versions exist
+    const unqualifiedSchemaId =
+      schemaId && schemaId.startsWith('did:indy:') ? getUnQualifiedDidIndyDid(schemaId) : undefined
+    const unqualifiedCredDefId =
+      credentialDefinitionId && credentialDefinitionId.startsWith('did:indy:')
+        ? getUnQualifiedDidIndyDid(credentialDefinitionId)
+        : undefined
+
     // If more than one candidate identifier exists in the index file then
     // order matters here.
-    const candidates = [schemaId, credentialDefinitionId, templateId].filter(
+    const candidates = [schemaId, unqualifiedSchemaId, credentialDefinitionId, unqualifiedCredDefId, templateId].filter(
       (value) => value !== undefined && value !== null && value !== ''
     )
 

--- a/packages/oca/tsconfig.json
+++ b/packages/oca/tsconfig.json
@@ -32,7 +32,7 @@
     // "paths": {}                                       /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": ["jest"],                                   /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */


### PR DESCRIPTION
# Summary of Changes

This PR adds a check for the unqualified versions of schema id and credential definition id if qualified versions are provided as identifiers. It keeps the same ordering and prefers the qualified version as OCA bundles that use that as a key will be newer.

I also added / updated some tests and mocks, and fixed a linting issue with jest.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
