### PR TITLE
feat: improving parseCredDefFromId function and CredentialCard11 attribute value

### DIFF
--- a/packages/legacy/core/App/components/misc/CredentialCard11.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard11.tsx
@@ -244,7 +244,7 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
 
   const parseAttribute = (item: (Attribute & Predicate) | undefined) => {
     let parsedItem = item
-    if (item && !item.value != null) {
+    if (item && item.value != null) {
       parsedItem = pTypeToText(item, t, attributeTypes) as Attribute & Predicate
     }
     const parsedValue = formatIfDate(

--- a/packages/legacy/core/App/components/misc/CredentialCard11.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard11.tsx
@@ -244,7 +244,7 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
 
   const parseAttribute = (item: (Attribute & Predicate) | undefined) => {
     let parsedItem = item
-    if (item && !item.value) {
+    if (item && !item.value != null) {
       parsedItem = pTypeToText(item, t, attributeTypes) as Attribute & Predicate
     }
     const parsedValue = formatIfDate(
@@ -253,7 +253,7 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
     )
     return {
       label: item?.label ?? item?.name ?? '',
-      value: item?.value ? parsedValue : `${parsedItem?.pType} ${parsedValue}`,
+      value: item?.value !== undefined && item?.value != null ? parsedValue : `${parsedItem?.pType} ${parsedValue}`,
     }
   }
 
@@ -407,7 +407,7 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
     return (
       item && (
         <View style={{ marginTop: 15 }}>
-          {!(item?.value || item?.satisfied) ? (
+          {!(item?.value != null || item?.satisfied) ? (
             <View style={{ flexDirection: 'row', alignItems: 'center' }}>
               <Icon
                 style={{ paddingTop: 2, paddingHorizontal: 2 }}
@@ -420,7 +420,7 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
           ) : (
             <AttributeLabel label={label} />
           )}
-          {!(item?.value || item?.pValue) ? null : (
+          {!(item?.value != null || item?.pValue) ? null : (
             <View style={{ flexDirection: 'row', alignItems: 'center' }}>
               {flaggedAttributes?.includes(label) && !item.pValue && !allPI && proof && (
                 <Icon

--- a/packages/legacy/core/App/utils/cred-def.ts
+++ b/packages/legacy/core/App/utils/cred-def.ts
@@ -1,22 +1,19 @@
-import { AnonCredsCredentialMetadataKey } from '@credo-ts/anoncreds'
+import { AnonCredsCredentialMetadataKey, parseIndyCredentialDefinitionId, parseIndySchemaId } from '@credo-ts/anoncreds'
 import { CredentialExchangeRecord as CredentialRecord } from '@credo-ts/core'
 
-import { credentialSchema, parseSchemaFromId } from './schema'
+import { credentialSchema } from './schema'
 
 export function parseCredDefFromId(credDefId?: string, schemaId?: string): string {
   let name = 'Credential'
   if (credDefId) {
-    const credDefRegex = /[^:]+/g
-    const credDefIdParts = credDefId.match(credDefRegex)
-    if (credDefIdParts?.length === 5) {
-      name = `${credDefIdParts?.[4].replace(/_|-/g, ' ')}`
-        .split(' ')
-        .map((credIdPart) => credIdPart.charAt(0).toUpperCase() + credIdPart.substring(1))
-        .join(' ')
-    }
+    const parseIndyCredDefId = parseIndyCredentialDefinitionId(credDefId)
+    name = parseIndyCredDefId.tag
   }
   if (name.toLocaleLowerCase() === 'default' || name.toLowerCase() === 'credential') {
-    name = parseSchemaFromId(schemaId).name
+    if (schemaId) {
+      const parseIndySchema = parseIndySchemaId(schemaId)
+      name = parseIndySchema.schemaName
+    }
   }
   return name
 }

--- a/packages/legacy/core/__tests__/screens/ProofChangeCredential.test.tsx
+++ b/packages/legacy/core/__tests__/screens/ProofChangeCredential.test.tsx
@@ -82,7 +82,7 @@ describe('displays a credential selection screen', () => {
   const attributeBase = {
     referent: '',
     schemaId: '',
-    credentialDefinitionId: 'AAAAAAAAAAAAAAAAAAAAAA:1:AA:1234:test',
+    credentialDefinitionId: 'AAAAAAAAAAAAAAAAAAAAAA:3:CL:1234:test',
     toJSON: jest.fn(),
   }
 

--- a/packages/legacy/core/__tests__/screens/ProofRequest.test.tsx
+++ b/packages/legacy/core/__tests__/screens/ProofRequest.test.tsx
@@ -136,7 +136,7 @@ describe('displays a proof request screen', () => {
     const attributeBase = {
       referent: '',
       schemaId: '',
-      credentialDefinitionId: 'AAAAAAAAAAAAAAAAAAAAAA:1:AA:1234:test',
+      credentialDefinitionId: 'AAAAAAAAAAAAAAAAAAAAAA:3:CL:1234:test',
       toJSON: jest.fn(),
     }
 


### PR DESCRIPTION
# Summary of Changes

### Expected behavior
Correct names of credentials in the proof request.

### Current behavior
The credential does not come with the correct name since `parseCredDefFromId` was not updated to deal with this new `credDefId` format.

### To fix
I added `parseIndyCredentialDefinitionId` and `parseIndySchemaId`.

### Observation
For the CredentialCard11 attribute, I added a non-null validation because when the attribute has a value of 0 it was not considered in the proof request

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [X] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [X] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [X] Updated documentation as needed for changed code and new or modified features;
- [ ] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
