### PR TITLE
fix: add logging and fix malformed deeplink handling

### DIFF
--- a/packages/legacy/core/App/navigators/RootStack.tsx
+++ b/packages/legacy/core/App/navigators/RootStack.tsx
@@ -19,7 +19,7 @@ import { useDeepLinks } from '../hooks/deep-links'
 import Chat from '../screens/Chat'
 import { BifoldError } from '../types/error'
 import { AuthenticateStackParams, Screens, Stacks, TabStacks } from '../types/navigators'
-import { connectFromScanOrDeeplink } from '../utils/helpers'
+import { connectFromScanOrDeepLink } from '../utils/helpers'
 import { testIdWithKey } from '../utils/testable'
 
 import ConnectStack from './ConnectStack'
@@ -108,7 +108,14 @@ const RootStack: React.FC = () => {
       }
 
       try {
-        await connectFromScanOrDeeplink(deepLink, agent, navigation, enableImplicitInvitations, enableReuseConnections)
+        await connectFromScanOrDeepLink(
+          deepLink,
+          agent,
+          navigation,
+          true, // isDeepLink
+          enableImplicitInvitations,
+          enableReuseConnections
+        )
       } catch (err: unknown) {
         const error = new BifoldError(
           t('Error.Title1039'),

--- a/packages/legacy/core/App/navigators/RootStack.tsx
+++ b/packages/legacy/core/App/navigators/RootStack.tsx
@@ -46,6 +46,7 @@ const RootStack: React.FC = () => {
   const defaultStackOptions = createDefaultStackOptions(theme)
   const { splash, enableImplicitInvitations, enableReuseConnections } = useConfiguration()
   const container = useContainer()
+  const logger = container.resolve(TOKENS.UTIL_LOGGER)
   const OnboardingStack = container.resolve(TOKENS.STACK_ONBOARDING)
   const loadState = container.resolve(TOKENS.LOAD_STATE)
   useDeepLinks()
@@ -71,7 +72,7 @@ const RootStack: React.FC = () => {
         await agent.wallet.close()
         await agent.shutdown()
       } catch (error) {
-        agent?.config?.logger?.error(`Error shutting down agent: ${error}`)
+        logger?.error(`Error shutting down agent: ${error}`)
       }
       dispatch({
         type: DispatchAction.DID_AUTHENTICATE,
@@ -111,6 +112,7 @@ const RootStack: React.FC = () => {
         await connectFromScanOrDeepLink(
           deepLink,
           agent,
+          logger,
           navigation,
           true, // isDeepLink
           enableImplicitInvitations,

--- a/packages/legacy/core/App/screens/Scan.tsx
+++ b/packages/legacy/core/App/screens/Scan.tsx
@@ -16,7 +16,7 @@ import { useStore } from '../contexts/store'
 import { BifoldError, QrCodeScanError } from '../types/error'
 import { ConnectStackParams } from '../types/navigators'
 import { PermissionContract } from '../types/permissions'
-import { connectFromScanOrDeeplink } from '../utils/helpers'
+import { connectFromScanOrDeepLink } from '../utils/helpers'
 
 export type ScanProps = StackScreenProps<ConnectStackParams>
 
@@ -35,10 +35,11 @@ const Scan: React.FC<ScanProps> = ({ navigation, route }) => {
 
   const handleInvitation = async (value: string): Promise<void> => {
     try {
-      await connectFromScanOrDeeplink(
+      await connectFromScanOrDeepLink(
         value,
         agent,
         navigation?.getParent(),
+        false, // isDeepLink
         enableImplicitInvitations,
         enableReuseConnections
       )

--- a/packages/legacy/core/App/screens/Scan.tsx
+++ b/packages/legacy/core/App/screens/Scan.tsx
@@ -11,6 +11,7 @@ import QRScanner from '../components/misc/QRScanner'
 import CameraDisclosureModal from '../components/modals/CameraDisclosureModal'
 import { ToastType } from '../components/toast/BaseToast'
 import LoadingView from '../components/views/LoadingView'
+import { TOKENS, useContainer } from '../container-api'
 import { useConfiguration } from '../contexts/configuration'
 import { useStore } from '../contexts/store'
 import { BifoldError, QrCodeScanError } from '../types/error'
@@ -28,6 +29,8 @@ const Scan: React.FC<ScanProps> = ({ navigation, route }) => {
   const [showDisclosureModal, setShowDisclosureModal] = useState<boolean>(true)
   const [qrCodeScanError, setQrCodeScanError] = useState<QrCodeScanError | null>(null)
   const { enableImplicitInvitations, enableReuseConnections } = useConfiguration()
+  const container = useContainer()
+  const logger = container.resolve(TOKENS.UTIL_LOGGER)
   let defaultToConnect = false
   if (route?.params && route.params['defaultToConnect']) {
     defaultToConnect = route.params['defaultToConnect']
@@ -38,6 +41,7 @@ const Scan: React.FC<ScanProps> = ({ navigation, route }) => {
       await connectFromScanOrDeepLink(
         value,
         agent,
+        logger,
         navigation?.getParent(),
         false, // isDeepLink
         enableImplicitInvitations,

--- a/packages/legacy/core/App/utils/helpers.ts
+++ b/packages/legacy/core/App/utils/helpers.ts
@@ -13,6 +13,7 @@ import {
 import {
   Agent,
   BasicMessageRecord,
+  BaseLogger,
   ConnectionRecord,
   CredentialExchangeRecord,
   CredentialState,
@@ -979,6 +980,7 @@ const hasValidQueryParam = (query: QueryParams) => {
  * Receive a message from a scan or deeplink and navigate accordingly
  * @param value a URI either containing a base64 encoded connection invite in the query parameters or a redirect URL itself
  * @param agent an Agent instance
+ * @param logger injected logger from DI container
  * @param navigation a navigation object either Scan screen or Home screen
  * @param isDeepLink a boolean to communicate where the value is coming from
  * @param implicitInvitations a boolean to determine if implicit invitation behavior should be used
@@ -987,6 +989,7 @@ const hasValidQueryParam = (query: QueryParams) => {
 export const connectFromScanOrDeepLink = async (
   value: string,
   agent: Agent | undefined,
+  logger: BaseLogger,
   navigation: any,
   isDeepLink: boolean,
   implicitInvitations: boolean = false,
@@ -998,7 +1001,7 @@ export const connectFromScanOrDeepLink = async (
 
   // Try built in Credo methods first
   try {
-    agent.config.logger.info(`Attempting to connect from ${isDeepLink ? 'deep link' : 'scan'}, value: ${value}`)
+    logger.info(`Attempting to connect from ${isDeepLink ? 'deep link' : 'scan'}, value: ${value}`)
     // this function uses credo methods and currently only supports oob, c_i, and d_m query params
     const receivedInvitation = await connectFromInvitation(value, agent, implicitInvitations, reuseConnection)
     if (receivedInvitation?.connectionRecord?.id) {
@@ -1016,7 +1019,7 @@ export const connectFromScanOrDeepLink = async (
     }
     // try unsupported deeplink if built-in Credo methods fail. Let this catch block throw any error, it will be caught a level up
   } catch (err: unknown) {
-    agent.config.logger.error('Error connecting from invitation, trying unsupported query params. Error:', err as Error)
+    logger.error('Error connecting from invitation, trying unsupported query params. Error:', err as Error)
     // Try unsupported deeplink here
     const queryParams = parseUrl(value)?.query
     // if there's a valid query param, try unpacking and receiving the message
@@ -1031,9 +1034,7 @@ export const connectFromScanOrDeepLink = async (
       throw new Error(`No valid query params found in URI: ${value} and unable to connect from redirect url`)
       // if it's a deeplink and gets this far, fail silently
     } else {
-      agent.config.logger.info(
-        `No valid query params found in deeplink URI: ${value} and unable to connect from redirect url`
-      )
+      logger.info(`No valid query params found in deeplink URI: ${value} and unable to connect from redirect url`)
     }
   }
 }

--- a/packages/legacy/core/App/utils/helpers.ts
+++ b/packages/legacy/core/App/utils/helpers.ts
@@ -977,9 +977,10 @@ const hasValidQueryParam = (query: QueryParams) => {
 
 /**
  * Receive a message from a scan or deeplink and navigate accordingly
- * @param value either a URI containing a base64 encoded connection invite in the query parameters or
+ * @param value a URI either containing a base64 encoded connection invite in the query parameters or a redirect URL itself
  * @param agent an Agent instance
  * @param navigation a navigation object either Scan screen or Home screen
+ * @param isDeepLink a boolean to communicate where the value is coming from
  * @param implicitInvitations a boolean to determine if implicit invitation behavior should be used
  * @param reuseConnection a boolean to determine if the connection reuse should be allowed
  */

--- a/packages/legacy/core/__tests__/screens/Scan.test.tsx
+++ b/packages/legacy/core/__tests__/screens/Scan.test.tsx
@@ -1,6 +1,10 @@
 import { useNavigation } from '@react-navigation/core'
 import { render, waitFor } from '@testing-library/react-native'
 import React from 'react'
+import { container } from 'tsyringe'
+
+import { ContainerProvider } from '../../App/container-api'
+import { MainContainer } from '../../App/container-impl'
 import { useConfiguration } from '../../App/contexts/configuration'
 import Scan from '../../App/screens/Scan'
 
@@ -21,6 +25,9 @@ jest.mock('react-native-orientation-locker', () => {
 jest.mock('../../App/contexts/configuration', () => ({
   useConfiguration: jest.fn(),
 }))
+jest.mock('@hyperledger/anoncreds-react-native', () => ({}))
+jest.mock('@hyperledger/aries-askar-react-native', () => ({}))
+jest.mock('@hyperledger/indy-vdr-react-native', () => ({}))
 
 describe('Scan Screen', () => {
   beforeEach(() => {
@@ -30,7 +37,12 @@ describe('Scan Screen', () => {
   })
 
   test('Renders correctly', async () => {
-    const tree = render(<Scan navigation={useNavigation()} route={{} as any} />)
+    const main = new MainContainer(container.createChildContainer()).init()
+    const tree = render(
+      <ContainerProvider value={main}>
+        <Scan navigation={useNavigation()} route={{} as any} />
+      </ContainerProvider>
+    )
     await waitFor(
       () => {
         expect(tree).toMatchSnapshot()

--- a/packages/legacy/core/__tests__/screens/Terms.test.tsx
+++ b/packages/legacy/core/__tests__/screens/Terms.test.tsx
@@ -1,15 +1,15 @@
 import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
+import { container } from 'tsyringe'
 
-import Terms from '../../App/screens/Terms'
-import { testIdWithKey } from '../../App/utils/testable'
 import { ContainerProvider } from '../../App/container-api'
 import { MainContainer } from '../../App/container-impl'
-import { container } from 'tsyringe'
-import { StoreProvider, defaultState } from '../../App/contexts/store'
 import { AuthContext } from '../../App/contexts/auth'
-import authContext from '../contexts/auth'
 import { ConfigurationContext } from '../../App/contexts/configuration'
+import { StoreProvider, defaultState } from '../../App/contexts/store'
+import Terms from '../../App/screens/Terms'
+import { testIdWithKey } from '../../App/utils/testable'
+import authContext from '../contexts/auth'
 import configurationContext from '../contexts/configuration'
 
 jest.mock('@react-navigation/core', () => {
@@ -23,30 +23,37 @@ jest.mock('@hyperledger/anoncreds-react-native', () => ({}))
 jest.mock('@hyperledger/aries-askar-react-native', () => ({}))
 jest.mock('@hyperledger/indy-vdr-react-native', () => ({}))
 
-
 describe('Terms Screen', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
   test('Renders correctly', async () => {
     const main = new MainContainer(container.createChildContainer()).init()
-    const tree = render(<ContainerProvider value={main}>
-              <StoreProvider
+    const tree = render(
+      <ContainerProvider value={main}>
+        <StoreProvider
           initialState={{
             ...defaultState,
           }}
         >
           <ConfigurationContext.Provider value={configurationContext}>
-          <AuthContext.Provider value={authContext}>
-      <Terms />
-      </AuthContext.Provider>
-      </ConfigurationContext.Provider></StoreProvider></ContainerProvider>)
+            <AuthContext.Provider value={authContext}>
+              <Terms />
+            </AuthContext.Provider>
+          </ConfigurationContext.Provider>
+        </StoreProvider>
+      </ContainerProvider>
+    )
     expect(tree).toMatchSnapshot()
   })
 
   test('Button enabled by checkbox being checked', async () => {
     const main = new MainContainer(container.createChildContainer()).init()
-    const tree = render(<ContainerProvider value={main}><Terms /></ContainerProvider>)
+    const tree = render(
+      <ContainerProvider value={main}>
+        <Terms />
+      </ContainerProvider>
+    )
     const { getByTestId } = tree
     const checkbox = getByTestId(testIdWithKey('IAgree'))
     fireEvent(checkbox, 'press')


### PR DESCRIPTION
# Summary of Changes

There was an unnecessary second attempt at fetching from a scanned / deeplinked URI as if it was a redirect URL. The built in Credo methods already attempt to do that [here.](https://github.com/openwallet-foundation/credo-ts/blob/a648af507c05110f6d15f6737e2c750247d11f61/packages/core/src/utils/parseInvitation.ts#L159-L160) This change removes that second attempt and adds more logging to help troubleshoot future issues. It also makes the sole difference in handling between scan and deeplink that deeplinks will fail silently (but still log) if there are no valid query params available in the URI whereas scanning will throw and show an invalid QR code error. 

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [ ] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
