### PR TITLE
chore: bump minor version and temporarily do from-package publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,8 +34,8 @@ jobs:
         run: |
           git update-index --assume-unchanged $(find . -type d -name node_modules -prune -o -name 'package.json' -print | tr "\n" " ")
           #export NEXT_VERSION_BUMP=$(yarn next-version-bump)
-          export NEXT_VERSION_BUMP="major"
-          npx lerna publish --no-private --loglevel=silly --canary $NEXT_VERSION_BUMP --dist-tag $NPM_TAG --force-publish --yes
+          export NEXT_VERSION_BUMP="minor"
+          npx lerna publish from-package --no-private --loglevel=silly --canary $NEXT_VERSION_BUMP --dist-tag $NPM_TAG --force-publish --yes
         env:
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH }}

--- a/lerna.json
+++ b/lerna.json
@@ -9,5 +9,5 @@
   ],
   "useWorkspaces": true,
   "npmClient": "yarn",
-  "version": "1.0.0"
+  "version": "1.1.0"
 }

--- a/packages/legacy/app/package.json
+++ b/packages/legacy/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aries-bifold-app",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "description": "Aries Bifold Wallet App",
   "scripts": {
@@ -33,8 +33,8 @@
     "@formatjs/intl-relativetimeformat": "9.3.1",
     "@hyperledger/anoncreds-react-native": "0.2.2",
     "@hyperledger/aries-askar-react-native": "0.2.1",
-    "@hyperledger/aries-bifold-core": "^1.0.0",
-    "@hyperledger/aries-oca": "^1.0.0",
+    "@hyperledger/aries-bifold-core": "^1.1.0",
+    "@hyperledger/aries-oca": "^1.1.0",
     "@hyperledger/indy-vdr-react-native": "0.2.2",
     "@react-native-async-storage/async-storage": "1.15.11",
     "@react-native-community/masked-view": "0.1.11",

--- a/packages/legacy/core/package.json
+++ b/packages/legacy/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/aries-bifold-core",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
   "react-native": "App/index.ts",
@@ -58,8 +58,8 @@
     "@formatjs/intl-relativetimeformat": "9.3.1",
     "@hyperledger/anoncreds-react-native": "0.2.2",
     "@hyperledger/aries-askar-react-native": "0.2.1",
-    "@hyperledger/aries-bifold-verifier": "^1.0.0",
-    "@hyperledger/aries-oca": "^1.0.0",
+    "@hyperledger/aries-bifold-verifier": "^1.1.0",
+    "@hyperledger/aries-oca": "^1.1.0",
     "@hyperledger/indy-vdr-react-native": "0.2.2",
     "@react-native-async-storage/async-storage": "1.15.11",
     "@react-native-community/eslint-config": "^3.2.0",

--- a/packages/oca/package.json
+++ b/packages/oca/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/aries-oca",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "TypeScript implementation of Overlay Capture Architecture (OCA) for styling Aries Verifiable Credentials",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/react-native-attestation/package.json
+++ b/packages/react-native-attestation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/aries-react-native-attestation",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Mobile app attestation",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/packages/remote-logs/package.json
+++ b/packages/remote-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/aries-bifold-remote-logs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Remote logging for credo-ts agents",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/verifier/package.json
+++ b/packages/verifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/aries-bifold-verifier",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "build/commonjs/index.js",
   "types": "build/typescript/index.d.ts",
   "module": "build/module/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4422,7 +4422,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperledger/aries-bifold-core@^1.0.0, @hyperledger/aries-bifold-core@workspace:packages/legacy/core":
+"@hyperledger/aries-bifold-core@^1.1.0, @hyperledger/aries-bifold-core@workspace:packages/legacy/core":
   version: 0.0.0-use.local
   resolution: "@hyperledger/aries-bifold-core@workspace:packages/legacy/core"
   dependencies:
@@ -4448,8 +4448,8 @@ __metadata:
     "@formatjs/intl-relativetimeformat": 9.3.1
     "@hyperledger/anoncreds-react-native": 0.2.2
     "@hyperledger/aries-askar-react-native": 0.2.1
-    "@hyperledger/aries-bifold-verifier": ^1.0.0
-    "@hyperledger/aries-oca": ^1.0.0
+    "@hyperledger/aries-bifold-verifier": ^1.1.0
+    "@hyperledger/aries-oca": ^1.1.0
     "@hyperledger/indy-vdr-react-native": 0.2.2
     "@react-native-async-storage/async-storage": 1.15.11
     "@react-native-community/eslint-config": ^3.2.0
@@ -4632,7 +4632,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperledger/aries-bifold-verifier@^1.0.0, @hyperledger/aries-bifold-verifier@workspace:packages/verifier":
+"@hyperledger/aries-bifold-verifier@^1.1.0, @hyperledger/aries-bifold-verifier@workspace:packages/verifier":
   version: 0.0.0-use.local
   resolution: "@hyperledger/aries-bifold-verifier@workspace:packages/verifier"
   dependencies:
@@ -4660,7 +4660,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperledger/aries-oca@^1.0.0, @hyperledger/aries-oca@workspace:packages/oca":
+"@hyperledger/aries-oca@^1.1.0, @hyperledger/aries-oca@workspace:packages/oca":
   version: 0.0.0-use.local
   resolution: "@hyperledger/aries-oca@workspace:packages/oca"
   dependencies:
@@ -8310,8 +8310,8 @@ __metadata:
     "@formatjs/intl-relativetimeformat": 9.3.1
     "@hyperledger/anoncreds-react-native": 0.2.2
     "@hyperledger/aries-askar-react-native": 0.2.1
-    "@hyperledger/aries-bifold-core": ^1.0.0
-    "@hyperledger/aries-oca": ^1.0.0
+    "@hyperledger/aries-bifold-core": ^1.1.0
+    "@hyperledger/aries-oca": ^1.1.0
     "@hyperledger/indy-vdr-react-native": 0.2.2
     "@react-native-async-storage/async-storage": 1.15.11
     "@react-native-community/masked-view": 0.1.11


### PR DESCRIPTION
# Summary of Changes

Because our packages got out of sync after failing to publish, we need to bump the version to ensure they are all back on the same release. I'm also doing a single run with the `from-package` option to ensure Lerna goes off of the package.json version (`1.1.0`) not the tag/npm version (`1.0.0-alpha.xxx`)

NOTE: **Please don't merge any other PRs until after the `from-package` option has been removed** 

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
