### PR TITLE
feat: getting oob label for connectionless proof

### DIFF
--- a/packages/legacy/core/App/hooks/oob.ts
+++ b/packages/legacy/core/App/hooks/oob.ts
@@ -1,0 +1,16 @@
+import { OutOfBandRecord } from '@credo-ts/core'
+import { useAgent } from '@credo-ts/react-hooks'
+import { useState } from 'react'
+
+export const useOutOfBandByReceivedInvitationId = (receivedInvitationId: string): OutOfBandRecord | undefined => {
+  const { agent } = useAgent()
+  const [oob, setOob] = useState<OutOfBandRecord | undefined>(undefined)
+  if (!oob) {
+    agent?.oob.findByReceivedInvitationId(receivedInvitationId).then((res) => {
+      if (res) {
+        setOob(res)
+      }
+    })
+  }
+  return oob
+}

--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -33,6 +33,7 @@ import { useStore } from '../contexts/store'
 import { useTheme } from '../contexts/theme'
 import { useTour } from '../contexts/tour/tour-context'
 import { useOutOfBandByConnectionId } from '../hooks/connections'
+import { useOutOfBandByReceivedInvitationId } from '../hooks/oob'
 import { useAllCredentialsForProof } from '../hooks/proofs'
 import { BifoldError } from '../types/error'
 import { NotificationStackParams, Screens, Stacks, TabStacks } from '../types/navigators'
@@ -69,6 +70,9 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
   const { ColorPallet, ListItems, TextTheme } = useTheme()
   const { RecordLoading } = useAnimatedComponents()
   const goalCode = useOutOfBandByConnectionId(proof?.connectionId ?? '')?.outOfBandInvitation.goalCode
+  const outOfBandInvitation = proof?.parentThreadId
+    ? useOutOfBandByReceivedInvitationId(proof?.parentThreadId)?.outOfBandInvitation
+    : undefined
   const { enableTours: enableToursConfig, useAttestation } = useConfiguration()
   const [containsPI, setContainsPI] = useState(false)
   const [activeCreds, setActiveCreds] = useState<ProofCredentialItems[]>([])
@@ -475,12 +479,16 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
 
                   <Text style={styles.headerText} testID={testIdWithKey('HeaderText')}>
                     {t('ProofRequest.YouDoNotHaveDataPredicate')}{' '}
-                    <Text style={[TextTheme.title]}>{proofConnectionLabel || t('ContactDetails.AContact')}</Text>
+                    <Text style={[TextTheme.title]}>
+                      {proofConnectionLabel || outOfBandInvitation?.label || t('ContactDetails.AContact')}
+                    </Text>
                   </Text>
                 </View>
               ) : (
                 <Text style={styles.headerText} testID={testIdWithKey('HeaderText')}>
-                  <Text style={[TextTheme.title]}>{proofConnectionLabel || t('ContactDetails.AContact')}</Text>{' '}
+                  <Text style={[TextTheme.title]}>
+                    {proofConnectionLabel || outOfBandInvitation?.label || t('ContactDetails.AContact')}
+                  </Text>{' '}
                   <Text>{t('ProofRequest.IsRequestingYouToShare')}</Text>
                   <Text style={[TextTheme.title]}>{` ${activeCreds?.length} `}</Text>
                   <Text>{activeCreds?.length > 1 ? t('ProofRequest.Credentials') : t('ProofRequest.Credential')}</Text>

--- a/packages/legacy/core/App/utils/cred-def.ts
+++ b/packages/legacy/core/App/utils/cred-def.ts
@@ -13,6 +13,8 @@ export function parseCredDefFromId(credDefId?: string, schemaId?: string): strin
     if (schemaId) {
       const parseIndySchema = parseIndySchemaId(schemaId)
       name = parseIndySchema.schemaName
+    } else {
+      name = 'Credential'
     }
   }
   return name


### PR DESCRIPTION
# Summary of Changes

### Expected behavior
It should have the verifier's name in connectionless proof 

### Current behavior
"A contact" is displayed as name

### To fix
I added `useOutOfBandByReceivedInvitationId` hooks to get `oobLabel` on ProofRequest screen

Before
![Screenshot_20240617_161720_Aries Bifold](https://github.com/openwallet-foundation/bifold-wallet/assets/97122568/afbdffd5-3737-48d2-89d4-75849204deb9)


After
![Screenshot_20240617_161732_Aries Bifold](https://github.com/openwallet-foundation/bifold-wallet/assets/97122568/1c8e96bf-ea4d-4ac8-b727-8a88e77d5780)

### Observation
For the cred_def, I added a else to prevent it from returning "default" when `schemaId` is undefined 

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [X] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [X] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [X] Updated documentation as needed for changed code and new or modified features;
- [X] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
