### PR TITLE
fix: detect links in chat regardless of case

### DIFF
--- a/packages/legacy/core/App/hooks/chat-messages.tsx
+++ b/packages/legacy/core/App/hooks/chat-messages.tsx
@@ -90,9 +90,9 @@ export const useChatMessagesByConnection = (connection: ConnectionRecord): Exten
     const transformedMessages: Array<ExtendedChatMessage> = basicMessages.map((record: BasicMessageRecord) => {
       const role = getMessageEventRole(record)
       // eslint-disable-next-line
-      const linkRegex = /(?:https?\:\/\/\w+(?:\.\w+)+\S*)|(?:[\w\d\.\_\-]+@\w+(?:\.\w+)+)/gm
+      const linkRegex = /(?:https?\:\/\/\w+(?:\.\w+)+\S*)|(?:[\w\d\.\_\-]+@\w+(?:\.\w+)+)/gmi
       // eslint-disable-next-line
-      const mailRegex = /^[\w\d\.\_\-]+@\w+(?:\.\w+)+$/gm
+      const mailRegex = /^[\w\d\.\_\-]+@\w+(?:\.\w+)+$/gmi
       const links = record.content.match(linkRegex) ?? []
       const handleLinkPress = (link: string) => {
         if (link.match(mailRegex)) {


### PR DESCRIPTION
# Summary of Changes

Previously the link detection logic in the chat was case sensitive, I've changed it to be case insensitive so things like `HtTPs://gOogle.Com` will still be detected as a link

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
