### PR TITLE
fix: show correct messaging when entire credential is missing vs predicate

### DIFF
--- a/packages/legacy/core/App/components/misc/CredentialCard11.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard11.tsx
@@ -430,10 +430,15 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
                   size={ListItems.recordAttributeText.fontSize}
                 />
               )}
-              <AttributeValue warn={flaggedAttributes?.includes(label) && !item.pValue && proof} value={parsedValue} />
+              {!error ? (
+                <AttributeValue
+                  warn={flaggedAttributes?.includes(label) && !item.pValue && proof}
+                  value={parsedValue}
+                />
+              ) : null}
             </View>
           )}
-          {item?.satisfied != undefined && item?.satisfied === false ? (
+          {!error && item?.satisfied != undefined && item?.satisfied === false ? (
             <Text style={[styles.errorText]} numberOfLines={1}>
               {t('ProofRequest.PredicateNotSatisfied')}
             </Text>

--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -461,7 +461,7 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
           <>
             <ConnectionImage connectionId={proof?.connectionId} />
             <View style={styles.headerTextContainer}>
-              {!hasSatisfiedPredicates(getCredentialsFields()) ? (
+              {hasAvailableCredentials && !hasSatisfiedPredicates(getCredentialsFields()) ? (
                 <View style={{ flexDirection: 'row', alignItems: 'center' }}>
                   <Icon
                     style={{ marginLeft: -2, marginRight: 10 }}

--- a/packages/legacy/core/__tests__/screens/ProofRequest.test.tsx
+++ b/packages/legacy/core/__tests__/screens/ProofRequest.test.tsx
@@ -15,7 +15,6 @@ import '@testing-library/jest-native/extend-expect'
 import { cleanup, fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
 
-import { useTranslation } from 'react-i18next'
 import { ConfigurationContext } from '../../App/contexts/configuration'
 import { NetworkContext, NetworkProvider } from '../../App/contexts/network'
 import ProofRequest from '../../App/screens/ProofRequest'
@@ -66,8 +65,6 @@ describe('displays a proof request screen', () => {
     const testEmail = 'test@email.com'
     const testTime = '2022-02-11 20:00:18.180718'
     const testAge = '16'
-
-    const { t } = useTranslation()
 
     const { id: credentialId } = new CredentialExchangeRecord({
       role: CredentialRole.Holder,

--- a/packages/legacy/core/__tests__/screens/W3cProofRequest.test.tsx
+++ b/packages/legacy/core/__tests__/screens/W3cProofRequest.test.tsx
@@ -1,4 +1,4 @@
-import { getCredentialsForAnonCredsProofRequest } from '@credo-ts/anoncreds'
+import { AnonCredsCredentialsForProofRequest, getCredentialsForAnonCredsProofRequest } from '@credo-ts/anoncreds'
 import {
   ClaimFormat,
   CredentialExchangeRecord,
@@ -15,8 +15,6 @@ import '@testing-library/jest-native/extend-expect'
 import { cleanup, fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
 
-import { AnonCredsCredentialsForProofRequest } from '@credo-ts/anoncreds'
-import { useTranslation } from 'react-i18next'
 import { ConfigurationContext } from '../../App/contexts/configuration'
 import { NetworkContext, NetworkProvider } from '../../App/contexts/network'
 import ProofRequest from '../../App/screens/ProofRequest'
@@ -24,6 +22,7 @@ import { testIdWithKey } from '../../App/utils/testable'
 import configurationContext from '../contexts/configuration'
 import networkContext from '../contexts/network'
 import timeTravel from '../helpers/timetravel'
+
 import {
   anonCredsCredentialsForProofRequest,
   difPexCredentialsForRequest,
@@ -80,8 +79,6 @@ describe('displays a proof request screen', () => {
     const testEmail = 'test@email.com'
     const testTime = '2022-02-11 20:00:18.180718'
     const testAge = '16'
-
-    const { t } = useTranslation()
 
     const { id: credentialId } = new CredentialExchangeRecord({
       id: '8eba4449-8a85-4954-b11c-e0590f39cbdb',
@@ -472,9 +469,6 @@ describe('displays a proof request screen', () => {
       })
 
       // @ts-ignore-next-line
-      getCredentialsForAnonCredsProofRequest.mockResolvedValue(anonCredsCredentialsForProofRequest)
-
-      // @ts-ignore-next-line
       getCredentialsForAnonCredsProofRequest.mockResolvedValue({
         attributes: anonCredsCredentialsForProofRequest.attributes,
         predicates: {
@@ -492,7 +486,7 @@ describe('displays a proof request screen', () => {
         },
       })
 
-      const { getByText, getByTestId } = render(
+      const tree = render(
         <ConfigurationContext.Provider value={configurationContext}>
           <NetworkContext.Provider value={networkContext}>
             <ProofRequest navigation={useNavigation()} route={{ params: { proofId: testProofRequest.id } } as any} />
@@ -504,28 +498,7 @@ describe('displays a proof request screen', () => {
         timeTravel(1000)
       })
 
-      const predicateMessage = getByText('ProofRequest.YouDoNotHaveDataPredicate', { exact: false })
-      const contact = getByText('ContactDetails.AContact', { exact: false })
-      const emailLabel = getByText(/Email/, { exact: false })
-      const emailValue = getByText(testEmail)
-      const ageLabel = getByText(/Age/, { exact: false })
-      const ageNotSatisfied = getByText('ProofRequest.PredicateNotSatisfied', { exact: false })
-      const cancelButton = getByTestId(testIdWithKey('Cancel'))
-
-      expect(predicateMessage).not.toBeNull()
-      expect(predicateMessage).toBeTruthy()
-      expect(contact).not.toBeNull()
-      expect(contact).toBeTruthy()
-      expect(emailLabel).not.toBeNull()
-      expect(emailLabel).toBeTruthy()
-      expect(emailValue).not.toBeNull()
-      expect(emailValue).toBeTruthy()
-      expect(ageLabel).not.toBeNull()
-      expect(ageLabel).toBeTruthy()
-      expect(ageNotSatisfied).not.toBeNull()
-      expect(ageNotSatisfied).toBeTruthy()
-      expect(cancelButton).not.toBeNull()
-      expect(cancelButton).not.toBeDisabled()
+      expect(tree).toMatchSnapshot()
     })
   })
 })

--- a/packages/legacy/core/__tests__/screens/__snapshots__/W3cProofRequest.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/W3cProofRequest.test.tsx.snap
@@ -1,0 +1,1377 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`displays a proof request screen with a proof request displays a proof request with one or more predicates not satisfied 1`] = `
+<RNCSafeAreaView
+  edges={
+    Array [
+      "bottom",
+      "left",
+      "right",
+    ]
+  }
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <RCTScrollView>
+    <View>
+      <View
+        style={
+          Object {
+            "flexGrow": 1,
+            "justifyContent": "space-between",
+          }
+        }
+      >
+        <RCTScrollView
+          ListHeaderComponent={
+            <View
+              style={
+                Object {
+                  "marginHorizontal": 20,
+                }
+              }
+            >
+              <React.Fragment>
+                <ConnectionImage
+                  connectionId=""
+                />
+                <View
+                  style={
+                    Object {
+                      "paddingVertical": 16,
+                    }
+                  }
+                >
+                  <Text
+                    style={
+                      Object {
+                        "color": "#FFFFFF",
+                        "flexShrink": 1,
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      }
+                    }
+                    testID="com.ariesbifold:id/HeaderText"
+                  >
+                    <Text
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 20,
+                            "fontWeight": "bold",
+                          },
+                        ]
+                      }
+                    >
+                      ContactDetails.AContact
+                    </Text>
+                     
+                    <Text>
+                      ProofRequest.IsRequestingYouToShare
+                    </Text>
+                    <Text
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 20,
+                            "fontWeight": "bold",
+                          },
+                        ]
+                      }
+                    >
+                       2 
+                    </Text>
+                    <Text>
+                      ProofRequest.Credentials
+                    </Text>
+                  </Text>
+                </View>
+                <Text
+                  style={
+                    Object {
+                      "color": "#FFFFFF",
+                      "fontSize": 20,
+                      "fontWeight": "bold",
+                    }
+                  }
+                >
+                  ProofRequest.FromYourWallet
+                </Text>
+              </React.Fragment>
+            </View>
+          }
+          data={
+            Array [
+              Object {
+                "altCredentials": Array [
+                  "8eba4449-8a85-4954-b11c-e0590f39cbdb",
+                ],
+                "attributes": Array [
+                  Attribute {
+                    "credentialId": "8eba4449-8a85-4954-b11c-e0590f39cbdb",
+                    "encoding": undefined,
+                    "format": undefined,
+                    "label": undefined,
+                    "mimeType": undefined,
+                    "name": "email",
+                    "nonRevoked": undefined,
+                    "restrictions": Array [
+                      Object {
+                        "cred_def_id": "did:indy:bcovrin:test:TfuPA6whW681GfU6fj1e3k/anoncreds/v0/CLAIM_DEF/462230/latest",
+                        "schema_id": "did:indy:bcovrin:test:TfuPA6whW681GfU6fj1e3k/anoncreds/v0/SCHEMA/Identity Schemaaf92af92-524d-41b6-bee8-00fb45e8eb6c/1.0.0",
+                      },
+                    ],
+                    "revealed": undefined,
+                    "revoked": false,
+                    "type": undefined,
+                    "value": "test@email.com",
+                  },
+                  Attribute {
+                    "credentialId": "8eba4449-8a85-4954-b11c-e0590f39cbdb",
+                    "encoding": undefined,
+                    "format": undefined,
+                    "label": undefined,
+                    "mimeType": undefined,
+                    "name": "time",
+                    "nonRevoked": undefined,
+                    "restrictions": Array [
+                      Object {
+                        "cred_def_id": "did:indy:bcovrin:test:TfuPA6whW681GfU6fj1e3k/anoncreds/v0/CLAIM_DEF/462230/latest",
+                        "schema_id": "did:indy:bcovrin:test:TfuPA6whW681GfU6fj1e3k/anoncreds/v0/SCHEMA/Identity Schemaaf92af92-524d-41b6-bee8-00fb45e8eb6c/1.0.0",
+                      },
+                    ],
+                    "revealed": undefined,
+                    "revoked": false,
+                    "type": undefined,
+                    "value": "2022-02-11 20:00:18.180718",
+                  },
+                ],
+                "credDefId": "did:indy:bcovrin:test:TfuPA6whW681GfU6fj1e3k/anoncreds/v0/CLAIM_DEF/462230/latest",
+                "credExchangeRecord": undefined,
+                "credId": "8eba4449-8a85-4954-b11c-e0590f39cbdb",
+                "credName": "latest",
+                "proofCredDefId": "did:indy:bcovrin:test:TfuPA6whW681GfU6fj1e3k/anoncreds/v0/CLAIM_DEF/462230/latest",
+                "proofSchemaId": "did:indy:bcovrin:test:TfuPA6whW681GfU6fj1e3k/anoncreds/v0/SCHEMA/Identity Schemaaf92af92-524d-41b6-bee8-00fb45e8eb6c/1.0.0",
+                "schemaId": "did:indy:bcovrin:test:TfuPA6whW681GfU6fj1e3k/anoncreds/v0/SCHEMA/Identity Schemaaf92af92-524d-41b6-bee8-00fb45e8eb6c/1.0.0",
+              },
+            ]
+          }
+          getItem={[Function]}
+          getItemCount={[Function]}
+          keyExtractor={[Function]}
+          onContentSizeChange={[Function]}
+          onLayout={[Function]}
+          onMomentumScrollBegin={[Function]}
+          onMomentumScrollEnd={[Function]}
+          onScroll={[Function]}
+          onScrollBeginDrag={[Function]}
+          onScrollEndDrag={[Function]}
+          removeClippedSubviews={false}
+          renderItem={[Function]}
+          scrollEnabled={false}
+          scrollEventThrottle={50}
+          stickyHeaderIndices={Array []}
+          viewabilityConfigCallbackPairs={Array []}
+        >
+          <View>
+            <View
+              collapsable={false}
+              onLayout={[Function]}
+            >
+              <View
+                style={
+                  Object {
+                    "marginHorizontal": 20,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "paddingVertical": 16,
+                    }
+                  }
+                >
+                  <Text
+                    style={
+                      Object {
+                        "color": "#FFFFFF",
+                        "flexShrink": 1,
+                        "fontSize": 18,
+                        "fontWeight": "normal",
+                      }
+                    }
+                    testID="com.ariesbifold:id/HeaderText"
+                  >
+                    <Text
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 20,
+                            "fontWeight": "bold",
+                          },
+                        ]
+                      }
+                    >
+                      ContactDetails.AContact
+                    </Text>
+                     
+                    <Text>
+                      ProofRequest.IsRequestingYouToShare
+                    </Text>
+                    <Text
+                      style={
+                        Array [
+                          Object {
+                            "color": "#FFFFFF",
+                            "fontSize": 20,
+                            "fontWeight": "bold",
+                          },
+                        ]
+                      }
+                    >
+                       2 
+                    </Text>
+                    <Text>
+                      ProofRequest.Credentials
+                    </Text>
+                  </Text>
+                </View>
+                <Text
+                  style={
+                    Object {
+                      "color": "#FFFFFF",
+                      "fontSize": 20,
+                      "fontWeight": "bold",
+                    }
+                  }
+                >
+                  ProofRequest.FromYourWallet
+                </Text>
+              </View>
+            </View>
+            <View
+              onFocusCapture={[Function]}
+              onLayout={[Function]}
+              style={null}
+            >
+              <View>
+                <View
+                  style={
+                    Object {
+                      "marginHorizontal": 20,
+                      "marginTop": 10,
+                    }
+                  }
+                >
+                  <View
+                    onLayout={[Function]}
+                    style={
+                      Array [
+                        Object {
+                          "backgroundColor": "#5f0f7b",
+                          "borderRadius": 10,
+                        },
+                        Object {
+                          "backgroundColor": "#313132",
+                        },
+                        Object {
+                          "elevation": 5,
+                          "overflow": "hidden",
+                        },
+                        undefined,
+                      ]
+                    }
+                  >
+                    <RNGestureHandlerButton
+                      collapsable={false}
+                      onGestureEvent={[Function]}
+                      onGestureHandlerEvent={[Function]}
+                      onGestureHandlerStateChange={[Function]}
+                      onHandlerStateChange={[Function]}
+                      rippleColor={0}
+                      testID="com.ariesbifold:id/ShowCredentialDetails"
+                    >
+                      <View
+                        accessible={false}
+                        collapsable={false}
+                        style={
+                          Object {
+                            "backgroundColor": "#313132",
+                            "borderRadius": 10,
+                            "opacity": 1,
+                          }
+                        }
+                      >
+                        <View
+                          testID="com.ariesbifold:id/CredentialCard"
+                        >
+                          <View
+                            accessibilityLabel="Credentials.IssuedBy Unknown Contact,  Latest Credentials.Credential. email, test@email.com, time, 2022-02-11 20:00:18.180718,,"
+                            accessible={true}
+                            style={
+                              Object {
+                                "flexDirection": "row",
+                                "minHeight": 247.5,
+                              }
+                            }
+                          >
+                            <View
+                              style={
+                                Array [
+                                  Object {
+                                    "backgroundColor": "#5f0f7b",
+                                    "borderBottomLeftRadius": 10,
+                                    "borderTopLeftRadius": 10,
+                                    "width": 90,
+                                  },
+                                  Object {
+                                    "backgroundColor": "#5f0f7b",
+                                    "overflow": "hidden",
+                                  },
+                                ]
+                              }
+                              testID="com.ariesbifold:id/CredentialCardSecondaryBody"
+                            />
+                            <View
+                              style={
+                                Array [
+                                  Object {
+                                    "alignItems": "center",
+                                    "backgroundColor": "#ffffff",
+                                    "borderRadius": 8,
+                                    "height": 90,
+                                    "justifyContent": "center",
+                                    "left": -52.5,
+                                    "shadowColor": "#000",
+                                    "shadowOffset": Object {
+                                      "height": 1,
+                                      "width": 1,
+                                    },
+                                    "shadowOpacity": 0.3,
+                                    "top": 37.5,
+                                    "width": 90,
+                                  },
+                                  Object {
+                                    "elevation": 5,
+                                  },
+                                ]
+                              }
+                            >
+                              <Text
+                                style={
+                                  Array [
+                                    Object {
+                                      "color": "#FFFFFF",
+                                      "fontSize": 18,
+                                      "fontWeight": "bold",
+                                    },
+                                    Object {
+                                      "alignSelf": "center",
+                                      "color": "#000",
+                                      "fontSize": 45,
+                                    },
+                                  ]
+                                }
+                              >
+                                L
+                              </Text>
+                            </View>
+                            <View
+                              style={
+                                Object {
+                                  "flex": 1,
+                                  "marginLeft": -52.5,
+                                  "padding": 37.5,
+                                }
+                              }
+                              testID="com.ariesbifold:id/CredentialCardPrimaryBody"
+                            >
+                              <View>
+                                <View
+                                  style={
+                                    Object {
+                                      "flexDirection": "row",
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    style={
+                                      Array [
+                                        Object {
+                                          "color": "#FFFFFF",
+                                          "fontSize": 18,
+                                          "fontWeight": "bold",
+                                        },
+                                        Object {
+                                          "color": "#FFFFFF",
+                                          "flexShrink": 1,
+                                        },
+                                        Object {
+                                          "color": "#FFFFFF",
+                                          "flex": 1,
+                                          "flexWrap": "wrap",
+                                          "lineHeight": 24,
+                                        },
+                                      ]
+                                    }
+                                    testID="com.ariesbifold:id/CredentialName"
+                                  >
+                                    Latest
+                                  </Text>
+                                </View>
+                              </View>
+                              <View
+                                ListFooterComponent={null}
+                                data={
+                                  Array [
+                                    Attribute {
+                                      "credentialId": "8eba4449-8a85-4954-b11c-e0590f39cbdb",
+                                      "encoding": undefined,
+                                      "format": undefined,
+                                      "label": undefined,
+                                      "mimeType": undefined,
+                                      "name": "email",
+                                      "nonRevoked": undefined,
+                                      "restrictions": Array [
+                                        Object {
+                                          "cred_def_id": "did:indy:bcovrin:test:TfuPA6whW681GfU6fj1e3k/anoncreds/v0/CLAIM_DEF/462230/latest",
+                                          "schema_id": "did:indy:bcovrin:test:TfuPA6whW681GfU6fj1e3k/anoncreds/v0/SCHEMA/Identity Schemaaf92af92-524d-41b6-bee8-00fb45e8eb6c/1.0.0",
+                                        },
+                                      ],
+                                      "revealed": undefined,
+                                      "revoked": false,
+                                      "type": undefined,
+                                      "value": "test@email.com",
+                                    },
+                                    Attribute {
+                                      "credentialId": "8eba4449-8a85-4954-b11c-e0590f39cbdb",
+                                      "encoding": undefined,
+                                      "format": undefined,
+                                      "label": undefined,
+                                      "mimeType": undefined,
+                                      "name": "time",
+                                      "nonRevoked": undefined,
+                                      "restrictions": Array [
+                                        Object {
+                                          "cred_def_id": "did:indy:bcovrin:test:TfuPA6whW681GfU6fj1e3k/anoncreds/v0/CLAIM_DEF/462230/latest",
+                                          "schema_id": "did:indy:bcovrin:test:TfuPA6whW681GfU6fj1e3k/anoncreds/v0/SCHEMA/Identity Schemaaf92af92-524d-41b6-bee8-00fb45e8eb6c/1.0.0",
+                                        },
+                                      ],
+                                      "revealed": undefined,
+                                      "revoked": false,
+                                      "type": undefined,
+                                      "value": "2022-02-11 20:00:18.180718",
+                                    },
+                                    undefined,
+                                    undefined,
+                                  ]
+                                }
+                                getItem={[Function]}
+                                getItemCount={[Function]}
+                                initialNumToRender={4}
+                                keyExtractor={[Function]}
+                                onContentSizeChange={[Function]}
+                                onLayout={[Function]}
+                                onMomentumScrollBegin={[Function]}
+                                onMomentumScrollEnd={[Function]}
+                                onScroll={[Function]}
+                                onScrollBeginDrag={[Function]}
+                                onScrollEndDrag={[Function]}
+                                removeClippedSubviews={false}
+                                renderItem={[Function]}
+                                scrollEnabled={false}
+                                scrollEventThrottle={50}
+                                stickyHeaderIndices={Array []}
+                                viewabilityConfigCallbackPairs={Array []}
+                              >
+                                <View
+                                  onFocusCapture={[Function]}
+                                  onLayout={[Function]}
+                                  style={null}
+                                >
+                                  <View
+                                    style={
+                                      Object {
+                                        "marginTop": 15,
+                                      }
+                                    }
+                                  >
+                                    <Text
+                                      style={
+                                        Array [
+                                          Object {
+                                            "color": "#FFFFFF",
+                                            "fontSize": 14,
+                                            "fontWeight": "normal",
+                                          },
+                                          Object {
+                                            "color": "#FFFFFF",
+                                            "flexShrink": 1,
+                                          },
+                                          Object {
+                                            "lineHeight": 19,
+                                            "opacity": 0.8,
+                                          },
+                                        ]
+                                      }
+                                      testID="com.ariesbifold:id/AttributeName"
+                                    >
+                                      Email
+                                    </Text>
+                                    <View
+                                      style={
+                                        Object {
+                                          "alignItems": "center",
+                                          "flexDirection": "row",
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        style={
+                                          Array [
+                                            Object {
+                                              "color": "#FFFFFF",
+                                              "fontSize": 18,
+                                              "fontWeight": "bold",
+                                            },
+                                            Object {
+                                              "color": "#FFFFFF",
+                                              "flexShrink": 1,
+                                            },
+                                            Object {
+                                              "lineHeight": 24,
+                                            },
+                                            Object {
+                                              "color": "#FFFFFF",
+                                            },
+                                          ]
+                                        }
+                                        testID="com.ariesbifold:id/AttributeValue"
+                                      >
+                                        test@email.com
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                                <View
+                                  onFocusCapture={[Function]}
+                                  onLayout={[Function]}
+                                  style={null}
+                                >
+                                  <View
+                                    style={
+                                      Object {
+                                        "marginTop": 15,
+                                      }
+                                    }
+                                  >
+                                    <Text
+                                      style={
+                                        Array [
+                                          Object {
+                                            "color": "#FFFFFF",
+                                            "fontSize": 14,
+                                            "fontWeight": "normal",
+                                          },
+                                          Object {
+                                            "color": "#FFFFFF",
+                                            "flexShrink": 1,
+                                          },
+                                          Object {
+                                            "lineHeight": 19,
+                                            "opacity": 0.8,
+                                          },
+                                        ]
+                                      }
+                                      testID="com.ariesbifold:id/AttributeName"
+                                    >
+                                      Time
+                                    </Text>
+                                    <View
+                                      style={
+                                        Object {
+                                          "alignItems": "center",
+                                          "flexDirection": "row",
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        style={
+                                          Array [
+                                            Object {
+                                              "color": "#FFFFFF",
+                                              "fontSize": 18,
+                                              "fontWeight": "bold",
+                                            },
+                                            Object {
+                                              "color": "#FFFFFF",
+                                              "flexShrink": 1,
+                                            },
+                                            Object {
+                                              "lineHeight": 24,
+                                            },
+                                            Object {
+                                              "color": "#FFFFFF",
+                                            },
+                                          ]
+                                        }
+                                        testID="com.ariesbifold:id/AttributeValue"
+                                      >
+                                        2022-02-11 20:00:18.180718
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                                <View
+                                  onFocusCapture={[Function]}
+                                  onLayout={[Function]}
+                                  style={null}
+                                />
+                                <View
+                                  onFocusCapture={[Function]}
+                                  onLayout={[Function]}
+                                  style={null}
+                                />
+                              </View>
+                            </View>
+                            <View
+                              style={
+                                Array [
+                                  Object {
+                                    "alignItems": "center",
+                                    "backgroundColor": "rgba(0, 0, 0, 0)",
+                                    "borderBottomLeftRadius": 10,
+                                    "borderTopRightRadius": 10,
+                                    "height": 90,
+                                    "justifyContent": "center",
+                                    "width": 90,
+                                  },
+                                  Object {
+                                    "position": "absolute",
+                                    "right": 0,
+                                    "top": 0,
+                                  },
+                                ]
+                              }
+                              testID="com.ariesbifold:id/CredentialCardStatus"
+                            >
+                              <View
+                                style={
+                                  Array [
+                                    Object {
+                                      "alignItems": "center",
+                                      "backgroundColor": "rgba(0, 0, 0, 0)",
+                                      "borderBottomLeftRadius": 10,
+                                      "borderTopRightRadius": 10,
+                                      "height": 90,
+                                      "justifyContent": "center",
+                                      "width": 90,
+                                    },
+                                  ]
+                                }
+                              />
+                            </View>
+                          </View>
+                        </View>
+                      </View>
+                    </RNGestureHandlerButton>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </RCTScrollView>
+        <RCTScrollView
+          ListFooterComponent={
+            <View
+              style={
+                Array [
+                  Object {
+                    "marginVertical": 15,
+                  },
+                  Object {
+                    "marginHorizontal": 20,
+                  },
+                ]
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "paddingTop": 10,
+                  }
+                }
+              >
+                <ForwardRef
+                  accessibilityLabel="Global.Cancel"
+                  buttonType={1}
+                  onPress={[Function]}
+                  testID="com.ariesbifold:id/Cancel"
+                  title="Global.Cancel"
+                />
+              </View>
+            </View>
+          }
+          ListHeaderComponent={
+            <View
+              style={
+                Object {
+                  "marginHorizontal": 20,
+                }
+              }
+            >
+              <React.Fragment>
+                <View
+                  style={
+                    Object {
+                      "borderColor": "#D3D3D3",
+                      "borderWidth": 1,
+                      "marginTop": 20,
+                      "width": "auto",
+                    }
+                  }
+                />
+                <Text
+                  style={
+                    Object {
+                      "color": "#FFFFFF",
+                      "fontSize": 20,
+                      "fontWeight": "bold",
+                      "marginTop": 10,
+                    }
+                  }
+                >
+                  ProofRequest.MissingCredentials
+                </Text>
+              </React.Fragment>
+            </View>
+          }
+          data={
+            Array [
+              Object {
+                "altCredentials": Array [
+                  "Credential",
+                ],
+                "credDefId": undefined,
+                "credExchangeRecord": undefined,
+                "credId": "Credential",
+                "credName": "Credential",
+                "predicates": Array [
+                  Predicate {
+                    "credentialId": "Credential",
+                    "encoding": undefined,
+                    "format": undefined,
+                    "label": undefined,
+                    "mimeType": undefined,
+                    "name": "age",
+                    "nonRevoked": undefined,
+                    "pType": "<=",
+                    "pValue": 18,
+                    "parameterizable": undefined,
+                    "restrictions": undefined,
+                    "revoked": false,
+                    "satisfied": undefined,
+                    "type": undefined,
+                  },
+                ],
+                "proofCredDefId": "",
+                "proofSchemaId": "",
+                "schemaId": undefined,
+              },
+            ]
+          }
+          getItem={[Function]}
+          getItemCount={[Function]}
+          keyExtractor={[Function]}
+          onContentSizeChange={[Function]}
+          onLayout={[Function]}
+          onMomentumScrollBegin={[Function]}
+          onMomentumScrollEnd={[Function]}
+          onScroll={[Function]}
+          onScrollBeginDrag={[Function]}
+          onScrollEndDrag={[Function]}
+          removeClippedSubviews={false}
+          renderItem={[Function]}
+          scrollEnabled={false}
+          scrollEventThrottle={50}
+          stickyHeaderIndices={Array []}
+          viewabilityConfigCallbackPairs={Array []}
+        >
+          <View>
+            <View
+              collapsable={false}
+              onLayout={[Function]}
+            >
+              <View
+                style={
+                  Object {
+                    "marginHorizontal": 20,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "borderColor": "#D3D3D3",
+                      "borderWidth": 1,
+                      "marginTop": 20,
+                      "width": "auto",
+                    }
+                  }
+                />
+                <Text
+                  style={
+                    Object {
+                      "color": "#FFFFFF",
+                      "fontSize": 20,
+                      "fontWeight": "bold",
+                      "marginTop": 10,
+                    }
+                  }
+                >
+                  ProofRequest.MissingCredentials
+                </Text>
+              </View>
+            </View>
+            <View
+              onFocusCapture={[Function]}
+              onLayout={[Function]}
+              style={null}
+            >
+              <View>
+                <View
+                  style={
+                    Object {
+                      "marginHorizontal": 20,
+                      "marginTop": 10,
+                    }
+                  }
+                >
+                  <View
+                    onLayout={[Function]}
+                    style={
+                      Array [
+                        Object {
+                          "backgroundColor": "#781e4b",
+                          "borderRadius": 10,
+                        },
+                        Object {
+                          "backgroundColor": "#313132",
+                        },
+                        Object {
+                          "elevation": 5,
+                          "overflow": "hidden",
+                        },
+                        undefined,
+                      ]
+                    }
+                  >
+                    <RNGestureHandlerButton
+                      collapsable={false}
+                      onGestureEvent={[Function]}
+                      onGestureHandlerEvent={[Function]}
+                      onGestureHandlerStateChange={[Function]}
+                      onHandlerStateChange={[Function]}
+                      rippleColor={0}
+                      testID="com.ariesbifold:id/ShowCredentialDetails"
+                    >
+                      <View
+                        accessible={false}
+                        collapsable={false}
+                        style={
+                          Object {
+                            "backgroundColor": "#313132",
+                            "borderRadius": 10,
+                            "opacity": 1,
+                          }
+                        }
+                      >
+                        <View
+                          testID="com.ariesbifold:id/CredentialCard"
+                        >
+                          <View
+                            accessibilityLabel="Credentials.IssuedBy Unknown Contact,  Credential Credentials.Credential. age, <= 18,,"
+                            accessible={true}
+                            style={
+                              Object {
+                                "flexDirection": "row",
+                                "minHeight": 247.5,
+                              }
+                            }
+                          >
+                            <View
+                              style={
+                                Array [
+                                  Object {
+                                    "backgroundColor": "#781e4b",
+                                    "borderBottomLeftRadius": 10,
+                                    "borderTopLeftRadius": 10,
+                                    "width": 90,
+                                  },
+                                  Object {
+                                    "backgroundColor": "#D8292F",
+                                    "overflow": "hidden",
+                                  },
+                                ]
+                              }
+                              testID="com.ariesbifold:id/CredentialCardSecondaryBody"
+                            />
+                            <View
+                              style={
+                                Array [
+                                  Object {
+                                    "alignItems": "center",
+                                    "backgroundColor": "#ffffff",
+                                    "borderRadius": 8,
+                                    "height": 90,
+                                    "justifyContent": "center",
+                                    "left": -52.5,
+                                    "shadowColor": "#000",
+                                    "shadowOffset": Object {
+                                      "height": 1,
+                                      "width": 1,
+                                    },
+                                    "shadowOpacity": 0.3,
+                                    "top": 37.5,
+                                    "width": 90,
+                                  },
+                                  Object {
+                                    "elevation": 5,
+                                  },
+                                ]
+                              }
+                            >
+                              <Text
+                                style={
+                                  Array [
+                                    Object {
+                                      "color": "#FFFFFF",
+                                      "fontSize": 18,
+                                      "fontWeight": "bold",
+                                    },
+                                    Object {
+                                      "alignSelf": "center",
+                                      "color": "#000",
+                                      "fontSize": 45,
+                                    },
+                                  ]
+                                }
+                              >
+                                <Text
+                                  allowFontScaling={false}
+                                  selectable={false}
+                                  style={
+                                    Array [
+                                      Object {
+                                        "color": undefined,
+                                        "fontSize": 30,
+                                      },
+                                      Object {
+                                        "color": "#D8292F",
+                                      },
+                                      Object {
+                                        "fontFamily": "Material Icons",
+                                        "fontStyle": "normal",
+                                        "fontWeight": "normal",
+                                      },
+                                      Object {},
+                                    ]
+                                  }
+                                >
+                                  
+                                </Text>
+                              </Text>
+                            </View>
+                            <View
+                              style={
+                                Object {
+                                  "flex": 1,
+                                  "marginLeft": -52.5,
+                                  "padding": 37.5,
+                                }
+                              }
+                              testID="com.ariesbifold:id/CredentialCardPrimaryBody"
+                            >
+                              <View>
+                                <View
+                                  style={
+                                    Object {
+                                      "flexDirection": "row",
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    style={
+                                      Array [
+                                        Object {
+                                          "color": "#FFFFFF",
+                                          "fontSize": 18,
+                                          "fontWeight": "bold",
+                                        },
+                                        Object {
+                                          "color": "#FFFFFF",
+                                          "flexShrink": 1,
+                                        },
+                                        Object {
+                                          "color": "#FFFFFF",
+                                          "flex": 1,
+                                          "flexWrap": "wrap",
+                                          "lineHeight": 24,
+                                        },
+                                      ]
+                                    }
+                                    testID="com.ariesbifold:id/CredentialName"
+                                  >
+                                    Credential
+                                  </Text>
+                                </View>
+                              </View>
+                              <View
+                                style={
+                                  Object {
+                                    "alignItems": "center",
+                                    "flexDirection": "row",
+                                  }
+                                }
+                              >
+                                <Text
+                                  allowFontScaling={false}
+                                  selectable={false}
+                                  style={
+                                    Array [
+                                      Object {
+                                        "color": undefined,
+                                        "fontSize": 30,
+                                      },
+                                      Array [
+                                        Object {
+                                          "color": "#D8292F",
+                                        },
+                                      ],
+                                      Object {
+                                        "fontFamily": "Material Icons",
+                                        "fontStyle": "normal",
+                                        "fontWeight": "normal",
+                                      },
+                                      Object {},
+                                    ]
+                                  }
+                                >
+                                  
+                                </Text>
+                                <Text
+                                  numberOfLines={1}
+                                  style={
+                                    Array [
+                                      Object {
+                                        "color": "#D8292F",
+                                        "fontSize": 18,
+                                        "fontWeight": "normal",
+                                      },
+                                    ]
+                                  }
+                                  testID="com.ariesbifold:id/RevokedOrNotAvailable"
+                                >
+                                  ProofRequest.NotAvailableInYourWallet
+                                </Text>
+                              </View>
+                              <View
+                                ListFooterComponent={null}
+                                data={
+                                  Array [
+                                    Object {
+                                      "credentialId": "Credential",
+                                      "encoding": undefined,
+                                      "format": undefined,
+                                      "label": undefined,
+                                      "mimeType": undefined,
+                                      "name": "age",
+                                      "nonRevoked": undefined,
+                                      "pType": "<=",
+                                      "pValue": 18,
+                                      "parameterizable": undefined,
+                                      "restrictions": undefined,
+                                      "revoked": false,
+                                      "satisfied": false,
+                                      "type": undefined,
+                                    },
+                                    undefined,
+                                    undefined,
+                                  ]
+                                }
+                                getItem={[Function]}
+                                getItemCount={[Function]}
+                                initialNumToRender={3}
+                                keyExtractor={[Function]}
+                                onContentSizeChange={[Function]}
+                                onLayout={[Function]}
+                                onMomentumScrollBegin={[Function]}
+                                onMomentumScrollEnd={[Function]}
+                                onScroll={[Function]}
+                                onScrollBeginDrag={[Function]}
+                                onScrollEndDrag={[Function]}
+                                removeClippedSubviews={false}
+                                renderItem={[Function]}
+                                scrollEnabled={false}
+                                scrollEventThrottle={50}
+                                stickyHeaderIndices={Array []}
+                                viewabilityConfigCallbackPairs={Array []}
+                              >
+                                <View
+                                  onFocusCapture={[Function]}
+                                  onLayout={[Function]}
+                                  style={null}
+                                >
+                                  <View
+                                    style={
+                                      Object {
+                                        "marginTop": 15,
+                                      }
+                                    }
+                                  >
+                                    <View
+                                      style={
+                                        Object {
+                                          "alignItems": "center",
+                                          "flexDirection": "row",
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        allowFontScaling={false}
+                                        selectable={false}
+                                        style={
+                                          Array [
+                                            Object {
+                                              "color": "#D8292F",
+                                              "fontSize": 18,
+                                            },
+                                            Object {
+                                              "paddingHorizontal": 2,
+                                              "paddingTop": 2,
+                                            },
+                                            Object {
+                                              "fontFamily": "Material Icons",
+                                              "fontStyle": "normal",
+                                              "fontWeight": "normal",
+                                            },
+                                            Object {},
+                                          ]
+                                        }
+                                      >
+                                        
+                                      </Text>
+                                      <Text
+                                        style={
+                                          Array [
+                                            Object {
+                                              "color": "#FFFFFF",
+                                              "fontSize": 14,
+                                              "fontWeight": "normal",
+                                            },
+                                            Object {
+                                              "color": "#FFFFFF",
+                                              "flexShrink": 1,
+                                            },
+                                            Object {
+                                              "lineHeight": 19,
+                                              "opacity": 0.8,
+                                            },
+                                          ]
+                                        }
+                                        testID="com.ariesbifold:id/AttributeName"
+                                      >
+                                        Age
+                                      </Text>
+                                    </View>
+                                    <View
+                                      style={
+                                        Object {
+                                          "alignItems": "center",
+                                          "flexDirection": "row",
+                                        }
+                                      }
+                                    />
+                                  </View>
+                                </View>
+                                <View
+                                  onFocusCapture={[Function]}
+                                  onLayout={[Function]}
+                                  style={null}
+                                />
+                                <View
+                                  onFocusCapture={[Function]}
+                                  onLayout={[Function]}
+                                  style={null}
+                                />
+                              </View>
+                            </View>
+                            <View
+                              style={
+                                Array [
+                                  Object {
+                                    "alignItems": "center",
+                                    "backgroundColor": "rgba(0, 0, 0, 0)",
+                                    "borderBottomLeftRadius": 10,
+                                    "borderTopRightRadius": 10,
+                                    "height": 90,
+                                    "justifyContent": "center",
+                                    "width": 90,
+                                  },
+                                  Object {
+                                    "position": "absolute",
+                                    "right": 0,
+                                    "top": 0,
+                                  },
+                                ]
+                              }
+                              testID="com.ariesbifold:id/CredentialCardStatus"
+                            >
+                              <View
+                                style={
+                                  Array [
+                                    Object {
+                                      "alignItems": "center",
+                                      "backgroundColor": "rgba(0, 0, 0, 0)",
+                                      "borderBottomLeftRadius": 10,
+                                      "borderTopRightRadius": 10,
+                                      "height": 90,
+                                      "justifyContent": "center",
+                                      "width": 90,
+                                    },
+                                  ]
+                                }
+                              />
+                            </View>
+                          </View>
+                        </View>
+                      </View>
+                    </RNGestureHandlerButton>
+                  </View>
+                </View>
+              </View>
+            </View>
+            <View
+              onLayout={[Function]}
+            >
+              <View
+                style={
+                  Array [
+                    Object {
+                      "marginVertical": 15,
+                    },
+                    Object {
+                      "marginHorizontal": 20,
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "paddingTop": 10,
+                    }
+                  }
+                >
+                  <View
+                    accessibilityLabel="Global.Cancel"
+                    accessibilityRole="button"
+                    accessibilityState={
+                      Object {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": false,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
+                    }
+                    accessibilityValue={
+                      Object {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onClick={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      Object {
+                        "backgroundColor": "#42803E",
+                        "borderRadius": 4,
+                        "opacity": 1,
+                        "padding": 16,
+                      }
+                    }
+                    testID="com.ariesbifold:id/Cancel"
+                  >
+                    <View
+                      style={
+                        Object {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "justifyContent": "center",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          Array [
+                            Object {
+                              "color": "#FFFFFF",
+                              "fontSize": 18,
+                              "fontWeight": "bold",
+                              "textAlign": "center",
+                            },
+                            false,
+                            false,
+                            false,
+                          ]
+                        }
+                      >
+                        Global.Cancel
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </RCTScrollView>
+      </View>
+      <Modal
+        animationType="none"
+        hardwareAccelerated={false}
+        transparent={true}
+        visible={false}
+      />
+      <Modal
+        animationType="slide"
+        hardwareAccelerated={false}
+        transparent={true}
+        visible={false}
+      />
+      <Modal
+        animationType="slide"
+        hardwareAccelerated={false}
+        visible={false}
+      />
+    </View>
+  </RCTScrollView>
+</RNCSafeAreaView>
+`;

--- a/packages/legacy/core/__tests__/screens/fixtures/w3c-proof-request.ts
+++ b/packages/legacy/core/__tests__/screens/fixtures/w3c-proof-request.ts
@@ -1,5 +1,6 @@
 import { AnonCredsCredentialsForProofRequest } from '@credo-ts/anoncreds'
 import { ClaimFormat, DifPexCredentialsForRequest, JsonTransformer, W3cCredentialRecord } from '@credo-ts/core'
+
 import { DifPexAnonCredsProofRequest } from '../../../App/utils/anonCredsProofRequestMapper'
 
 export const testW3cCredentialRecord = JsonTransformer.fromJSON(


### PR DESCRIPTION
# Summary of Changes

This PR fixes the text displayed when an entire credential is missing vs when just a predicate is not satisfied.

Here's the before:
![before](https://github.com/openwallet-foundation/bifold-wallet/assets/32586431/2446a397-9ab4-4e77-b1b3-94ba9c068f5b)

Here's the after:
![after](https://github.com/openwallet-foundation/bifold-wallet/assets/32586431/668e3e19-929e-4d75-b0a1-37352c4efe00)

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
