### PR TITLE
fix: fixed how we handle deeplinks that don't have connection params

### DIFF
--- a/packages/legacy/core/App/navigators/RootStack.tsx
+++ b/packages/legacy/core/App/navigators/RootStack.tsx
@@ -100,7 +100,7 @@ const RootStack: React.FC = () => {
   useEffect(() => {
     async function handleDeepLink(deepLink: string) {
       // If it's just the general link with no params, set link inactive and do nothing
-      if (deepLink.endsWith('//')) {
+      if (deepLink.search(/oob=|c_i=|d_m=|url=/) < 0) {
         dispatch({
           type: DispatchAction.ACTIVE_DEEP_LINK,
           payload: [undefined],


### PR DESCRIPTION
# Summary of Changes

Previously when handling deeplinks coming from the BCSC app flow, the wallet would try to process the deeplinks because they didn't end like `bcwallet://` or `didcom://`. It seems the BCSC app now uses deeplinks in the form `bcwallet://bcsc/v1?did=null&status=cancel` I've changed the way we handle deeplinks in the root stack to only try to process deeplinkks if they contain connection parameters.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
