### PR TITLE
feat: add OCA checkForUpdates to the splash screen

### DIFF
--- a/packages/legacy/core/App/screens/Splash.tsx
+++ b/packages/legacy/core/App/screens/Splash.tsx
@@ -1,6 +1,7 @@
 import { Agent, HttpOutboundTransport, WsOutboundTransport } from '@credo-ts/core'
 import { useAgent } from '@credo-ts/react-hooks'
 import { agentDependencies } from '@credo-ts/react-native'
+import { RemoteOCABundleResolver } from '@hyperledger/aries-oca/build/legacy'
 import { useNavigation } from '@react-navigation/core'
 import { CommonActions } from '@react-navigation/native'
 import React, { useEffect, useState } from 'react'
@@ -22,7 +23,6 @@ import { Screens, Stacks } from '../types/navigators'
 import { Onboarding as StoreOnboardingState } from '../types/state'
 import { getAgentModules, createLinkSecretIfRequired } from '../utils/agent'
 import { migrateToAskar, didMigrateToAskar } from '../utils/migration'
-import { RemoteOCABundleResolver } from '@hyperledger/aries-oca/build/legacy'
 
 const OnboardingVersion = 1
 

--- a/packages/legacy/core/App/screens/Splash.tsx
+++ b/packages/legacy/core/App/screens/Splash.tsx
@@ -22,6 +22,7 @@ import { Screens, Stacks } from '../types/navigators'
 import { Onboarding as StoreOnboardingState } from '../types/state'
 import { getAgentModules, createLinkSecretIfRequired } from '../utils/agent'
 import { migrateToAskar, didMigrateToAskar } from '../utils/migration'
+import { RemoteOCABundleResolver } from '@hyperledger/aries-oca/build/legacy'
 
 const OnboardingVersion = 1
 
@@ -98,6 +99,7 @@ const Splash: React.FC = () => {
   const { version: TermsVersion } = container.resolve(TOKENS.SCREEN_TERMS)
   const logger = container.resolve(TOKENS.UTIL_LOGGER)
   const indyLedgers = container.resolve(TOKENS.UTIL_LEDGERS)
+  const ocaBundleResolver = container.resolve(TOKENS.UTIL_OCA_RESOLVER) as RemoteOCABundleResolver
   const styles = StyleSheet.create({
     container: {
       flex: 1,
@@ -209,6 +211,10 @@ const Splash: React.FC = () => {
     const initAgent = async (): Promise<void> => {
       try {
         const credentials = await getWalletCredentials()
+
+        if (typeof ocaBundleResolver['checkForUpdates'] != "undefined") {
+          await ocaBundleResolver.checkForUpdates()
+        }
 
         if (!credentials?.id || !credentials.key) {
           // Cannot find wallet id/secret

--- a/packages/legacy/core/App/screens/Splash.tsx
+++ b/packages/legacy/core/App/screens/Splash.tsx
@@ -210,11 +210,8 @@ const Splash: React.FC = () => {
 
     const initAgent = async (): Promise<void> => {
       try {
+        await ocaBundleResolver.checkForUpdates?.()
         const credentials = await getWalletCredentials()
-
-        if (typeof ocaBundleResolver['checkForUpdates'] != "undefined") {
-          await ocaBundleResolver.checkForUpdates()
-        }
 
         if (!credentials?.id || !credentials.key) {
           // Cannot find wallet id/secret


### PR DESCRIPTION
# Summary of Changes

Adds support to check for OCA remote files at app startup - in the splash screen. This PR does not add support for OCA in the reference app, although that was tested. The reason for exclusion is that the method to publish OCA files is not formalized and the current support is experimental and only currently used by BCGov.

The reason for the PR is to allow upstream wallets to experiment with OCA.

The source code changes were mostly copied from the BCGov wallet.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [ x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [ x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x ] Updated documentation as needed for changed code and new or modified features;
- [ x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
