### PR TITLE
fix: allow exp override

### DIFF
--- a/packages/remote-logs/src/logger.ts
+++ b/packages/remote-logs/src/logger.ts
@@ -115,6 +115,20 @@ export class RemoteLogger extends BaseLogger {
     this.eventListener = undefined
   }
 
+  public overrideCurrentAutoDisableExpiration(expirationInMinutes: number) {
+    if (expirationInMinutes <= 0) {
+      return
+    }
+
+    if (this.remoteLoggingAutoDisableTimer) {
+      clearTimeout(this.remoteLoggingAutoDisableTimer)
+    }
+
+    this.remoteLoggingAutoDisableTimer = setTimeout(() => {
+      this.remoteLoggingEnabled = false
+    }, expirationInMinutes * 60000)
+  }
+
   public test(message: string, data?: object | undefined): void {
     this.log?.test({ message, data })
   }


### PR DESCRIPTION
# Summary of Changes

Allow the expiration of the remote logger timer. This will allow for the timer to be manually configured when restoring state.

# Related Issues

Please reference here any issue #'s that are relevant to this PR, or simply enter "N/A" if this PR does not relate to any existing issues.

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
