### PR TITLE
feat: upgrade info text box and add to proof request screen

### DIFF
--- a/packages/legacy/core/App/components/texts/InfoTextBox.tsx
+++ b/packages/legacy/core/App/components/texts/InfoTextBox.tsx
@@ -1,48 +1,120 @@
 import React from 'react'
-import { StyleSheet, Text, View } from 'react-native'
+import { StyleSheet, Text, TextStyle, View, ViewStyle } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
 import { useTheme } from '../../contexts/theme'
+import { InfoBoxType } from '../misc/InfoBox'
 
 export interface TextBoxProps {
   children: React.ReactElement | string
+  type?: InfoBoxType
+  iconVerticalPosition?: 'high' | 'middle'
+  iconHorizontalPosition?: 'left' | 'right'
+  style?: ViewStyle
+  textStyle?: TextStyle
 }
 
 const iconSize = 30
 const offset = 10
 
-const InfoTextBox: React.FC<TextBoxProps> = ({ children }) => {
+const InfoTextBox: React.FC<TextBoxProps> = ({
+  children,
+  type = InfoBoxType.Info,
+  iconVerticalPosition = 'high',
+  iconHorizontalPosition = 'left',
+  style = {},
+  textStyle = {},
+}) => {
   const { ColorPallet, TextTheme } = useTheme()
   const styles = StyleSheet.create({
     container: {
-      backgroundColor: ColorPallet.notification.info,
+      padding: 10,
       borderRadius: 5,
       borderWidth: 1,
+      backgroundColor: ColorPallet.notification.info,
       borderColor: ColorPallet.notification.infoBorder,
-      padding: 10,
+      ...style,
     },
     row: {
-      flexDirection: 'row',
+      flexDirection: iconHorizontalPosition === 'left' ? 'row' : 'row-reverse',
       alignItems: 'center',
+      justifyContent: 'space-between',
     },
-    textContainer: {
+    text: {
       ...TextTheme.bold,
-      color: ColorPallet.notification.infoText,
       alignSelf: 'center',
-      flexShrink: 1,
+      flex: 1,
+      flexWrap: 'wrap',
+      color: ColorPallet.notification.infoText,
+      ...textStyle,
     },
     iconContainer: {
-      marginRight: offset,
-      alignSelf: 'center',
+      marginRight: iconHorizontalPosition === 'left' ? offset : 0,
+      marginLeft: iconHorizontalPosition === 'right' ? offset : 0,
+      alignSelf: iconVerticalPosition === 'high' ? 'flex-start' : 'center',
     },
   })
+
+  let iconName = 'info'
+  let iconColor = ColorPallet.notification.infoIcon
+
+  switch (type) {
+    case InfoBoxType.Info:
+      break
+
+    case InfoBoxType.Success:
+      iconName = 'check-circle'
+      iconColor = ColorPallet.notification.successIcon
+      styles.container = {
+        ...styles.container,
+        backgroundColor: ColorPallet.notification.success,
+        borderColor: ColorPallet.notification.successBorder,
+      }
+      styles.text = {
+        ...styles.text,
+        color: ColorPallet.notification.successText,
+      }
+      break
+
+    case InfoBoxType.Warn:
+      iconName = 'warning'
+      iconColor = ColorPallet.notification.warnIcon
+      styles.container = {
+        ...styles.container,
+        backgroundColor: ColorPallet.notification.warn,
+        borderColor: ColorPallet.notification.warnBorder,
+      }
+      styles.text = {
+        ...styles.text,
+        color: ColorPallet.notification.warnText,
+      }
+      break
+
+    case InfoBoxType.Error:
+      iconName = 'error'
+      iconColor = ColorPallet.notification.errorIcon
+      styles.container = {
+        ...styles.container,
+        backgroundColor: ColorPallet.notification.error,
+        borderColor: ColorPallet.notification.errorBorder,
+      }
+      styles.text = {
+        ...styles.text,
+        color: ColorPallet.notification.errorText,
+      }
+      break
+
+    default:
+      throw new Error('InfoTextBox type needs to be set correctly')
+  }
+
   return (
     <View style={styles.container}>
       <View style={styles.row}>
         <View style={styles.iconContainer}>
-          <Icon name={'info'} size={iconSize} color={ColorPallet.notification.infoIcon} />
+          <Icon name={iconName} size={iconSize} color={iconColor} />
         </View>
-        {typeof children === 'string' ? <Text style={styles.textContainer}>{children}</Text> : <>{children}</>}
+        {typeof children === 'string' ? <Text style={styles.text}>{children}</Text> : <>{children}</>}
       </View>
     </View>
   )

--- a/packages/legacy/core/App/hooks/chat-messages.tsx
+++ b/packages/legacy/core/App/hooks/chat-messages.tsx
@@ -76,9 +76,9 @@ export const useChatMessagesByConnection = (connection: ConnectionRecord): Exten
   const { t } = useTranslation()
   const { ChatTheme: theme, ColorPallet } = useTheme()
   const navigation = useNavigation<StackNavigationProp<RootStackParams | ContactStackParams>>()
-  const basicMessages = useBasicMessagesByConnectionId(connection.id)
-  const credentials = useCredentialsByConnectionId(connection.id)
-  const proofs = useProofsByConnectionId(connection.id)
+  const basicMessages = useBasicMessagesByConnectionId(connection?.id)
+  const credentials = useCredentialsByConnectionId(connection?.id)
+  const proofs = useProofsByConnectionId(connection?.id)
   const [theirLabel, setTheirLabel] = useState(getConnectionName(connection, store.preferences.alternateContactNames))
 
   // This useEffect is for properly rendering changes to the alt contact name, useMemo did not pick them up

--- a/packages/legacy/core/App/localization/en/index.ts
+++ b/packages/legacy/core/App/localization/en/index.ts
@@ -510,6 +510,7 @@ const translation = {
     "DeclineBulletPoint3": "Are you sure you want to decline this proof request?",
     "NoInfoShared": "No information was shared",
     "YourInfo": "Your information was not shared",
+    "YouCantRespond": "You can't respond due to the following reasons. Please address them before continuing.",
   },
   "Settings": {
     "Version": "Version",

--- a/packages/legacy/core/App/localization/fr/index.ts
+++ b/packages/legacy/core/App/localization/fr/index.ts
@@ -495,6 +495,7 @@ const translation = {
         "DeclineBulletPoint3": "Etes-vous sûr vous voulez refuser cette demande de preuve?",
         "NoInfoShared": "Aucune information n'a été partagée",
         "YourInfo": "Votre information n'a pas été partagée",
+        "YouCantRespond": "You can't respond due to the following reasons. Please address them before continuing. (FR)",
     },
     "Settings": {
         "Version": "Version",

--- a/packages/legacy/core/App/localization/pt-br/index.ts
+++ b/packages/legacy/core/App/localization/pt-br/index.ts
@@ -485,6 +485,7 @@ const translation = {
     "DeclineBulletPoint3": "Você tem certeza que quer recusar esta requisição de prova?",
     "NoInfoShared": "No information was shared (PT-BR)",
     "YourInfo": "Your information was not shared (PT-BR)",
+    "YouCantRespond": "You can't respond due to the following reasons. Please address them before continuing. (PT-BR)",
   },
   "Settings": {
     "Version": "Versão",

--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -20,6 +20,7 @@ import Button, { ButtonType } from '../components/buttons/Button'
 import { CredentialCard } from '../components/misc'
 import ConnectionAlert from '../components/misc/ConnectionAlert'
 import ConnectionImage from '../components/misc/ConnectionImage'
+import { InfoBoxType } from '../components/misc/InfoBox'
 import CommonRemoveModal from '../components/modals/CommonRemoveModal'
 import ProofCancelModal from '../components/modals/ProofCancelModal'
 import InfoTextBox from '../components/texts/InfoTextBox'
@@ -452,6 +453,15 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
     navigation.getParent()?.navigate(TabStacks.HomeStack, { screen: Screens.Home })
   }
 
+  const isShareDisabled = () => {
+    return (
+      !hasAvailableCredentials ||
+      !hasSatisfiedPredicates(getCredentialsFields()) ||
+      revocationOffense ||
+      proof?.state !== ProofState.RequestReceived
+    )
+  }
+
   const proofPageHeader = () => {
     return (
       <View style={styles.pageMargin}>
@@ -494,37 +504,20 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
                   <Text>{activeCreds?.length > 1 ? t('ProofRequest.Credentials') : t('ProofRequest.Credential')}</Text>
                 </Text>
               )}
-              {containsPI && (
-                <View
-                  style={{
-                    backgroundColor: ColorPallet.notification.warn,
-                    width: '100%',
-                    marginTop: 10,
-                    borderColor: ColorPallet.notification.warnBorder,
-                    borderWidth: 2,
-                    borderRadius: 4,
-                    flexDirection: 'row',
-                  }}
+              {containsPI ? (
+                <InfoTextBox
+                  type={InfoBoxType.Warn}
+                  style={{ marginTop: 16 }}
+                  textStyle={{ fontSize: TextTheme.title.fontSize }}
                 >
-                  <Icon
-                    style={{ marginTop: 15, marginLeft: 10 }}
-                    name="warning"
-                    color={ColorPallet.notification.warnIcon}
-                    size={TextTheme.title.fontSize + 5}
-                  />
-                  <Text
-                    style={{
-                      ...TextTheme.title,
-                      color: ColorPallet.notification.warnText,
-                      flex: 1,
-                      flexWrap: 'wrap',
-                      margin: 10,
-                    }}
-                  >
-                    {t('ProofRequest.SensitiveInformation')}
-                  </Text>
-                </View>
-              )}
+                  {t('ProofRequest.SensitiveInformation')}
+                </InfoTextBox>
+              ) : null}
+              {isShareDisabled() ? (
+                <InfoTextBox type={InfoBoxType.Error} style={{ marginTop: 16 }} textStyle={{ fontWeight: 'normal' }}>
+                  {t('ProofRequest.YouCantRespond')}
+                </InfoTextBox>
+              ) : null}
             </View>
             {!hasAvailableCredentials && hasMatchingCredDef && (
               <Text
@@ -565,10 +558,7 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
         {!(loading || attestationLoading) && proofConnectionLabel && goalCode === 'aries.vc.verify' ? (
           <ConnectionAlert connectionID={proofConnectionLabel} />
         ) : null}
-        {!hasAvailableCredentials ||
-        !hasSatisfiedPredicates(getCredentialsFields()) ||
-        revocationOffense ||
-        proof?.state !== ProofState.RequestReceived ? (
+        {isShareDisabled() ? (
           <View style={styles.footerButton}>
             <Button
               title={t('Global.Cancel')}

--- a/packages/legacy/core/__tests__/components/__snapshots__/InfoTextBox.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/InfoTextBox.test.tsx.snap
@@ -17,13 +17,15 @@ exports[`InfoTextBox Component Renders correctly 1`] = `
       Object {
         "alignItems": "center",
         "flexDirection": "row",
+        "justifyContent": "space-between",
       }
     }
   >
     <View
       style={
         Object {
-          "alignSelf": "center",
+          "alignSelf": "flex-start",
+          "marginLeft": 0,
           "marginRight": 10,
         }
       }
@@ -39,7 +41,8 @@ exports[`InfoTextBox Component Renders correctly 1`] = `
         Object {
           "alignSelf": "center",
           "color": "#FFFFFF",
-          "flexShrink": 1,
+          "flex": 1,
+          "flexWrap": "wrap",
           "fontSize": 18,
           "fontWeight": "bold",
         }

--- a/packages/legacy/core/__tests__/screens/__snapshots__/Home.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/Home.test.tsx.snap
@@ -60,13 +60,15 @@ exports[`displays a home screen renders correctly 1`] = `
             Object {
               "alignItems": "center",
               "flexDirection": "row",
+              "justifyContent": "space-between",
             }
           }
         >
           <View
             style={
               Object {
-                "alignSelf": "center",
+                "alignSelf": "flex-start",
+                "marginLeft": 0,
                 "marginRight": 10,
               }
             }

--- a/packages/legacy/core/__tests__/screens/__snapshots__/Terms.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/Terms.test.tsx.snap
@@ -37,13 +37,15 @@ exports[`Terms Screen Button enabled by checkbox being checked 1`] = `
             Object {
               "alignItems": "center",
               "flexDirection": "row",
+              "justifyContent": "space-between",
             }
           }
         >
           <View
             style={
               Object {
-                "alignSelf": "center",
+                "alignSelf": "flex-start",
+                "marginLeft": 0,
                 "marginRight": 10,
               }
             }
@@ -75,7 +77,8 @@ exports[`Terms Screen Button enabled by checkbox being checked 1`] = `
               Object {
                 "alignSelf": "center",
                 "color": "#FFFFFF",
-                "flexShrink": 1,
+                "flex": 1,
+                "flexWrap": "wrap",
                 "fontSize": 18,
                 "fontWeight": "bold",
               }
@@ -483,13 +486,15 @@ exports[`Terms Screen Renders correctly 1`] = `
             Object {
               "alignItems": "center",
               "flexDirection": "row",
+              "justifyContent": "space-between",
             }
           }
         >
           <View
             style={
               Object {
-                "alignSelf": "center",
+                "alignSelf": "flex-start",
+                "marginLeft": 0,
                 "marginRight": 10,
               }
             }
@@ -521,7 +526,8 @@ exports[`Terms Screen Renders correctly 1`] = `
               Object {
                 "alignSelf": "center",
                 "color": "#FFFFFF",
-                "flexShrink": 1,
+                "flex": 1,
+                "flexWrap": "wrap",
                 "fontSize": 18,
                 "fontWeight": "bold",
               }

--- a/packages/legacy/core/__tests__/screens/__snapshots__/W3cProofRequest.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/W3cProofRequest.test.tsx.snap
@@ -90,6 +90,21 @@ exports[`displays a proof request screen with a proof request displays a proof r
                       ProofRequest.Credentials
                     </Text>
                   </Text>
+                  <InfoTextBox
+                    style={
+                      Object {
+                        "marginTop": 16,
+                      }
+                    }
+                    textStyle={
+                      Object {
+                        "fontWeight": "normal",
+                      }
+                    }
+                    type={3}
+                  >
+                    ProofRequest.YouCantRespond
+                  </InfoTextBox>
                 </View>
                 <Text
                   style={
@@ -261,6 +276,74 @@ exports[`displays a proof request screen with a proof request displays a proof r
                       ProofRequest.Credentials
                     </Text>
                   </Text>
+                  <View
+                    style={
+                      Object {
+                        "backgroundColor": "#313132",
+                        "borderColor": "#D8292F",
+                        "borderRadius": 5,
+                        "borderWidth": 1,
+                        "marginTop": 16,
+                        "padding": 10,
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        Object {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "justifyContent": "space-between",
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          Object {
+                            "alignSelf": "flex-start",
+                            "marginLeft": 0,
+                            "marginRight": 10,
+                          }
+                        }
+                      >
+                        <Text
+                          allowFontScaling={false}
+                          selectable={false}
+                          style={
+                            Array [
+                              Object {
+                                "color": "#D8292F",
+                                "fontSize": 30,
+                              },
+                              undefined,
+                              Object {
+                                "fontFamily": "Material Icons",
+                                "fontStyle": "normal",
+                                "fontWeight": "normal",
+                              },
+                              Object {},
+                            ]
+                          }
+                        >
+                          
+                        </Text>
+                      </View>
+                      <Text
+                        style={
+                          Object {
+                            "alignSelf": "center",
+                            "color": "#FFFFFF",
+                            "flex": 1,
+                            "flexWrap": "wrap",
+                            "fontSize": 18,
+                            "fontWeight": "normal",
+                          }
+                        }
+                      >
+                        ProofRequest.YouCantRespond
+                      </Text>
+                    </View>
+                  </View>
                 </View>
                 <Text
                   style={


### PR DESCRIPTION
# Summary of Changes

This PR improves the `InfoTextBox` component and makes it configurable. It then adds the `InfoTextBox` to the proof request screen in two places; one, a new message if you are unable to respond to the proof for whatever reason, and two, a replacement for the custom sensitive information warning.

See below pics

![info_text_boxes](https://github.com/user-attachments/assets/850b11d7-7a78-425d-962c-ddbacf3e01c7)
![cant_respond](https://github.com/user-attachments/assets/67c1e3ac-061e-478b-a9ea-905ea6252278)
![sensitive_info](https://github.com/user-attachments/assets/c6fc0df3-34ca-4d06-a2d5-373b4a23d1c8)


# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
