### PR TITLE
fix: make Connection modal+screen screen only, two other mini bugs

### DIFF
--- a/packages/legacy/core/App/components/misc/NewQRView.tsx
+++ b/packages/legacy/core/App/components/misc/NewQRView.tsx
@@ -184,7 +184,7 @@ const NewQRView: React.FC<Props> = ({ defaultToConnect, handleCodeScan, error, e
     if (record?.state === DidExchangeState.Completed) {
       navigation.getParent()?.navigate(Stacks.ConnectionStack, {
         screen: Screens.Connection,
-        params: { connectionId: record.id },
+        params: { oobRecordId: recordId },
       })
     }
   }, [record])

--- a/packages/legacy/core/App/navigators/DeliveryStack.tsx
+++ b/packages/legacy/core/App/navigators/DeliveryStack.tsx
@@ -29,7 +29,11 @@ const DeliveryStack: React.FC = () => {
         headerRight: () => <HeaderRightHome />,
       }}
     >
-      <Stack.Screen name={Screens.Connection} component={Connection} options={{ ...defaultStackOptions }} />
+      <Stack.Screen
+        name={Screens.Connection}
+        component={Connection}
+        options={{ ...defaultStackOptions, headerShown: false }}
+      />
       <Stack.Screen
         name={Screens.ProofRequest}
         component={ProofRequest}

--- a/packages/legacy/core/App/navigators/RootStack.tsx
+++ b/packages/legacy/core/App/navigators/RootStack.tsx
@@ -2,7 +2,12 @@ import { ProofState } from '@credo-ts/core'
 import { useAgent, useProofByState } from '@credo-ts/react-hooks'
 import { ProofCustomMetadata, ProofMetadata } from '@hyperledger/aries-bifold-verifier'
 import { useNavigation } from '@react-navigation/native'
-import { StackCardStyleInterpolator, StackNavigationProp, createStackNavigator } from '@react-navigation/stack'
+import {
+  CardStyleInterpolators,
+  StackCardStyleInterpolator,
+  StackNavigationProp,
+  createStackNavigator,
+} from '@react-navigation/stack'
 import React, { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { AppState, DeviceEventEmitter } from 'react-native'
@@ -237,7 +242,15 @@ const RootStack: React.FC = () => {
         />
         <Stack.Screen name={Stacks.ContactStack} component={ContactStack} />
         <Stack.Screen name={Stacks.NotificationStack} component={NotificationStack} />
-        <Stack.Screen name={Stacks.ConnectionStack} component={DeliveryStack} options={{ gestureEnabled: false }} />
+        <Stack.Screen
+          name={Stacks.ConnectionStack}
+          component={DeliveryStack}
+          options={{
+            gestureEnabled: false,
+            cardStyleInterpolator: CardStyleInterpolators.forVerticalIOS,
+            presentation: 'modal',
+          }}
+        />
         <Stack.Screen name={Stacks.ProofRequestsStack} component={ProofRequestStack} />
         <Stack.Screen
           name={Stacks.HistoryStack}

--- a/packages/legacy/core/App/navigators/TabStack.tsx
+++ b/packages/legacy/core/App/navigators/TabStack.tsx
@@ -49,6 +49,7 @@ const TabStack: React.FC = () => {
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: ColorPallet.brand.primary }}>
       <Tab.Navigator
+        initialRouteName={TabStacks.HomeStack}
         screenOptions={{
           unmountOnBlur: true,
           tabBarStyle: {

--- a/packages/legacy/core/App/screens/Connection.tsx
+++ b/packages/legacy/core/App/screens/Connection.tsx
@@ -2,7 +2,7 @@ import { CommonActions, useFocusEffect } from '@react-navigation/native'
 import { StackScreenProps } from '@react-navigation/stack'
 import React, { useCallback, useEffect, useMemo, useReducer, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { AccessibilityInfo, BackHandler, Modal, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { AccessibilityInfo, BackHandler, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import Button, { ButtonType } from '../components/buttons/Button'
@@ -21,7 +21,7 @@ type ConnectionProps = StackScreenProps<DeliveryStackParams, Screens.Connection>
 type MergeFunction = (current: LocalState, next: Partial<LocalState>) => LocalState
 
 type LocalState = {
-  isVisible: boolean
+  inProgress: boolean
   isInitialized: boolean
   notificationRecord?: any
   shouldShowDelayMessage: boolean
@@ -49,7 +49,7 @@ const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
 
   const merge: MergeFunction = (current, next) => ({ ...current, ...next })
   const [state, dispatch] = useReducer(merge, {
-    isVisible: true,
+    inProgress: true,
     isInitialized: false,
     shouldShowDelayMessage: false,
     notificationRecord: undefined,
@@ -100,7 +100,7 @@ const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
   }
 
   const onDismissModalTouched = () => {
-    dispatch({ shouldShowDelayMessage: false, isVisible: false })
+    dispatch({ shouldShowDelayMessage: false, inProgress: false })
     navigation.getParent()?.navigate(TabStacks.HomeStack, { screen: Screens.Home })
   }
 
@@ -112,7 +112,7 @@ const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
   useEffect(() => {
     if (state.shouldShowDelayMessage && !state.notificationRecord) {
       if (autoRedirectConnectionToHome) {
-        dispatch({ shouldShowDelayMessage: false, isVisible: false })
+        dispatch({ shouldShowDelayMessage: false, inProgress: false })
         navigation.getParent()?.navigate(TabStacks.HomeStack, { screen: Screens.Home })
       } else {
         AccessibilityInfo.announceForAccessibility(t('Connection.TakingTooLong'))
@@ -121,7 +121,7 @@ const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
   }, [state.shouldShowDelayMessage])
 
   useEffect(() => {
-    if (!oobRecord || !state.isVisible) {
+    if (!oobRecord || !state.inProgress) {
       return
     }
 
@@ -130,7 +130,7 @@ const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
     if (connection && !(Object.values(GoalCodes) as [string]).includes(oobRecord?.outOfBandInvitation.goalCode ?? '')) {
       logger?.info('Connection: Handling connection without goal code, navigate to Chat')
 
-      dispatch({ isVisible: false })
+      dispatch({ inProgress: false })
       navigation.getParent()?.dispatch(
         CommonActions.reset({
           index: 1,
@@ -149,7 +149,7 @@ const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
 
     // Connectionless proof request, we don't have connectionless offers.
     if (!connection) {
-      dispatch({ isVisible: false })
+      dispatch({ inProgress: false })
       navigation.replace(Screens.ProofRequest, { proofId: state.notificationRecord.id })
 
       return
@@ -169,7 +169,7 @@ const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
     if (goalCode === GoalCodes.proofRequestVerify || goalCode === GoalCodes.proofRequestVerifyOnce) {
       logger?.info(`Connection: Handling ${goalCode} goal code, navigate to ProofRequest`)
 
-      dispatch({ isVisible: false })
+      dispatch({ inProgress: false })
       navigation.replace(Screens.ProofRequest, { proofId: state.notificationRecord.id })
 
       return
@@ -178,7 +178,7 @@ const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
     if (goalCode === GoalCodes.credentialOffer) {
       logger?.info(`Connection: Handling ${goalCode} goal code, navigate to CredentialOffer`)
 
-      dispatch({ isVisible: false })
+      dispatch({ inProgress: false })
       navigation.replace(Screens.CredentialOffer, { credentialId: state.notificationRecord.id })
 
       return
@@ -186,7 +186,7 @@ const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
 
     logger?.info(`Connection: Unable to handle ${goalCode} goal code`)
 
-    dispatch({ isVisible: false })
+    dispatch({ inProgress: false })
     navigation.getParent()?.dispatch(
       CommonActions.reset({
         index: 1,
@@ -208,7 +208,7 @@ const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
   )
 
   useEffect(() => {
-    if (!state.isVisible || state.notificationRecord) {
+    if (!state.inProgress || state.notificationRecord) {
       return
     }
 
@@ -232,46 +232,34 @@ const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
   }, [notifications, state])
 
   return (
-    <Modal
-      visible={state.isVisible}
-      transparent={true}
-      animationType={'slide'}
-      onRequestClose={() => {
-        dispatch({ isVisible: false })
-      }}
-    >
-      <SafeAreaView style={{ backgroundColor: ColorPallet.brand.modalPrimaryBackground }}>
-        <ScrollView style={[styles.container]}>
-          <View style={[styles.messageContainer]}>
-            <Text
-              style={[TextTheme.modalHeadingThree, styles.messageText]}
-              testID={testIdWithKey('CredentialOnTheWay')}
-            >
-              {t('Connection.JustAMoment')}
-            </Text>
-          </View>
-
-          <View style={[styles.image]}>
-            <ConnectionLoading />
-          </View>
-
-          {state.shouldShowDelayMessage && (
-            <Text style={[TextTheme.modalNormal, styles.delayMessageText]} testID={testIdWithKey('TakingTooLong')}>
-              {t('Connection.TakingTooLong')}
-            </Text>
-          )}
-        </ScrollView>
-        <View style={[styles.controlsContainer]}>
-          <Button
-            title={t('Loading.BackToHome')}
-            accessibilityLabel={t('Loading.BackToHome')}
-            testID={testIdWithKey('BackToHome')}
-            onPress={onDismissModalTouched}
-            buttonType={ButtonType.ModalSecondary}
-          />
+    <SafeAreaView style={{ backgroundColor: ColorPallet.brand.modalPrimaryBackground }}>
+      <ScrollView style={styles.container}>
+        <View style={styles.messageContainer}>
+          <Text style={[TextTheme.modalHeadingThree, styles.messageText]} testID={testIdWithKey('CredentialOnTheWay')}>
+            {t('Connection.JustAMoment')}
+          </Text>
         </View>
-      </SafeAreaView>
-    </Modal>
+
+        <View style={styles.image}>
+          <ConnectionLoading />
+        </View>
+
+        {state.shouldShowDelayMessage && (
+          <Text style={[TextTheme.modalNormal, styles.delayMessageText]} testID={testIdWithKey('TakingTooLong')}>
+            {t('Connection.TakingTooLong')}
+          </Text>
+        )}
+      </ScrollView>
+      <View style={styles.controlsContainer}>
+        <Button
+          title={t('Loading.BackToHome')}
+          accessibilityLabel={t('Loading.BackToHome')}
+          testID={testIdWithKey('BackToHome')}
+          onPress={onDismissModalTouched}
+          buttonType={ButtonType.ModalSecondary}
+        />
+      </View>
+    </SafeAreaView>
   )
 }
 

--- a/packages/legacy/core/__tests__/screens/__snapshots__/Connection.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/Connection.test.tsx.snap
@@ -1,664 +1,1612 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Connection Modal Component Connection, no goal code navigation to chat 1`] = `
-<Modal
-  animationType="slide"
-  hardwareAccelerated={false}
-  onRequestClose={[Function]}
-  transparent={true}
-  visible={false}
-/>
+<RNCSafeAreaView
+  style={
+    Object {
+      "backgroundColor": "#000000",
+    }
+  }
+>
+  <RCTScrollView
+    style={
+      Object {
+        "backgroundColor": "#000000",
+        "height": "100%",
+        "padding": 20,
+      }
+    }
+  >
+    <View>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 26,
+                "fontWeight": "bold",
+              },
+              Object {
+                "fontWeight": "normal",
+                "marginTop": 30,
+                "textAlign": "center",
+              },
+            ]
+          }
+          testID="com.ariesbifold:id/CredentialOnTheWay"
+        >
+          Connection.JustAMoment
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "marginTop": 20,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            }
+          }
+        >
+          <
+            fill="#FFFFFF"
+            height={130}
+            style={
+              Object {
+                "position": "absolute",
+              }
+            }
+            width={130}
+          />
+          <View
+            collapsable={false}
+            style={
+              Object {
+                "transform": Array [
+                  Object {
+                    "rotate": "0deg",
+                  },
+                ],
+              }
+            }
+          >
+            <
+              fill="#FFFFFF"
+              height={250}
+              width={250}
+            />
+          </View>
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+  <View
+    style={
+      Object {
+        "margin": 20,
+        "marginTop": "auto",
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Loading.BackToHome"
+      accessibilityRole="button"
+      accessibilityState={
+        Object {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        Object {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "borderColor": "#42803E",
+          "borderRadius": 4,
+          "borderWidth": 2,
+          "opacity": 1,
+          "padding": 16,
+        }
+      }
+      testID="com.ariesbifold:id/BackToHome"
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#42803E",
+                "fontSize": 18,
+                "fontWeight": "bold",
+                "textAlign": "center",
+              },
+              false,
+              false,
+              false,
+            ]
+          }
+        >
+          Loading.BackToHome
+        </Text>
+      </View>
+    </View>
+  </View>
+</RNCSafeAreaView>
 `;
 
 exports[`Connection Modal Component Dismiss on demand 1`] = `
-<Modal
-  animationType="slide"
-  hardwareAccelerated={false}
-  onRequestClose={[Function]}
-  transparent={true}
-  visible={true}
+<RNCSafeAreaView
+  style={
+    Object {
+      "backgroundColor": "#000000",
+    }
+  }
 >
-  <RNCSafeAreaView
+  <RCTScrollView
     style={
       Object {
         "backgroundColor": "#000000",
+        "height": "100%",
+        "padding": 20,
       }
     }
   >
-    <RCTScrollView
-      style={
-        Array [
+    <View>
+      <View
+        style={
           Object {
-            "backgroundColor": "#000000",
-            "height": "100%",
-            "padding": 20,
-          },
-        ]
-      }
-    >
-      <View>
-        <View
-          style={
-            Array [
-              Object {
-                "alignItems": "center",
-              },
-            ]
+            "alignItems": "center",
           }
-        >
-          <Text
-            style={
-              Array [
-                Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 26,
-                  "fontWeight": "bold",
-                },
-                Object {
-                  "fontWeight": "normal",
-                  "marginTop": 30,
-                  "textAlign": "center",
-                },
-              ]
-            }
-            testID="com.ariesbifold:id/CredentialOnTheWay"
-          >
-            Connection.JustAMoment
-          </Text>
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "marginTop": 20,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Object {
-                "alignItems": "center",
-                "justifyContent": "center",
-              }
-            }
-          >
-            <
-              fill="#FFFFFF"
-              height={130}
-              style={
-                Object {
-                  "position": "absolute",
-                }
-              }
-              width={130}
-            />
-            <View
-              collapsable={false}
-              style={
-                Object {
-                  "transform": Array [
-                    Object {
-                      "rotate": "360deg",
-                    },
-                  ],
-                }
-              }
-            >
-              <
-                fill="#FFFFFF"
-                height={250}
-                width={250}
-              />
-            </View>
-          </View>
-        </View>
+        }
+      >
         <Text
           style={
             Array [
               Object {
                 "color": "#FFFFFF",
-                "fontSize": 18,
-                "fontWeight": "normal",
+                "fontSize": 26,
+                "fontWeight": "bold",
               },
               Object {
-                "marginTop": 20,
+                "fontWeight": "normal",
+                "marginTop": 30,
                 "textAlign": "center",
               },
             ]
           }
-          testID="com.ariesbifold:id/TakingTooLong"
+          testID="com.ariesbifold:id/CredentialOnTheWay"
         >
-          Connection.TakingTooLong
+          Connection.JustAMoment
         </Text>
       </View>
-    </RCTScrollView>
-    <View
-      style={
-        Array [
-          Object {
-            "margin": 20,
-            "marginTop": "auto",
-          },
-        ]
-      }
-    >
       <View
-        accessibilityLabel="Loading.BackToHome"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": false,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          Object {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "borderColor": "#42803E",
-            "borderRadius": 4,
-            "borderWidth": 2,
-            "opacity": 1,
-            "padding": 16,
+            "marginTop": 20,
           }
         }
-        testID="com.ariesbifold:id/BackToHome"
       >
         <View
           style={
             Object {
               "alignItems": "center",
-              "flexDirection": "row",
               "justifyContent": "center",
             }
           }
         >
-          <Text
+          <
+            fill="#FFFFFF"
+            height={130}
             style={
-              Array [
-                Object {
-                  "color": "#42803E",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
-                  "textAlign": "center",
-                },
-                false,
-                false,
-                false,
-              ]
+              Object {
+                "position": "absolute",
+              }
+            }
+            width={130}
+          />
+          <View
+            collapsable={false}
+            style={
+              Object {
+                "transform": Array [
+                  Object {
+                    "rotate": "360deg",
+                  },
+                ],
+              }
             }
           >
-            Loading.BackToHome
-          </Text>
+            <
+              fill="#FFFFFF"
+              height={250}
+              width={250}
+            />
+          </View>
         </View>
       </View>
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "#FFFFFF",
+              "fontSize": 18,
+              "fontWeight": "normal",
+            },
+            Object {
+              "marginTop": 20,
+              "textAlign": "center",
+            },
+          ]
+        }
+        testID="com.ariesbifold:id/TakingTooLong"
+      >
+        Connection.TakingTooLong
+      </Text>
     </View>
-  </RNCSafeAreaView>
-</Modal>
+  </RCTScrollView>
+  <View
+    style={
+      Object {
+        "margin": 20,
+        "marginTop": "auto",
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Loading.BackToHome"
+      accessibilityRole="button"
+      accessibilityState={
+        Object {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        Object {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "borderColor": "#42803E",
+          "borderRadius": 4,
+          "borderWidth": 2,
+          "opacity": 1,
+          "padding": 16,
+        }
+      }
+      testID="com.ariesbifold:id/BackToHome"
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#42803E",
+                "fontSize": 18,
+                "fontWeight": "bold",
+                "textAlign": "center",
+              },
+              false,
+              false,
+              false,
+            ]
+          }
+        >
+          Loading.BackToHome
+        </Text>
+      </View>
+    </View>
+  </View>
+</RNCSafeAreaView>
 `;
 
 exports[`Connection Modal Component Invalid goal code extracted, do nothing 1`] = `
-<Modal
-  animationType="slide"
-  hardwareAccelerated={false}
-  onRequestClose={[Function]}
-  transparent={true}
-  visible={false}
-/>
-`;
-
-exports[`Connection Modal Component No connection, navigation to proof 1`] = `
-<Modal
-  animationType="slide"
-  hardwareAccelerated={false}
-  onRequestClose={[Function]}
-  transparent={true}
-  visible={false}
-/>
-`;
-
-exports[`Connection Modal Component Renders correctly 1`] = `
-<Modal
-  animationType="slide"
-  hardwareAccelerated={false}
-  onRequestClose={[Function]}
-  transparent={true}
-  visible={true}
+<RNCSafeAreaView
+  style={
+    Object {
+      "backgroundColor": "#000000",
+    }
+  }
 >
-  <RNCSafeAreaView
+  <RCTScrollView
     style={
       Object {
         "backgroundColor": "#000000",
+        "height": "100%",
+        "padding": 20,
       }
     }
   >
-    <RCTScrollView
-      style={
-        Array [
-          Object {
-            "backgroundColor": "#000000",
-            "height": "100%",
-            "padding": 20,
-          },
-        ]
-      }
-    >
-      <View>
-        <View
-          style={
-            Array [
-              Object {
-                "alignItems": "center",
-              },
-            ]
-          }
-        >
-          <Text
-            style={
-              Array [
-                Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 26,
-                  "fontWeight": "bold",
-                },
-                Object {
-                  "fontWeight": "normal",
-                  "marginTop": 30,
-                  "textAlign": "center",
-                },
-              ]
-            }
-            testID="com.ariesbifold:id/CredentialOnTheWay"
-          >
-            Connection.JustAMoment
-          </Text>
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "marginTop": 20,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Object {
-                "alignItems": "center",
-                "justifyContent": "center",
-              }
-            }
-          >
-            <
-              fill="#FFFFFF"
-              height={130}
-              style={
-                Object {
-                  "position": "absolute",
-                }
-              }
-              width={130}
-            />
-            <View
-              collapsable={false}
-              style={
-                Object {
-                  "transform": Array [
-                    Object {
-                      "rotate": "0deg",
-                    },
-                  ],
-                }
-              }
-            >
-              <
-                fill="#FFFFFF"
-                height={250}
-                width={250}
-              />
-            </View>
-          </View>
-        </View>
-      </View>
-    </RCTScrollView>
-    <View
-      style={
-        Array [
-          Object {
-            "margin": 20,
-            "marginTop": "auto",
-          },
-        ]
-      }
-    >
+    <View>
       <View
-        accessibilityLabel="Loading.BackToHome"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": false,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          Object {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "borderColor": "#42803E",
-            "borderRadius": 4,
-            "borderWidth": 2,
-            "opacity": 1,
-            "padding": 16,
+            "alignItems": "center",
           }
         }
-        testID="com.ariesbifold:id/BackToHome"
       >
-        <View
-          style={
-            Object {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "justifyContent": "center",
-            }
-          }
-        >
-          <Text
-            style={
-              Array [
-                Object {
-                  "color": "#42803E",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
-                  "textAlign": "center",
-                },
-                false,
-                false,
-                false,
-              ]
-            }
-          >
-            Loading.BackToHome
-          </Text>
-        </View>
-      </View>
-    </View>
-  </RNCSafeAreaView>
-</Modal>
-`;
-
-exports[`Connection Modal Component Updates after delay 1`] = `
-<Modal
-  animationType="slide"
-  hardwareAccelerated={false}
-  onRequestClose={[Function]}
-  transparent={true}
-  visible={true}
->
-  <RNCSafeAreaView
-    style={
-      Object {
-        "backgroundColor": "#000000",
-      }
-    }
-  >
-    <RCTScrollView
-      style={
-        Array [
-          Object {
-            "backgroundColor": "#000000",
-            "height": "100%",
-            "padding": 20,
-          },
-        ]
-      }
-    >
-      <View>
-        <View
-          style={
-            Array [
-              Object {
-                "alignItems": "center",
-              },
-            ]
-          }
-        >
-          <Text
-            style={
-              Array [
-                Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 26,
-                  "fontWeight": "bold",
-                },
-                Object {
-                  "fontWeight": "normal",
-                  "marginTop": 30,
-                  "textAlign": "center",
-                },
-              ]
-            }
-            testID="com.ariesbifold:id/CredentialOnTheWay"
-          >
-            Connection.JustAMoment
-          </Text>
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "marginTop": 20,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Object {
-                "alignItems": "center",
-                "justifyContent": "center",
-              }
-            }
-          >
-            <
-              fill="#FFFFFF"
-              height={130}
-              style={
-                Object {
-                  "position": "absolute",
-                }
-              }
-              width={130}
-            />
-            <View
-              collapsable={false}
-              style={
-                Object {
-                  "transform": Array [
-                    Object {
-                      "rotate": "360deg",
-                    },
-                  ],
-                }
-              }
-            >
-              <
-                fill="#FFFFFF"
-                height={250}
-                width={250}
-              />
-            </View>
-          </View>
-        </View>
         <Text
           style={
             Array [
               Object {
                 "color": "#FFFFFF",
-                "fontSize": 18,
-                "fontWeight": "normal",
+                "fontSize": 26,
+                "fontWeight": "bold",
               },
               Object {
-                "marginTop": 20,
+                "fontWeight": "normal",
+                "marginTop": 30,
                 "textAlign": "center",
               },
             ]
           }
-          testID="com.ariesbifold:id/TakingTooLong"
+          testID="com.ariesbifold:id/CredentialOnTheWay"
         >
-          Connection.TakingTooLong
+          Connection.JustAMoment
         </Text>
       </View>
-    </RCTScrollView>
-    <View
-      style={
-        Array [
-          Object {
-            "margin": 20,
-            "marginTop": "auto",
-          },
-        ]
-      }
-    >
       <View
-        accessibilityLabel="Loading.BackToHome"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": false,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          Object {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "borderColor": "#42803E",
-            "borderRadius": 4,
-            "borderWidth": 2,
-            "opacity": 1,
-            "padding": 16,
+            "marginTop": 20,
           }
         }
-        testID="com.ariesbifold:id/BackToHome"
       >
         <View
           style={
             Object {
               "alignItems": "center",
-              "flexDirection": "row",
               "justifyContent": "center",
             }
           }
         >
-          <Text
+          <
+            fill="#FFFFFF"
+            height={130}
             style={
-              Array [
-                Object {
-                  "color": "#42803E",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
-                  "textAlign": "center",
-                },
-                false,
-                false,
-                false,
-              ]
+              Object {
+                "position": "absolute",
+              }
+            }
+            width={130}
+          />
+          <View
+            collapsable={false}
+            style={
+              Object {
+                "transform": Array [
+                  Object {
+                    "rotate": "360deg",
+                  },
+                ],
+              }
             }
           >
-            Loading.BackToHome
-          </Text>
+            <
+              fill="#FFFFFF"
+              height={250}
+              width={250}
+            />
+          </View>
+        </View>
+      </View>
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "#FFFFFF",
+              "fontSize": 18,
+              "fontWeight": "normal",
+            },
+            Object {
+              "marginTop": 20,
+              "textAlign": "center",
+            },
+          ]
+        }
+        testID="com.ariesbifold:id/TakingTooLong"
+      >
+        Connection.TakingTooLong
+      </Text>
+    </View>
+  </RCTScrollView>
+  <View
+    style={
+      Object {
+        "margin": 20,
+        "marginTop": "auto",
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Loading.BackToHome"
+      accessibilityRole="button"
+      accessibilityState={
+        Object {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        Object {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "borderColor": "#42803E",
+          "borderRadius": 4,
+          "borderWidth": 2,
+          "opacity": 1,
+          "padding": 16,
+        }
+      }
+      testID="com.ariesbifold:id/BackToHome"
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#42803E",
+                "fontSize": 18,
+                "fontWeight": "bold",
+                "textAlign": "center",
+              },
+              false,
+              false,
+              false,
+            ]
+          }
+        >
+          Loading.BackToHome
+        </Text>
+      </View>
+    </View>
+  </View>
+</RNCSafeAreaView>
+`;
+
+exports[`Connection Modal Component No connection, navigation to proof 1`] = `
+<RNCSafeAreaView
+  style={
+    Object {
+      "backgroundColor": "#000000",
+    }
+  }
+>
+  <RCTScrollView
+    style={
+      Object {
+        "backgroundColor": "#000000",
+        "height": "100%",
+        "padding": 20,
+      }
+    }
+  >
+    <View>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 26,
+                "fontWeight": "bold",
+              },
+              Object {
+                "fontWeight": "normal",
+                "marginTop": 30,
+                "textAlign": "center",
+              },
+            ]
+          }
+          testID="com.ariesbifold:id/CredentialOnTheWay"
+        >
+          Connection.JustAMoment
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "marginTop": 20,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            }
+          }
+        >
+          <
+            fill="#FFFFFF"
+            height={130}
+            style={
+              Object {
+                "position": "absolute",
+              }
+            }
+            width={130}
+          />
+          <View
+            collapsable={false}
+            style={
+              Object {
+                "transform": Array [
+                  Object {
+                    "rotate": "0deg",
+                  },
+                ],
+              }
+            }
+          >
+            <
+              fill="#FFFFFF"
+              height={250}
+              width={250}
+            />
+          </View>
         </View>
       </View>
     </View>
-  </RNCSafeAreaView>
-</Modal>
+  </RCTScrollView>
+  <View
+    style={
+      Object {
+        "margin": 20,
+        "marginTop": "auto",
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Loading.BackToHome"
+      accessibilityRole="button"
+      accessibilityState={
+        Object {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        Object {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "borderColor": "#42803E",
+          "borderRadius": 4,
+          "borderWidth": 2,
+          "opacity": 1,
+          "padding": 16,
+        }
+      }
+      testID="com.ariesbifold:id/BackToHome"
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#42803E",
+                "fontSize": 18,
+                "fontWeight": "bold",
+                "textAlign": "center",
+              },
+              false,
+              false,
+              false,
+            ]
+          }
+        >
+          Loading.BackToHome
+        </Text>
+      </View>
+    </View>
+  </View>
+</RNCSafeAreaView>
+`;
+
+exports[`Connection Modal Component Renders correctly 1`] = `
+<RNCSafeAreaView
+  style={
+    Object {
+      "backgroundColor": "#000000",
+    }
+  }
+>
+  <RCTScrollView
+    style={
+      Object {
+        "backgroundColor": "#000000",
+        "height": "100%",
+        "padding": 20,
+      }
+    }
+  >
+    <View>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 26,
+                "fontWeight": "bold",
+              },
+              Object {
+                "fontWeight": "normal",
+                "marginTop": 30,
+                "textAlign": "center",
+              },
+            ]
+          }
+          testID="com.ariesbifold:id/CredentialOnTheWay"
+        >
+          Connection.JustAMoment
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "marginTop": 20,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            }
+          }
+        >
+          <
+            fill="#FFFFFF"
+            height={130}
+            style={
+              Object {
+                "position": "absolute",
+              }
+            }
+            width={130}
+          />
+          <View
+            collapsable={false}
+            style={
+              Object {
+                "transform": Array [
+                  Object {
+                    "rotate": "0deg",
+                  },
+                ],
+              }
+            }
+          >
+            <
+              fill="#FFFFFF"
+              height={250}
+              width={250}
+            />
+          </View>
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+  <View
+    style={
+      Object {
+        "margin": 20,
+        "marginTop": "auto",
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Loading.BackToHome"
+      accessibilityRole="button"
+      accessibilityState={
+        Object {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        Object {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "borderColor": "#42803E",
+          "borderRadius": 4,
+          "borderWidth": 2,
+          "opacity": 1,
+          "padding": 16,
+        }
+      }
+      testID="com.ariesbifold:id/BackToHome"
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#42803E",
+                "fontSize": 18,
+                "fontWeight": "bold",
+                "textAlign": "center",
+              },
+              false,
+              false,
+              false,
+            ]
+          }
+        >
+          Loading.BackToHome
+        </Text>
+      </View>
+    </View>
+  </View>
+</RNCSafeAreaView>
+`;
+
+exports[`Connection Modal Component Updates after delay 1`] = `
+<RNCSafeAreaView
+  style={
+    Object {
+      "backgroundColor": "#000000",
+    }
+  }
+>
+  <RCTScrollView
+    style={
+      Object {
+        "backgroundColor": "#000000",
+        "height": "100%",
+        "padding": 20,
+      }
+    }
+  >
+    <View>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 26,
+                "fontWeight": "bold",
+              },
+              Object {
+                "fontWeight": "normal",
+                "marginTop": 30,
+                "textAlign": "center",
+              },
+            ]
+          }
+          testID="com.ariesbifold:id/CredentialOnTheWay"
+        >
+          Connection.JustAMoment
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "marginTop": 20,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            }
+          }
+        >
+          <
+            fill="#FFFFFF"
+            height={130}
+            style={
+              Object {
+                "position": "absolute",
+              }
+            }
+            width={130}
+          />
+          <View
+            collapsable={false}
+            style={
+              Object {
+                "transform": Array [
+                  Object {
+                    "rotate": "360deg",
+                  },
+                ],
+              }
+            }
+          >
+            <
+              fill="#FFFFFF"
+              height={250}
+              width={250}
+            />
+          </View>
+        </View>
+      </View>
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "#FFFFFF",
+              "fontSize": 18,
+              "fontWeight": "normal",
+            },
+            Object {
+              "marginTop": 20,
+              "textAlign": "center",
+            },
+          ]
+        }
+        testID="com.ariesbifold:id/TakingTooLong"
+      >
+        Connection.TakingTooLong
+      </Text>
+    </View>
+  </RCTScrollView>
+  <View
+    style={
+      Object {
+        "margin": 20,
+        "marginTop": "auto",
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Loading.BackToHome"
+      accessibilityRole="button"
+      accessibilityState={
+        Object {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        Object {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "borderColor": "#42803E",
+          "borderRadius": 4,
+          "borderWidth": 2,
+          "opacity": 1,
+          "padding": 16,
+        }
+      }
+      testID="com.ariesbifold:id/BackToHome"
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#42803E",
+                "fontSize": 18,
+                "fontWeight": "bold",
+                "textAlign": "center",
+              },
+              false,
+              false,
+              false,
+            ]
+          }
+        >
+          Loading.BackToHome
+        </Text>
+      </View>
+    </View>
+  </View>
+</RNCSafeAreaView>
 `;
 
 exports[`Connection Modal Component Valid goal code aries.vc.issue extracted, navigation to accept offer 1`] = `
-<Modal
-  animationType="slide"
-  hardwareAccelerated={false}
-  onRequestClose={[Function]}
-  transparent={true}
-  visible={false}
-/>
+<RNCSafeAreaView
+  style={
+    Object {
+      "backgroundColor": "#000000",
+    }
+  }
+>
+  <RCTScrollView
+    style={
+      Object {
+        "backgroundColor": "#000000",
+        "height": "100%",
+        "padding": 20,
+      }
+    }
+  >
+    <View>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 26,
+                "fontWeight": "bold",
+              },
+              Object {
+                "fontWeight": "normal",
+                "marginTop": 30,
+                "textAlign": "center",
+              },
+            ]
+          }
+          testID="com.ariesbifold:id/CredentialOnTheWay"
+        >
+          Connection.JustAMoment
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "marginTop": 20,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            }
+          }
+        >
+          <
+            fill="#FFFFFF"
+            height={130}
+            style={
+              Object {
+                "position": "absolute",
+              }
+            }
+            width={130}
+          />
+          <View
+            collapsable={false}
+            style={
+              Object {
+                "transform": Array [
+                  Object {
+                    "rotate": "0deg",
+                  },
+                ],
+              }
+            }
+          >
+            <
+              fill="#FFFFFF"
+              height={250}
+              width={250}
+            />
+          </View>
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+  <View
+    style={
+      Object {
+        "margin": 20,
+        "marginTop": "auto",
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Loading.BackToHome"
+      accessibilityRole="button"
+      accessibilityState={
+        Object {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        Object {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "borderColor": "#42803E",
+          "borderRadius": 4,
+          "borderWidth": 2,
+          "opacity": 1,
+          "padding": 16,
+        }
+      }
+      testID="com.ariesbifold:id/BackToHome"
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#42803E",
+                "fontSize": 18,
+                "fontWeight": "bold",
+                "textAlign": "center",
+              },
+              false,
+              false,
+              false,
+            ]
+          }
+        >
+          Loading.BackToHome
+        </Text>
+      </View>
+    </View>
+  </View>
+</RNCSafeAreaView>
 `;
 
 exports[`Connection Modal Component Valid goal code aries.vc.verify extracted, navigation to proof request 1`] = `
-<Modal
-  animationType="slide"
-  hardwareAccelerated={false}
-  onRequestClose={[Function]}
-  transparent={true}
-  visible={false}
-/>
+<RNCSafeAreaView
+  style={
+    Object {
+      "backgroundColor": "#000000",
+    }
+  }
+>
+  <RCTScrollView
+    style={
+      Object {
+        "backgroundColor": "#000000",
+        "height": "100%",
+        "padding": 20,
+      }
+    }
+  >
+    <View>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 26,
+                "fontWeight": "bold",
+              },
+              Object {
+                "fontWeight": "normal",
+                "marginTop": 30,
+                "textAlign": "center",
+              },
+            ]
+          }
+          testID="com.ariesbifold:id/CredentialOnTheWay"
+        >
+          Connection.JustAMoment
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "marginTop": 20,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            }
+          }
+        >
+          <
+            fill="#FFFFFF"
+            height={130}
+            style={
+              Object {
+                "position": "absolute",
+              }
+            }
+            width={130}
+          />
+          <View
+            collapsable={false}
+            style={
+              Object {
+                "transform": Array [
+                  Object {
+                    "rotate": "0deg",
+                  },
+                ],
+              }
+            }
+          >
+            <
+              fill="#FFFFFF"
+              height={250}
+              width={250}
+            />
+          </View>
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+  <View
+    style={
+      Object {
+        "margin": 20,
+        "marginTop": "auto",
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Loading.BackToHome"
+      accessibilityRole="button"
+      accessibilityState={
+        Object {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        Object {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "borderColor": "#42803E",
+          "borderRadius": 4,
+          "borderWidth": 2,
+          "opacity": 1,
+          "padding": 16,
+        }
+      }
+      testID="com.ariesbifold:id/BackToHome"
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#42803E",
+                "fontSize": 18,
+                "fontWeight": "bold",
+                "textAlign": "center",
+              },
+              false,
+              false,
+              false,
+            ]
+          }
+        >
+          Loading.BackToHome
+        </Text>
+      </View>
+    </View>
+  </View>
+</RNCSafeAreaView>
 `;
 
 exports[`Connection Modal Component Valid goal code aries.vc.verify.once extracted, navigation to proof request 1`] = `
-<Modal
-  animationType="slide"
-  hardwareAccelerated={false}
-  onRequestClose={[Function]}
-  transparent={true}
-  visible={false}
-/>
+<RNCSafeAreaView
+  style={
+    Object {
+      "backgroundColor": "#000000",
+    }
+  }
+>
+  <RCTScrollView
+    style={
+      Object {
+        "backgroundColor": "#000000",
+        "height": "100%",
+        "padding": 20,
+      }
+    }
+  >
+    <View>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 26,
+                "fontWeight": "bold",
+              },
+              Object {
+                "fontWeight": "normal",
+                "marginTop": 30,
+                "textAlign": "center",
+              },
+            ]
+          }
+          testID="com.ariesbifold:id/CredentialOnTheWay"
+        >
+          Connection.JustAMoment
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "marginTop": 20,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            }
+          }
+        >
+          <
+            fill="#FFFFFF"
+            height={130}
+            style={
+              Object {
+                "position": "absolute",
+              }
+            }
+            width={130}
+          />
+          <View
+            collapsable={false}
+            style={
+              Object {
+                "transform": Array [
+                  Object {
+                    "rotate": "0deg",
+                  },
+                ],
+              }
+            }
+          >
+            <
+              fill="#FFFFFF"
+              height={250}
+              width={250}
+            />
+          </View>
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+  <View
+    style={
+      Object {
+        "margin": 20,
+        "marginTop": "auto",
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Loading.BackToHome"
+      accessibilityRole="button"
+      accessibilityState={
+        Object {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        Object {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "borderColor": "#42803E",
+          "borderRadius": 4,
+          "borderWidth": 2,
+          "opacity": 1,
+          "padding": 16,
+        }
+      }
+      testID="com.ariesbifold:id/BackToHome"
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#42803E",
+                "fontSize": 18,
+                "fontWeight": "bold",
+                "textAlign": "center",
+              },
+              false,
+              false,
+              false,
+            ]
+          }
+        >
+          Loading.BackToHome
+        </Text>
+      </View>
+    </View>
+  </View>
+</RNCSafeAreaView>
 `;


### PR DESCRIPTION
# Summary of Changes

This PR makes the `Connection.tsx` just a screen, not also a modal. I had to make a couple small changes to get the animation to still be the classic modal animation. Two other fixes are included:
- adding an `initialRoute` prop to the tab navigator to fix the constant `Sending onAnimatedValueUpdate with no listeners registered` warnings
- sending the proper param from the connection invitation screen

# Related Issues
N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
