### PR TITLE
fix: add custom notifications dependency

### DIFF
--- a/packages/legacy/core/App/container-impl.ts
+++ b/packages/legacy/core/App/container-impl.ts
@@ -13,6 +13,7 @@ import { LocalStorageKeys } from './constants'
 import { TOKENS, Container, TokenMapping } from './container-api'
 import { DispatchAction, ReducerAction } from './contexts/reducers/store'
 import { defaultState } from './contexts/store'
+import { defaultCustomNotifications } from './defaultConfiguration'
 import { IHistoryManager } from './modules/history'
 import HistoryManager from './modules/history/context/historyManager'
 import OnboardingStack from './navigators/OnboardingStack'
@@ -60,6 +61,7 @@ export class MainContainer implements Container {
     this._container.registerInstance(TOKENS.UTIL_LOGGER, new ConsoleLogger())
     this._container.registerInstance(TOKENS.UTIL_OCA_RESOLVER, new DefaultOCABundleResolver(bundle))
     this._container.registerInstance(TOKENS.UTIL_LEDGERS, defaultIndyLedgers)
+    this._container.registerInstance(TOKENS.CUSTOM_NOTIFICATION, defaultCustomNotifications)
     this._container.registerInstance(TOKENS.UTIL_PROOF_TEMPLATE, useProofRequestTemplates)
     this._container.registerInstance(TOKENS.CACHE_CRED_DEFS, [])
     this._container.registerInstance(TOKENS.CACHE_SCHEMAS, [])

--- a/packages/legacy/core/App/defaultConfiguration.ts
+++ b/packages/legacy/core/App/defaultConfiguration.ts
@@ -1,4 +1,3 @@
-import { CustomNotification } from './types/notification'
 import EmptyList from './components/misc/EmptyList'
 import Record from './components/record/Record'
 import HomeFooterView from './components/views/HomeFooterView'
@@ -14,9 +13,9 @@ import Scan from './screens/Scan'
 import Splash from './screens/Splash'
 import Terms from './screens/Terms'
 import UseBiometry from './screens/UseBiometry'
+import { CustomNotification } from './types/notification'
 
-export const defaultCustomNotifications: CustomNotification = 
-{
+export const defaultCustomNotifications: CustomNotification = {
   component: () => null,
   onCloseAction: () => null,
   title: '',

--- a/packages/legacy/core/App/defaultConfiguration.ts
+++ b/packages/legacy/core/App/defaultConfiguration.ts
@@ -1,3 +1,4 @@
+import { CustomNotification } from './types/notification'
 import EmptyList from './components/misc/EmptyList'
 import Record from './components/record/Record'
 import HomeFooterView from './components/views/HomeFooterView'
@@ -13,6 +14,16 @@ import Scan from './screens/Scan'
 import Splash from './screens/Splash'
 import Terms from './screens/Terms'
 import UseBiometry from './screens/UseBiometry'
+
+export const defaultCustomNotifications: CustomNotification = 
+{
+  component: () => null,
+  onCloseAction: () => null,
+  title: '',
+  description: '',
+  buttonTitle: '',
+  pageTitle: '',
+}
 
 export const defaultConfiguration: ConfigurationContext = {
   pages: OnboardingPages,


### PR DESCRIPTION
# Summary of Changes

This PR #1211  moved custom notifications from default config to be DI injected but it missed adding the dependency in the app so the sample app crashes on start for missing dependency



- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
