### PR TITLE
fix: convert tour modal to an abs overlay

### DIFF
--- a/packages/legacy/app/App.tsx
+++ b/packages/legacy/app/App.tsx
@@ -2,7 +2,6 @@ import {
   AgentProvider,
   AnimatedComponentsProvider,
   AuthProvider,
-  CommonUtilProvider,
   ConfigurationProvider,
   ErrorModal,
   NetInfo,
@@ -54,31 +53,29 @@ const App = () => {
         <ThemeProvider value={theme}>
           <AnimatedComponentsProvider value={animatedComponents}>
             <ConfigurationProvider value={defaultConfiguration}>
-              <CommonUtilProvider>
-                <AuthProvider>
-                  <NetworkProvider>
-                    <StatusBar
-                      hidden={false}
-                      barStyle="light-content"
-                      backgroundColor={theme.ColorPallet.brand.primary}
-                      translucent={false}
-                    />
-                    <NetInfo />
-                    <ErrorModal />
-                    <TourProvider
-                      homeTourSteps={homeTourSteps}
-                      credentialsTourSteps={credentialsTourSteps}
-                      credentialOfferTourSteps={credentialOfferTourSteps}
-                      proofRequestTourSteps={proofRequestTourSteps}
-                      overlayColor={'gray'}
-                      overlayOpacity={0.7}
-                    >
-                      <RootStack />
-                    </TourProvider>
-                    <Toast topOffset={15} config={toastConfig} />
-                  </NetworkProvider>
-                </AuthProvider>
-              </CommonUtilProvider>
+              <AuthProvider>
+                <NetworkProvider>
+                  <StatusBar
+                    hidden={false}
+                    barStyle="light-content"
+                    backgroundColor={theme.ColorPallet.brand.primary}
+                    translucent={false}
+                  />
+                  <NetInfo />
+                  <ErrorModal />
+                  <TourProvider
+                    homeTourSteps={homeTourSteps}
+                    credentialsTourSteps={credentialsTourSteps}
+                    credentialOfferTourSteps={credentialOfferTourSteps}
+                    proofRequestTourSteps={proofRequestTourSteps}
+                    overlayColor={'gray'}
+                    overlayOpacity={0.7}
+                  >
+                    <RootStack />
+                  </TourProvider>
+                  <Toast topOffset={15} config={toastConfig} />
+                </NetworkProvider>
+              </AuthProvider>
             </ConfigurationProvider>
           </AnimatedComponentsProvider>
         </ThemeProvider>

--- a/packages/legacy/core/App/components/tour/TourOverlay.tsx
+++ b/packages/legacy/core/App/components/tour/TourOverlay.tsx
@@ -84,56 +84,47 @@ export const TourOverlay = (props: TourOverlayProps) => {
     setViewBox(`0 0 ${windowWidth + 1} ${windowHeight + 1}`)
   }, [windowWidth, windowHeight])
 
-  return (
-    <Modal
-      animationType="fade"
-      presentationStyle="overFullScreen"
-      transparent={true}
-      visible={currentStep !== undefined}
-    >
-      <View style={{ height: windowHeight + 1, width: windowWidth + 1 }} testID={testIdWithKey('SpotlightOverlay')}>
-        <Svg
-          testID={testIdWithKey('SpotOverlay')}
+  return currentStep !== undefined ? (
+    <View style={{ position: 'absolute', top: 0, left: 0, height: windowHeight + 1, width: windowWidth + 1 }} testID={testIdWithKey('SpotlightOverlay')}>
+      <Svg
+        testID={testIdWithKey('SpotOverlay')}
+        height={windowHeight + 1}
+        width={windowWidth + 1}
+        viewBox={viewBox}
+        onPress={handleBackdropPress}
+        shouldRasterizeIOS={true}
+        renderToHardwareTextureAndroid={true}
+      >
+        <Defs>
+          <Mask id="mask" x={0} y={0} height={windowHeight + 1} width={windowWidth + 1}>
+            <Rect height={windowHeight + 1} width={windowWidth + 1} fill="#fff" />
+            <SpotCutout />
+          </Mask>
+        </Defs>
+
+        <Rect
           height={windowHeight + 1}
           width={windowWidth + 1}
-          viewBox={viewBox}
-          onPress={handleBackdropPress}
-          shouldRasterizeIOS={true}
-          renderToHardwareTextureAndroid={true}
-        >
-          <Defs>
-            <Mask id="mask" x={0} y={0} height={windowHeight + 1} width={windowWidth + 1}>
-              <Rect height={windowHeight + 1} width={windowWidth + 1} fill="#fff" />
-              <SpotCutout />
-            </Mask>
-          </Defs>
+          fill={color}
+          mask="url(#mask)"
+          opacity={backdropOpacity}
+        />
+      </Svg>
 
-          <Rect
-            height={windowHeight + 1}
-            width={windowWidth + 1}
-            fill={color}
-            mask="url(#mask)"
-            opacity={backdropOpacity}
-          />
-        </Svg>
-
-        <View
-          ref={tooltipRef}
-          testID={testIdWithKey('SpotTooltip')}
-          style={{ ...tooltipStyle, opacity: 1, position: 'absolute' }}
-        >
-          {currentStep !== undefined && (
-            <tourStep.render
-              currentTour={currentTour}
-              currentStep={currentStep}
-              changeSpot={changeSpot}
-              next={next}
-              previous={previous}
-              stop={stop}
-            />
-          )}
-        </View>
+      <View
+        ref={tooltipRef}
+        testID={testIdWithKey('SpotTooltip')}
+        style={{ ...tooltipStyle, opacity: 1, position: 'absolute' }}
+      >
+        <tourStep.render
+          currentTour={currentTour}
+          currentStep={currentStep}
+          changeSpot={changeSpot}
+          next={next}
+          previous={previous}
+          stop={stop}
+        />
       </View>
-    </Modal>
-  )
+    </View>
+  ) : null
 }

--- a/packages/legacy/core/App/components/tour/TourOverlay.tsx
+++ b/packages/legacy/core/App/components/tour/TourOverlay.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useRef, useState, useEffect } from 'react'
-import { ColorValue, LayoutRectangle, Modal, View, ViewStyle, useWindowDimensions } from 'react-native'
+import { ColorValue, LayoutRectangle, View, ViewStyle, useWindowDimensions } from 'react-native'
 import { Defs, Mask, Rect, Svg } from 'react-native-svg'
 
 import { tourMargin } from '../../constants'

--- a/packages/legacy/core/__tests__/components/InfoBox.test.tsx
+++ b/packages/legacy/core/__tests__/components/InfoBox.test.tsx
@@ -10,7 +10,7 @@ jest.mock('../../App/contexts/configuration', () => ({
   useConfiguration: jest.fn(),
 }))
 
-describe('ErrorModal Component', () => {
+describe('InfoBox Component', () => {
   test('Renders correctly as Info', async () => {
     const tree = render(
       <InfoBox
@@ -95,6 +95,7 @@ describe('ErrorModal Component', () => {
 
     expect(callToAction).toBeCalledTimes(1)
   })
+
   beforeEach(() => {
     // @ts-ignore-next-line
     useConfiguration.mockReturnValue({ showDetailsInfo: true })

--- a/packages/legacy/core/__tests__/components/__snapshots__/AttachTourStep.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/AttachTourStep.test.tsx.snap
@@ -1,25 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AttachTourStep Renders properly with defaults 1`] = `
-Array [
-  <View
-    collapsable={false}
-    focusable={false}
-    style={
-      Object {
-        "alignSelf": "center",
-      }
+<View
+  collapsable={false}
+  focusable={false}
+  style={
+    Object {
+      "alignSelf": "center",
     }
-    testID="com.ariesbifold:id/AttachTourStep"
-  >
-    <View />
-  </View>,
-  <Modal
-    animationType="fade"
-    hardwareAccelerated={false}
-    presentationStyle="overFullScreen"
-    transparent={true}
-    visible={false}
-  />,
-]
+  }
+  testID="com.ariesbifold:id/AttachTourStep"
+>
+  <View />
+</View>
 `;

--- a/packages/legacy/core/__tests__/components/__snapshots__/InfoBox.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/InfoBox.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ErrorModal Component Renders correctly as Error 1`] = `
+exports[`InfoBox Component Renders correctly as Error 1`] = `
 <View
   style={
     Object {
@@ -254,7 +254,7 @@ exports[`ErrorModal Component Renders correctly as Error 1`] = `
 </View>
 `;
 
-exports[`ErrorModal Component Renders correctly as Info 1`] = `
+exports[`InfoBox Component Renders correctly as Info 1`] = `
 <View
   style={
     Object {
@@ -508,7 +508,7 @@ exports[`ErrorModal Component Renders correctly as Info 1`] = `
 </View>
 `;
 
-exports[`ErrorModal Component Renders correctly as Success 1`] = `
+exports[`InfoBox Component Renders correctly as Success 1`] = `
 <View
   style={
     Object {
@@ -762,7 +762,7 @@ exports[`ErrorModal Component Renders correctly as Success 1`] = `
 </View>
 `;
 
-exports[`ErrorModal Component Renders correctly as Warning 1`] = `
+exports[`InfoBox Component Renders correctly as Warning 1`] = `
 <View
   style={
     Object {

--- a/packages/legacy/core/__tests__/components/__snapshots__/SpotCutout.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/SpotCutout.test.tsx.snap
@@ -1,11 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SpotCutout Renders properly with defaults 1`] = `
-<Modal
-  animationType="fade"
-  hardwareAccelerated={false}
-  presentationStyle="overFullScreen"
-  transparent={true}
-  visible={false}
-/>
-`;
+exports[`SpotCutout Renders properly with defaults 1`] = `null`;

--- a/packages/legacy/core/__tests__/components/__snapshots__/TourBox.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/TourBox.test.tsx.snap
@@ -1,282 +1,273 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TourBox Renders properly with defaults 1`] = `
-Array [
+<View
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    Object {
+      "backgroundColor": "#313132",
+      "borderColor": "#0099FF",
+      "borderRadius": 5,
+      "borderWidth": 1,
+      "flex": 1,
+      "margin": "auto",
+      "padding": 20,
+    }
+  }
+>
   <View
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
     style={
       Object {
-        "backgroundColor": "#313132",
-        "borderColor": "#0099FF",
-        "borderRadius": 5,
-        "borderWidth": 1,
-        "flex": 1,
-        "margin": "auto",
-        "padding": 20,
+        "flexDirection": "row",
+        "justifyContent": "space-between",
       }
     }
   >
     <View
       style={
         Object {
-          "flexDirection": "row",
-          "justifyContent": "space-between",
+          "flexGrow": 1,
         }
       }
     >
-      <View
+      <Text
+        allowFontScaling={false}
         style={
           Object {
-            "flexGrow": 1,
+            "alignSelf": "flex-start",
+            "color": "#FFFFFF",
+            "fontSize": 26,
+            "fontWeight": "bold",
           }
         }
+        testID="com.ariesbifold:id/HeaderText"
+      >
+        Title
+      </Text>
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "alignSelf": "flex-end",
+          },
+        ]
+      }
+    >
+      <View
+        accessibilityLabel="Global.Close"
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          Object {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        hitSlop={
+          Object {
+            "bottom": 44,
+            "left": 44,
+            "right": 44,
+            "top": 44,
+          }
+        }
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID="com.ariesbifold:id/Close"
+      >
+        <Text
+          allowFontScaling={false}
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "color": "#0099FF",
+                "fontSize": 30,
+              },
+              undefined,
+              Object {
+                "fontFamily": "Material Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "marginVertical": 16,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "justifyContent": "space-around",
+      }
+    }
+  >
+    <View>
+      <View
+        accessibilityLabel="Left"
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          Object {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        hitSlop={
+          Object {
+            "bottom": 44,
+            "left": 44,
+            "right": 44,
+            "top": 44,
+          }
+        }
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID="com.ariesbifold:id/Back"
       >
         <Text
           allowFontScaling={false}
           style={
             Object {
-              "alignSelf": "flex-start",
-              "color": "#FFFFFF",
-              "fontSize": 26,
+              "color": "#42803E",
+              "fontSize": 18,
               "fontWeight": "bold",
             }
           }
-          testID="com.ariesbifold:id/HeaderText"
         >
-          Title
+          Left
         </Text>
-      </View>
-      <View
-        style={
-          Array [
-            Object {
-              "alignSelf": "flex-end",
-            },
-          ]
-        }
-      >
-        <View
-          accessibilityLabel="Global.Close"
-          accessibilityRole="button"
-          accessibilityState={
-            Object {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            Object {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          collapsable={false}
-          focusable={true}
-          hitSlop={
-            Object {
-              "bottom": 44,
-              "left": 44,
-              "right": 44,
-              "top": 44,
-            }
-          }
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Object {
-              "opacity": 1,
-            }
-          }
-          testID="com.ariesbifold:id/Close"
-        >
-          <Text
-            allowFontScaling={false}
-            selectable={false}
-            style={
-              Array [
-                Object {
-                  "color": "#0099FF",
-                  "fontSize": 30,
-                },
-                undefined,
-                Object {
-                  "fontFamily": "Material Icons",
-                  "fontStyle": "normal",
-                  "fontWeight": "normal",
-                },
-                Object {},
-              ]
-            }
-          >
-            
-          </Text>
-        </View>
       </View>
     </View>
     <View
       style={
         Object {
-          "flex": 1,
-          "marginVertical": 16,
+          "alignSelf": "center",
+          "flexDirection": "row",
         }
       }
     />
-    <View
-      style={
-        Object {
-          "flexDirection": "row",
-          "justifyContent": "space-around",
-        }
-      }
-    >
-      <View>
-        <View
-          accessibilityLabel="Left"
-          accessibilityRole="button"
-          accessibilityState={
-            Object {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            Object {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          collapsable={false}
-          focusable={true}
-          hitSlop={
-            Object {
-              "bottom": 44,
-              "left": 44,
-              "right": 44,
-              "top": 44,
-            }
-          }
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Object {
-              "opacity": 1,
-            }
-          }
-          testID="com.ariesbifold:id/Back"
-        >
-          <Text
-            allowFontScaling={false}
-            style={
-              Object {
-                "color": "#42803E",
-                "fontSize": 18,
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Left
-          </Text>
-        </View>
-      </View>
+    <View>
       <View
+        accessibilityLabel="Right"
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          Object {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        hitSlop={
+          Object {
+            "bottom": 44,
+            "left": 44,
+            "right": 44,
+            "top": 44,
+          }
+        }
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "alignSelf": "center",
-            "flexDirection": "row",
+            "opacity": 1,
           }
         }
-      />
-      <View>
-        <View
-          accessibilityLabel="Right"
-          accessibilityRole="button"
-          accessibilityState={
-            Object {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            Object {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          collapsable={false}
-          focusable={true}
-          hitSlop={
-            Object {
-              "bottom": 44,
-              "left": 44,
-              "right": 44,
-              "top": 44,
-            }
-          }
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
+        testID="com.ariesbifold:id/Next"
+      >
+        <Text
+          allowFontScaling={false}
           style={
             Object {
-              "opacity": 1,
+              "color": "#42803E",
+              "fontSize": 18,
+              "fontWeight": "bold",
             }
           }
-          testID="com.ariesbifold:id/Next"
         >
-          <Text
-            allowFontScaling={false}
-            style={
-              Object {
-                "color": "#42803E",
-                "fontSize": 18,
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Right
-          </Text>
-        </View>
+          Right
+        </Text>
       </View>
     </View>
-  </View>,
-  <Modal
-    animationType="fade"
-    hardwareAccelerated={false}
-    presentationStyle="overFullScreen"
-    transparent={true}
-    visible={false}
-  />,
-]
+  </View>
+</View>
 `;

--- a/packages/legacy/core/__tests__/components/__snapshots__/TourOverlay.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/TourOverlay.test.tsx.snap
@@ -1,100 +1,79 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TourBox Renders properly with defaults 1`] = `
-Array [
-  <Modal
-    animationType="fade"
-    hardwareAccelerated={false}
-    presentationStyle="overFullScreen"
-    transparent={true}
-    visible={true}
-  >
-    <View
-      style={
+<View
+  style={
+    Object {
+      "height": 1335,
+      "left": 0,
+      "position": "absolute",
+      "top": 0,
+      "width": 751,
+    }
+  }
+  testID="com.ariesbifold:id/SpotlightOverlay"
+>
+  <RNSVGSvgView
+    align="xMidYMid"
+    bbHeight={1335}
+    bbWidth={751}
+    focusable={false}
+    height={1335}
+    meetOrSlice={0}
+    minX={0}
+    minY={0}
+    onPress={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    renderToHardwareTextureAndroid={true}
+    responsible={true}
+    shouldRasterizeIOS={true}
+    style={
+      Array [
         Object {
+          "backgroundColor": "transparent",
+          "borderWidth": 0,
+        },
+        Object {
+          "flex": 0,
           "height": 1335,
           "width": 751,
-        }
-      }
-      testID="com.ariesbifold:id/SpotlightOverlay"
-    >
-      <RNSVGSvgView
-        align="xMidYMid"
-        bbHeight={1335}
-        bbWidth={751}
-        focusable={false}
-        height={1335}
-        meetOrSlice={0}
-        minX={0}
-        minY={0}
-        onPress={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        renderToHardwareTextureAndroid={true}
-        responsible={true}
-        shouldRasterizeIOS={true}
-        style={
-          Array [
-            Object {
-              "backgroundColor": "transparent",
-              "borderWidth": 0,
-            },
-            Object {
-              "flex": 0,
-              "height": 1335,
-              "width": 751,
-            },
-          ]
-        }
-        testID="com.ariesbifold:id/SpotOverlay"
-        vbHeight={1335}
-        vbWidth={751}
-        width={751}
-      >
-        <RNSVGGroup>
-          <RNSVGDefs>
-            <RNSVGMask
-              height={1335}
-              maskContentUnits={1}
-              maskTransform={
-                Array [
-                  1,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0,
-                ]
-              }
-              maskUnits={0}
-              name="mask"
-              width={751}
-              x={0}
-              y={0}
-            >
-              <RNSVGRect
-                fill={4294967295}
-                height={1335}
-                propList={
-                  Array [
-                    "fill",
-                  ]
-                }
-                width={751}
-                x={0}
-                y={0}
-              />
-            </RNSVGMask>
-          </RNSVGDefs>
+        },
+      ]
+    }
+    testID="com.ariesbifold:id/SpotOverlay"
+    vbHeight={1335}
+    vbWidth={751}
+    width={751}
+  >
+    <RNSVGGroup>
+      <RNSVGDefs>
+        <RNSVGMask
+          height={1335}
+          maskContentUnits={1}
+          maskTransform={
+            Array [
+              1,
+              0,
+              0,
+              1,
+              0,
+              0,
+            ]
+          }
+          maskUnits={0}
+          name="mask"
+          width={751}
+          x={0}
+          y={0}
+        >
           <RNSVGRect
-            fill={4286611584}
+            fill={4294967295}
             height={1335}
-            mask="mask"
-            opacity={0.7}
             propList={
               Array [
                 "fill",
@@ -104,34 +83,41 @@ Array [
             x={0}
             y={0}
           />
-        </RNSVGGroup>
-      </RNSVGSvgView>
-      <View
-        style={
-          Object {
-            "left": 25,
-            "opacity": 1,
-            "position": "absolute",
-            "right": 25,
-            "top": 222.33333333333334,
-          }
+        </RNSVGMask>
+      </RNSVGDefs>
+      <RNSVGRect
+        fill={4286611584}
+        height={1335}
+        mask="mask"
+        opacity={0.7}
+        propList={
+          Array [
+            "fill",
+          ]
         }
-        testID="com.ariesbifold:id/SpotTooltip"
-      >
-        <View>
-          <Text>
-            Test
-          </Text>
-        </View>
-      </View>
+        width={751}
+        x={0}
+        y={0}
+      />
+    </RNSVGGroup>
+  </RNSVGSvgView>
+  <View
+    style={
+      Object {
+        "left": 25,
+        "opacity": 1,
+        "position": "absolute",
+        "right": 25,
+        "top": 222.33333333333334,
+      }
+    }
+    testID="com.ariesbifold:id/SpotTooltip"
+  >
+    <View>
+      <Text>
+        Test
+      </Text>
     </View>
-  </Modal>,
-  <Modal
-    animationType="fade"
-    hardwareAccelerated={false}
-    presentationStyle="overFullScreen"
-    transparent={true}
-    visible={false}
-  />,
-]
+  </View>
+</View>
 `;


### PR DESCRIPTION
# Summary of Changes

App guides work as they did before, just now they don't use a modal for the overlay, just an absolutely positioned view. Also fixed a couple minor things, renamed a misnamed test and removed an no longer existing provider 

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
