### PR TITLE
fix: rules of hooks lint warnings

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -87,7 +87,6 @@ export default [
       'no-unsafe-optional-chaining': 'warn',
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/ban-ts-comment': 'warn',
-      'react-hooks/rules-of-hooks': 'warn',
       "react-hooks/exhaustive-deps": "warn",
     }
   },

--- a/packages/legacy/core/App/components/misc/ConnectionImage.tsx
+++ b/packages/legacy/core/App/components/misc/ConnectionImage.tsx
@@ -3,7 +3,7 @@ import { Image, StyleSheet, View } from 'react-native'
 
 import { useTheme } from '../../contexts/theme'
 import { toImageSource } from '../../utils/credential'
-import { getConnectionImageUrl } from '../../utils/helpers'
+import { useConnectionImageUrl } from '../../utils/helpers'
 
 interface ConnectionImageProps {
   connectionId?: string
@@ -30,7 +30,7 @@ const ConnectionImage: React.FC<ConnectionImageProps> = ({ connectionId }) => {
     },
   })
 
-  const connectionImage = getConnectionImageUrl(connectionId ?? '')
+  const connectionImage = useConnectionImageUrl(connectionId ?? '')
 
   return connectionImage ? (
     <View style={styles.connectionImageContainer}>

--- a/packages/legacy/core/App/components/misc/CredentialCard10.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard10.tsx
@@ -15,7 +15,7 @@ import {
   isValidAnonCredsCredential,
   toImageSource,
 } from '../../utils/credential'
-import { formatTime, getCredentialConnectionLabel } from '../../utils/helpers'
+import { formatTime, useCredentialConnectionLabel } from '../../utils/helpers'
 import { buildFieldsFromAnonCredsCredential } from '../../utils/oca'
 import { testIdWithKey } from '../../utils/testable'
 
@@ -74,7 +74,7 @@ const CredentialCard10: React.FC<CredentialCard10Props> = ({ credential, style =
   const { ColorPallet, TextTheme } = useTheme()
   const [overlay, setOverlay] = useState<CredentialOverlay<LegacyBrandingOverlay>>({})
   const [isRevoked, setIsRevoked] = useState<boolean>(false)
-  const credentialConnectionLabel = getCredentialConnectionLabel(credential)
+  const credentialConnectionLabel = useCredentialConnectionLabel(credential)
   const [bundleResolver] = useServices([TOKENS.UTIL_OCA_RESOLVER])
 
   const styles = StyleSheet.create({

--- a/packages/legacy/core/App/components/misc/CredentialCard11.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard11.tsx
@@ -23,7 +23,7 @@ import { TOKENS, useServices } from '../../container-api'
 import { useTheme } from '../../contexts/theme'
 import { GenericFn } from '../../types/fn'
 import { credentialTextColor, getCredentialIdentifiers, toImageSource } from '../../utils/credential'
-import { formatIfDate, getCredentialConnectionLabel, isDataUrl, pTypeToText } from '../../utils/helpers'
+import { formatIfDate, useCredentialConnectionLabel, isDataUrl, pTypeToText } from '../../utils/helpers'
 import { shadeIsLightOrDark, Shade } from '../../utils/luminance'
 import { testIdWithKey } from '../../utils/testable'
 
@@ -101,7 +101,7 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
   const [isRevoked, setIsRevoked] = useState<boolean>(credential?.revocationNotification !== undefined)
   const [flaggedAttributes, setFlaggedAttributes] = useState<string[]>()
   const [allPI, setAllPI] = useState<boolean>()
-  const credentialConnectionLabel = getCredentialConnectionLabel(credential)
+  const credentialConnectionLabel = useCredentialConnectionLabel(credential)
   const [isProofRevoked, setIsProofRevoked] = useState<boolean>(
     credential?.revocationNotification !== undefined && !!proof
   )

--- a/packages/legacy/core/App/components/tour/CredentialOfferTourSteps.tsx
+++ b/packages/legacy/core/App/components/tour/CredentialOfferTourSteps.tsx
@@ -3,13 +3,13 @@ import { useTranslation } from 'react-i18next'
 import { Text } from 'react-native'
 
 import { useTheme } from '../../contexts/theme'
-import { TourStep } from '../../contexts/tour/tour-context'
+import { RenderProps, TourStep } from '../../contexts/tour/tour-context'
 
 import { TourBox } from './TourBox'
 
 export const credentialOfferTourSteps: TourStep[] = [
   {
-    render: (props) => {
+    Render: (props: RenderProps) => {
       const { currentTour, currentStep, next, stop, previous } = props
       const { t } = useTranslation()
       const { ColorPallet, TextTheme } = useTheme()

--- a/packages/legacy/core/App/components/tour/CredentialsTourSteps.tsx
+++ b/packages/legacy/core/App/components/tour/CredentialsTourSteps.tsx
@@ -3,13 +3,13 @@ import { useTranslation } from 'react-i18next'
 import { Text } from 'react-native'
 
 import { useTheme } from '../../contexts/theme'
-import { TourStep } from '../../contexts/tour/tour-context'
+import { RenderProps, TourStep } from '../../contexts/tour/tour-context'
 
 import { TourBox } from './TourBox'
 
 export const credentialsTourSteps: TourStep[] = [
   {
-    render: (props) => {
+    Render: (props: RenderProps) => {
       const { currentTour, currentStep, next, stop, previous } = props
       const { t } = useTranslation()
       const { ColorPallet, TextTheme } = useTheme()

--- a/packages/legacy/core/App/components/tour/HomeTourSteps.tsx
+++ b/packages/legacy/core/App/components/tour/HomeTourSteps.tsx
@@ -3,13 +3,13 @@ import { useTranslation } from 'react-i18next'
 import { Text } from 'react-native'
 
 import { useTheme } from '../../contexts/theme'
-import { TourStep } from '../../contexts/tour/tour-context'
+import { RenderProps, TourStep } from '../../contexts/tour/tour-context'
 
 import { TourBox } from './TourBox'
 
 export const homeTourSteps: TourStep[] = [
   {
-    render: (props) => {
+    Render: (props: RenderProps) => {
       const { currentTour, currentStep, next, stop, previous } = props
       const { t } = useTranslation()
       const { ColorPallet, TextTheme } = useTheme()
@@ -40,7 +40,7 @@ export const homeTourSteps: TourStep[] = [
     },
   },
   {
-    render: (props) => {
+    Render: (props: RenderProps) => {
       const { currentTour, currentStep, next, stop, previous } = props
       const { t } = useTranslation()
       const { ColorPallet, TextTheme } = useTheme()
@@ -71,7 +71,7 @@ export const homeTourSteps: TourStep[] = [
     },
   },
   {
-    render: (props) => {
+    Render: (props: RenderProps) => {
       const { currentTour, currentStep, next, stop, previous } = props
       const { t } = useTranslation()
       const { ColorPallet, TextTheme } = useTheme()

--- a/packages/legacy/core/App/components/tour/ProofRequestTourSteps.tsx
+++ b/packages/legacy/core/App/components/tour/ProofRequestTourSteps.tsx
@@ -3,13 +3,13 @@ import { useTranslation } from 'react-i18next'
 import { Text } from 'react-native'
 
 import { useTheme } from '../../contexts/theme'
-import { TourStep } from '../../contexts/tour/tour-context'
+import { RenderProps, TourStep } from '../../contexts/tour/tour-context'
 
 import { TourBox } from './TourBox'
 
 export const proofRequestTourSteps: TourStep[] = [
   {
-    render: (props) => {
+    Render: (props: RenderProps) => {
       const { currentTour, currentStep, next, stop, previous } = props
       const { t } = useTranslation()
       const { ColorPallet, TextTheme } = useTheme()

--- a/packages/legacy/core/App/components/tour/TourOverlay.tsx
+++ b/packages/legacy/core/App/components/tour/TourOverlay.tsx
@@ -116,7 +116,7 @@ export const TourOverlay = (props: TourOverlayProps) => {
         testID={testIdWithKey('SpotTooltip')}
         style={{ ...tooltipStyle, opacity: 1, position: 'absolute' }}
       >
-        <tourStep.render
+        <tourStep.Render
           currentTour={currentTour}
           currentStep={currentStep}
           changeSpot={changeSpot}

--- a/packages/legacy/core/App/container-impl.ts
+++ b/packages/legacy/core/App/container-impl.ts
@@ -1,5 +1,5 @@
 import { BaseLogger, Agent } from '@credo-ts/core'
-import { useProofRequestTemplates } from '@hyperledger/aries-bifold-verifier'
+import { getProofRequestTemplates } from '@hyperledger/aries-bifold-verifier'
 import { DefaultOCABundleResolver } from '@hyperledger/aries-oca/build/legacy'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { StackNavigationProp } from '@react-navigation/stack'
@@ -87,7 +87,7 @@ export class MainContainer implements Container {
     this._container.registerInstance(TOKENS.UTIL_LOGGER, new ConsoleLogger())
     this._container.registerInstance(TOKENS.UTIL_OCA_RESOLVER, new DefaultOCABundleResolver(bundle))
     this._container.registerInstance(TOKENS.UTIL_LEDGERS, defaultIndyLedgers)
-    this._container.registerInstance(TOKENS.UTIL_PROOF_TEMPLATE, useProofRequestTemplates)
+    this._container.registerInstance(TOKENS.UTIL_PROOF_TEMPLATE, getProofRequestTemplates)
     this._container.registerInstance(TOKENS.UTIL_ATTESTATION_MONITOR, { useValue: undefined })
     this._container.registerInstance(TOKENS.NOTIFICATIONS, { useNotifications })
     this._container.registerInstance(TOKENS.CONFIG, defaultConfig)

--- a/packages/legacy/core/App/contexts/tour/tour-context.tsx
+++ b/packages/legacy/core/App/contexts/tour/tour-context.tsx
@@ -66,7 +66,7 @@ export interface TourStep {
    * It receives the {@link RenderProps} so you can access the context of the
    * tour within the tooltip.
    */
-  render: (props: RenderProps) => ReactElement
+  Render: (props: RenderProps) => ReactElement
 }
 
 export interface Tour {

--- a/packages/legacy/core/App/contexts/tour/tour-provider.tsx
+++ b/packages/legacy/core/App/contexts/tour/tour-provider.tsx
@@ -151,7 +151,7 @@ const TourProviderComponent = (props: TourProviderProps, ref:  Ref<Tour>) => {
     }
 
     stepToRender = currentStep !== undefined ? steps[currentStep] : undefined
-    return stepToRender ?? { render: () => <></> }
+    return stepToRender ?? { Render: () => <></> }
   }, [homeTourSteps, credentialsTourSteps, credentialOfferTourSteps, proofRequestTourSteps, currentStep])
 
   const tour = useMemo(

--- a/packages/legacy/core/App/index.ts
+++ b/packages/legacy/core/App/index.ts
@@ -86,7 +86,7 @@ export type {
   ITheme,
 } from './theme'
 export type { BifoldAgent } from './utils/agent'
-export type { TourStep } from './contexts/tour/tour-context'
+export type { TourStep, RenderProps } from './contexts/tour/tour-context'
 export type { GenericFn } from './types/fn'
 export type { AuthenticateStackParams, OnboardingStackParams, NotificationStackParams } from './types/navigators'
 export type { OnboardingStyleSheet }

--- a/packages/legacy/core/App/screens/CredentialDetails.tsx
+++ b/packages/legacy/core/App/screens/CredentialDetails.tsx
@@ -30,7 +30,7 @@ import {
   isValidAnonCredsCredential,
   toImageSource,
 } from '../utils/credential'
-import { formatTime, getCredentialConnectionLabel } from '../utils/helpers'
+import { formatTime, useCredentialConnectionLabel } from '../utils/helpers'
 import { buildFieldsFromAnonCredsCredential } from '../utils/oca'
 import { testIdWithKey } from '../utils/testable'
 
@@ -64,7 +64,7 @@ const CredentialDetails: React.FC<CredentialDetailsProps> = ({ navigation, route
     metaOverlay: undefined,
     brandingOverlay: undefined,
   })
-  const credentialConnectionLabel = getCredentialConnectionLabel(credential)
+  const credentialConnectionLabel = useCredentialConnectionLabel(credential)
   const { width, height } = useWindowDimensions()
 
   const styles = StyleSheet.create({

--- a/packages/legacy/core/App/screens/CredentialOffer.tsx
+++ b/packages/legacy/core/App/screens/CredentialOffer.tsx
@@ -33,7 +33,7 @@ import { TourID } from '../types/tour'
 import { useAppAgent } from '../utils/agent'
 import { parseCredDefFromId } from '../utils/cred-def'
 import { getCredentialIdentifiers, isValidAnonCredsCredential } from '../utils/credential'
-import { getCredentialConnectionLabel } from '../utils/helpers'
+import { useCredentialConnectionLabel } from '../utils/helpers'
 import { buildFieldsFromAnonCredsCredential } from '../utils/oca'
 import { testIdWithKey } from '../utils/testable'
 
@@ -59,7 +59,7 @@ const CredentialOffer: React.FC<CredentialOfferProps> = ({ navigation, route }) 
   const [declineModalVisible, setDeclineModalVisible] = useState(false)
   const [overlay, setOverlay] = useState<CredentialOverlay<BrandingOverlay>>({ presentationFields: [] })
   const credential = useCredentialById(credentialId)
-  const credentialConnectionLabel = getCredentialConnectionLabel(credential)
+  const credentialConnectionLabel = useCredentialConnectionLabel(credential)
   const [store, dispatch] = useStore()
   const { start } = useTour()
   const screenIsFocused = useIsFocused()

--- a/packages/legacy/core/App/screens/OnboardingPages.tsx
+++ b/packages/legacy/core/App/screens/OnboardingPages.tsx
@@ -86,7 +86,7 @@ const createImageDisplayOptions = (OnboardingTheme: any) => {
   }
 }
 
-const customPages = (onTutorialCompleted: GenericFn, OnboardingTheme: any) => {
+const CustomPages = (onTutorialCompleted: GenericFn, OnboardingTheme: any) => {
   const { t } = useTranslation()
   const styles = createStyles(OnboardingTheme)
   const imageDisplayOptions = createImageDisplayOptions(OnboardingTheme)
@@ -202,7 +202,7 @@ const OnboardingPages = (onTutorialCompleted: GenericFn, OnboardingTheme: any): 
         g.devModeListener ? incrementDeveloperMenuCounter : undefined
       )
     ),
-    customPages(onTutorialCompleted, OnboardingTheme),
+    CustomPages(onTutorialCompleted, OnboardingTheme),
   ]
 }
 

--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -60,7 +60,7 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
   const { t } = useTranslation()
   const { assertConnectedNetwork } = useNetwork()
   const proof = useProofById(proofId)
-  const connection = proof?.connectionId ? useConnectionById(proof.connectionId) : undefined
+  const connection = useConnectionById(proof?.connectionId ?? '')
   const [pendingModalVisible, setPendingModalVisible] = useState(false)
   const [revocationOffense, setRevocationOffense] = useState(false)
   const [retrievedCredentials, setRetrievedCredentials] = useState<AnonCredsCredentialsForProofRequest>()
@@ -71,9 +71,7 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
   const { ColorPallet, ListItems, TextTheme } = useTheme()
   const { RecordLoading } = useAnimatedComponents()
   const goalCode = useOutOfBandByConnectionId(proof?.connectionId ?? '')?.outOfBandInvitation.goalCode
-  const outOfBandInvitation = proof?.parentThreadId
-    ? useOutOfBandByReceivedInvitationId(proof?.parentThreadId)?.outOfBandInvitation
-    : undefined
+  const outOfBandInvitation = useOutOfBandByReceivedInvitationId(proof?.parentThreadId ?? '')?.outOfBandInvitation
   const [containsPI, setContainsPI] = useState(false)
   const [activeCreds, setActiveCreds] = useState<ProofCredentialItems[]>([])
   const [selectedCredentials, setSelectedCredentials] = useState<string[]>([])

--- a/packages/legacy/core/App/screens/ProofRequestDetails.tsx
+++ b/packages/legacy/core/App/screens/ProofRequestDetails.tsx
@@ -181,7 +181,7 @@ const ProofRequestDetails: React.FC<ProofRequestDetailsProps> = ({ route, naviga
     [setCustomPredicateValues, setInvalidPredicate]
   )
 
-  const useProofRequest = useCallback(async () => {
+  const activateProofRequest = useCallback(async () => {
     if (!template) {
       return
     }
@@ -228,7 +228,7 @@ const ProofRequestDetails: React.FC<ProofRequestDetailsProps> = ({ route, naviga
             accessibilityLabel={connectionId ? t('Verifier.SendThisProofRequest') : t('Verifier.UseProofRequest')}
             testID={connectionId ? testIdWithKey('SendThisProofRequest') : testIdWithKey('UseProofRequest')}
             buttonType={ButtonType.Primary}
-            onPress={() => useProofRequest()}
+            onPress={() => activateProofRequest()}
           />
         </View>
         {store.preferences.useDataRetention && (

--- a/packages/legacy/core/App/screens/ProofRequestUsageHistory.tsx
+++ b/packages/legacy/core/App/screens/ProofRequestUsageHistory.tsx
@@ -42,7 +42,7 @@ const ProofRequestUsageHistoryRecord: React.FC<ProofRequestUsageHistoryRecordPro
   const { t } = useTranslation()
   const { ListItems, ColorPallet } = useTheme()
   const [store] = useStore()
-  const connection = record.connectionId ? useConnectionById(record.connectionId) : undefined
+  const connection = useConnectionById(record.connectionId ?? '')
   const theirLabel = useMemo(
     () => getConnectionName(connection, store.preferences.alternateContactNames),
     [connection, store.preferences.alternateContactNames]

--- a/packages/legacy/core/App/utils/helpers.ts
+++ b/packages/legacy/core/App/utils/helpers.ts
@@ -245,15 +245,6 @@ export function formatIfDate(format: string | undefined, value: string | number 
   return value
 }
 
-/**
- * @deprecated The function should not be used
- */
-export function connectionRecordFromId(connectionId?: string): ConnectionRecord | void {
-  if (connectionId) {
-    return useConnectionById(connectionId)
-  }
-}
-
 export function getConnectionName(
   connection: ConnectionRecord | undefined,
   alternateContactNames: Record<string, string>
@@ -267,20 +258,21 @@ export function getConnectionName(
   )
 }
 
-export function getCredentialConnectionLabel(credential?: CredentialExchangeRecord) {
+export function useCredentialConnectionLabel(credential?: CredentialExchangeRecord) {
+  const connection = useConnectionById(credential?.connectionId ?? '')
+
   if (!credential) {
     return ''
   }
 
   if (credential.connectionId) {
-    const connection = useConnectionById(credential.connectionId)
     return connection?.alias || connection?.theirLabel || credential.connectionId
   }
 
   return 'Unknown Contact'
 }
 
-export function getConnectionImageUrl(connectionId: string) {
+export function useConnectionImageUrl(connectionId: string) {
   const connection = useConnectionById(connectionId)
   if (!connection) {
     return undefined

--- a/packages/legacy/core/App/utils/proofBundle.ts
+++ b/packages/legacy/core/App/utils/proofBundle.ts
@@ -2,7 +2,7 @@ import { BaseLogger } from '@credo-ts/core'
 import {
   AnonCredsProofRequestTemplatePayload,
   ProofRequestTemplate,
-  useProofRequestTemplates,
+  getProofRequestTemplates,
 } from '@hyperledger/aries-bifold-verifier'
 import axios, { AxiosError } from 'axios'
 
@@ -72,11 +72,10 @@ export const useRemoteProofBundleResolver = (
   indexFileBaseUrl: string | undefined,
   log?: BaseLogger
 ): ProofBundleResolverType => {
+  const [proofRequestTemplates] = useServices([TOKENS.UTIL_PROOF_TEMPLATE])
   if (indexFileBaseUrl) {
     return new RemoteProofBundleResolver(indexFileBaseUrl, log)
   } else {
-    const [proofRequestTemplates] = useServices([TOKENS.UTIL_PROOF_TEMPLATE])
-
     return new DefaultProofBundleResolver(proofRequestTemplates)
   }
 }
@@ -154,7 +153,7 @@ export class DefaultProofBundleResolver implements ProofBundleResolverType {
   private proofRequestTemplates
 
   public constructor(proofRequestTemplates: ProofRequestTemplateFn | undefined) {
-    this.proofRequestTemplates = proofRequestTemplates ?? useProofRequestTemplates
+    this.proofRequestTemplates = proofRequestTemplates ?? getProofRequestTemplates
   }
 
   public async resolve(acceptDevRestrictions: boolean): Promise<ProofRequestTemplate[]> {

--- a/packages/legacy/core/__mocks__/@credo-ts/react-hooks.ts
+++ b/packages/legacy/core/__mocks__/@credo-ts/react-hooks.ts
@@ -73,6 +73,8 @@ const mockOobModule = {
   findById: jest.fn().mockReturnValue(Promise.resolve(null)),
   createInvitation: jest.fn(),
   toUrl: jest.fn(),
+  findByReceivedInvitationId: jest.fn().mockReturnValue(Promise.resolve(null)),
+  parseInvitation: jest.fn().mockReturnValue(Promise.resolve(null)),
 }
 const mockBasicMessageRepository = {
   update: jest.fn(),

--- a/packages/legacy/core/__tests__/components/TourOverlay.test.tsx
+++ b/packages/legacy/core/__tests__/components/TourOverlay.test.tsx
@@ -11,7 +11,7 @@ import { TourProvider } from '../../App/contexts/tour/tour-provider'
 import { TourID } from '../../App/types/tour'
 
 const tourStep = {
-  render: () => {
+  Render: () => {
     return (
       <View>
         <Text>Test</Text>

--- a/packages/legacy/core/__tests__/screens/CredentialDetails.test.tsx
+++ b/packages/legacy/core/__tests__/screens/CredentialDetails.test.tsx
@@ -7,7 +7,6 @@ import React from 'react'
 
 import { hiddenFieldValue } from '../../App/constants'
 import CredentialDetails from '../../App/screens/CredentialDetails'
-import { formatTime } from '../../App/utils/helpers'
 import { BasicAppContext } from '../helpers/app'
 
 const buildCredentialExchangeRecord = () => {
@@ -80,7 +79,7 @@ describe('displays a credential details screen', () => {
       useCredentialById.mockReturnValue(mock_testOpenVPCredentialRecord)
     })
 
-    test.skip('a credential name and issue date is displayed', async () => {
+    test('a credential name and issued by is displayed', async () => {
       const { findByText } = render(
         <BasicAppContext>
           <CredentialDetails
@@ -91,13 +90,10 @@ describe('displays a credential details screen', () => {
       )
 
       const credentialName = await findByText('Unverified Person', { exact: false })
-      const credentialIssuedAt = await findByText(
-        `CredentialDetails.Issued: ${formatTime(mock_testOpenVPCredentialRecord.createdAt, { format: 'MMM D, YYYY' })}`,
-        { exact: false }
-      )
+      const credentialIssuedBy = await findByText('CredentialDetails.IssuedBy')
 
       expect(credentialName).not.toBe(null)
-      expect(credentialIssuedAt).not.toBe(null)
+      expect(credentialIssuedBy).not.toBe(null)
     })
   })
 

--- a/packages/legacy/core/__tests__/screens/ListContacts.test.tsx
+++ b/packages/legacy/core/__tests__/screens/ListContacts.test.tsx
@@ -1,18 +1,18 @@
-import { useNavigation } from '@react-navigation/native'
 import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import React from 'react'
+import { container } from 'tsyringe'
 
+import { useNavigation as testUseNavigation } from '../../__mocks__/@react-navigation/native'
 import { StoreProvider, defaultState } from '../../App/contexts/store'
 import ListContacts from '../../App/screens/ListContacts'
 import { BasicAppContext, CustomBasicAppContext } from '../helpers/app'
 import { TOKENS } from '../../App/container-api'
 import { MainContainer } from '../../App/container-impl'
-import { container } from 'tsyringe'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 jest.mock('react-native-localize', () => { })
 
-const navigation = useNavigation()
+const navigation = testUseNavigation()
 
 describe('ListContacts Component', () => {
   beforeEach(() => {
@@ -77,7 +77,6 @@ describe('ListContacts Component', () => {
   })
 
   test('Hide list does not filter out specific contacts when developer mode is enabled', async () => {
-    const navigation = useNavigation()
     const context = new MainContainer(container.createChildContainer()).init()
     const config = context.resolve(TOKENS.CONFIG)
     context.container.registerInstance(TOKENS.CONFIG, { ...config, contactHideList: ['Faber'] })

--- a/packages/legacy/core/__tests__/screens/ListProofRequests.test.tsx
+++ b/packages/legacy/core/__tests__/screens/ListProofRequests.test.tsx
@@ -1,11 +1,11 @@
+import { getProofRequestTemplates } from '@hyperledger/aries-bifold-verifier'
 import mockRNCNetInfo from '@react-native-community/netinfo/jest/netinfo-mock'
-import { useNavigation } from '@react-navigation/native'
 import { act, fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
 
+import { useNavigation as testUseNavigation } from '../../__mocks__/@react-navigation/native'
 import { NetworkProvider } from '../../App/contexts/network'
 import ListProofRequests from '../../App/screens/ListProofRequests'
-import { useProofRequestTemplates } from '@hyperledger/aries-bifold-verifier'
 import { BasicAppContext } from '../helpers/app'
 
 jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter')
@@ -16,7 +16,7 @@ jest.mock('react-native-localize', () => { })
 jest.useFakeTimers({ legacyFakeTimers: true })
 jest.spyOn(global, 'setTimeout')
 
-const navigation = useNavigation()
+const navigation = testUseNavigation()
 
 describe('ListProofRequests Component', () => {
   const renderView = (params?: any) => {
@@ -54,7 +54,7 @@ describe('ListProofRequests Component', () => {
       fireEvent(templateItemInstance, 'press')
 
       expect(navigation.navigate).toBeCalledWith('Proof Request Details', {
-        templateId: useProofRequestTemplates(false)[0].id,
+        templateId: getProofRequestTemplates(false)[0].id,
       })
     })
   })

--- a/packages/legacy/core/__tests__/screens/PasteUrl.test.tsx
+++ b/packages/legacy/core/__tests__/screens/PasteUrl.test.tsx
@@ -8,9 +8,7 @@ import { useNavigation } from '@react-navigation/native'
 import { MainContainer } from '../../App/container-impl'
 import { container } from 'tsyringe'
 import { testIdWithKey } from '../../App/utils/testable'
-import { useTranslation } from 'react-i18next'
 
-const { t } = useTranslation()
 
 describe('displays a paste url screen', () => {
   test('Paste URL renders correctly', () => {
@@ -48,7 +46,7 @@ describe('displays a paste url screen', () => {
     expect(touchableDisabled).not.toBeNull()
     fireEvent.press(touchableDisabled, 'press')
 
-    const errorModal = await tree.findByText(t('PasteUrl.ErrorTextboxEmpty'))
+    const errorModal = await tree.findByText('PasteUrl.ErrorTextboxEmpty')
     expect(errorModal).not.toBeNull()
   })
 
@@ -74,7 +72,7 @@ describe('displays a paste url screen', () => {
     expect(continueButton).not.toBeNull()
     fireEvent.press(continueButton, 'press')
 
-    const errorModal = await tree.findByText(t('PasteUrl.ErrorInvalidUrl'))
+    const errorModal = await tree.findByText('PasteUrl.ErrorInvalidUrl')
     expect(errorModal).not.toBeNull()
   })
 
@@ -103,7 +101,7 @@ describe('displays a paste url screen', () => {
     expect(continueButton).not.toBeNull()
     fireEvent.press(continueButton, 'press')
 
-    const errorModal = tree.queryByText(t('PasteUrl.ErrorInvalidUrl'))
+    const errorModal = tree.queryByText('PasteUrl.ErrorInvalidUrl')
     expect(errorModal).toBeNull()
   })
 })

--- a/packages/legacy/core/__tests__/screens/ProofDetails.test.tsx
+++ b/packages/legacy/core/__tests__/screens/ProofDetails.test.tsx
@@ -4,10 +4,10 @@ import { Attachment, AttachmentData } from '@credo-ts/core/build/decorators/atta
 import { useProofById } from '@credo-ts/react-hooks'
 import * as verifier from '@hyperledger/aries-bifold-verifier'
 import mockRNCNetInfo from '@react-native-community/netinfo/jest/netinfo-mock'
-import { useNavigation } from '@react-navigation/native'
 import '@testing-library/jest-native/extend-expect'
 import { RenderAPI, cleanup, fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
+import { useNavigation as testUseNavigation } from '../../__mocks__/@react-navigation/native'
 import ProofDetails from '../../App/screens/ProofDetails'
 import { testIdWithKey } from '../../App/utils/testable'
 import { BasicAppContext } from '../helpers/app'
@@ -107,7 +107,7 @@ describe('ProofDetails Component', () => {
   const renderView = (params?: { recordId: string; isHistory: boolean }) => {
     return render(
       <BasicAppContext>
-        <ProofDetails navigation={useNavigation()} route={{ params } as any} />
+        <ProofDetails navigation={testUseNavigation() as any} route={{ params } as any} />
       </BasicAppContext>
     )
   }
@@ -168,7 +168,7 @@ describe('ProofDetails Component', () => {
     })
 
     test('Generate new QR code button should navigate correctly', async () => {
-      const navigation = useNavigation()
+      const navigation = testUseNavigation() as any
       const tree = renderView({ recordId: testVerifiedProofRequest.id, isHistory: false })
 
       const generateNewButton = await tree.findByTestId(testIdWithKey('GenerateNewQR'))
@@ -179,7 +179,7 @@ describe('ProofDetails Component', () => {
     })
 
     test('Done', async () => {
-      const navigation = useNavigation()
+      const navigation = testUseNavigation() as any
       const { findByTestId } = renderView({ recordId: testVerifiedProofRequest.id, isHistory: false })
 
       const doneButton = await findByTestId(testIdWithKey('BackToList'))

--- a/packages/legacy/core/__tests__/screens/ProofRequesting.test.tsx
+++ b/packages/legacy/core/__tests__/screens/ProofRequesting.test.tsx
@@ -1,14 +1,3 @@
-import { useConnections } from '@credo-ts/react-hooks'
-import mockRNCNetInfo from '@react-native-community/netinfo/jest/netinfo-mock'
-import { useNavigation } from '@react-navigation/native'
-import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react-native'
-import React from 'react'
-
-import * as verifier from '@hyperledger/aries-bifold-verifier'
-import { useProofRequestTemplates } from '@hyperledger/aries-bifold-verifier'
-import { testIdWithKey } from '../../App'
-import ProofRequesting from '../../App/screens/ProofRequesting'
-
 import { INDY_PROOF_REQUEST_ATTACHMENT_ID, V1RequestPresentationMessage } from '@credo-ts/anoncreds'
 import {
   ConnectionRecord,
@@ -20,7 +9,17 @@ import {
   ProofState,
 } from '@credo-ts/core'
 import { Attachment, AttachmentData } from '@credo-ts/core/build/decorators/attachment/Attachment'
+import { useConnections } from '@credo-ts/react-hooks'
+import * as verifier from '@hyperledger/aries-bifold-verifier'
+import { getProofRequestTemplates } from '@hyperledger/aries-bifold-verifier'
+import mockRNCNetInfo from '@react-native-community/netinfo/jest/netinfo-mock'
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react-native'
+import React from 'react'
+
+import { useNavigation as testUseNavigation } from '../../__mocks__/@react-navigation/native'
+import { testIdWithKey } from '../../App'
 import * as proofRequestTemplatesHooks from '../../App/hooks/proof-request-templates'
+import ProofRequesting from '../../App/screens/ProofRequesting'
 
 jest.mock('@react-native-community/netinfo', () => mockRNCNetInfo)
 jest.mock('@hyperledger/aries-bifold-verifier', () => {
@@ -38,7 +37,7 @@ jest.mock('react-native-device-info', () => {
 jest.useFakeTimers({ legacyFakeTimers: true })
 jest.spyOn(global, 'setTimeout')
 
-const templates = useProofRequestTemplates(true)
+const templates = getProofRequestTemplates(true)
 const template = templates[0]
 const templateId = template.id
 
@@ -121,7 +120,7 @@ describe('ProofRequesting Component', () => {
   })
 
   const renderView = (params?: { templateId: string; predicateValues: any }) => {
-    return render(<ProofRequesting navigation={useNavigation()} route={{ params } as any} />)
+    return render(<ProofRequesting navigation={testUseNavigation() as any} route={{ params } as any} />)
   }
 
   test('renders correctly', async () => {

--- a/packages/legacy/core/__tests__/utils/helpers.test.ts
+++ b/packages/legacy/core/__tests__/utils/helpers.test.ts
@@ -49,7 +49,7 @@ describe('check rolling base64 encode/decode', () => {
 
 // This is a difficult function to test completely because of the i18n
 describe('formatTime', () => {
-  test.skip('without params', () => {
+  test('without params', () => {
     const result = formatTime(new Date('December 17, 2012 03:24:00'))
     // This would be December 17, 2012 but the i18n is not working in Jest
     expect(result).toBe('Dec 17, 2012')

--- a/packages/verifier/src/__tests__/verifier/proof-request.test.ts
+++ b/packages/verifier/src/__tests__/verifier/proof-request.test.ts
@@ -1,4 +1,4 @@
-import { useProofRequestTemplates } from '../../request-templates'
+import { getProofRequestTemplates } from '../../request-templates'
 import { buildProofRequestDataForTemplate, hasPredicates } from '../../utils/proof-request'
 
 import SpyInstance = jest.SpyInstance
@@ -9,7 +9,7 @@ describe('Helpers', () => {
   beforeAll(() => {
     spy = jest.spyOn(Date, 'now').mockImplementation(() => 1677766511505)
   })
-  const templates = useProofRequestTemplates(false)
+  const templates = getProofRequestTemplates(false)
 
   test('Build anoncreds proof request from template containing two requested attributes', async () => {
     const template = templates[0]

--- a/packages/verifier/src/index.ts
+++ b/packages/verifier/src/index.ts
@@ -42,4 +42,4 @@ export {
   hasPredicates,
   isParameterizable,
 } from './utils/proof-request'
-export { useProofRequestTemplates } from './request-templates'
+export { getProofRequestTemplates } from './request-templates'

--- a/packages/verifier/src/request-templates.ts
+++ b/packages/verifier/src/request-templates.ts
@@ -1,6 +1,6 @@
 import { ProofRequestTemplate, ProofRequestType } from './types/proof-reqeust-template'
 
-export const useProofRequestTemplates = (useDevRestrictions: boolean) => {
+export const getProofRequestTemplates = (useDevRestrictions: boolean) => {
   const studentRestrictions = [{ cred_def_id: 'XUxBrVSALWHLeycAUhrNr9:3:CL:26293:student_card' }]
   const studentDevRestrictions = [{ schema_name: 'student_card' }]
   const restrictions = useDevRestrictions ? studentDevRestrictions : studentRestrictions


### PR DESCRIPTION
# Summary of Changes

This is the second wave of fixes for react lint warnings, this time fixing `react-hooks/rules-of-hooks` warnings and then making them errors going forward. I will do a final wave with `react-hooks/exhaustive-deps` but there was beginning to be too many changes at once.

In refactoring some tests I found a good approach for testing hooks, please take a look at the `Proof bundle resolver works correctly` test if you need inspo for testing hooks in the future.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
