### PR TITLE
fix: potential fix for deeplink

### DIFF
--- a/packages/legacy/core/App/contexts/store.tsx
+++ b/packages/legacy/core/App/contexts/store.tsx
@@ -65,7 +65,6 @@ export const defaultState: State = {
     seenCredentialOfferTour: false,
     seenProofRequestTour: false,
   },
-  deepLink: '',
   loading: false,
   stateLoaded: false,
 }


### PR DESCRIPTION
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>

# Summary of Changes

The initial state was being mass assigned when the state was loaded from asyncStorage. Since it had a default value of `''` it would overwrite the deeplink in the current state. Still unclear why this only happened in production.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [ ] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [ ] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [ ] Updated documentation as needed for changed code and new or modified features;
- [ ] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
