### PR TITLE
feat: make notifications empty list injectable

### DIFF
--- a/packages/legacy/core/App/components/misc/NoNewUpdates.tsx
+++ b/packages/legacy/core/App/components/misc/NoNewUpdates.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, Text } from 'react-native'
+import { StyleSheet, Text, View } from 'react-native'
 
 import { useTheme } from '../../contexts/theme'
 import { testIdWithKey } from '../../utils/testable'
 import InfoTextBox from '../texts/InfoTextBox'
-import { View } from 'react-native'
 
 const NoNewUpdates: React.FC = () => {
   const { t } = useTranslation()

--- a/packages/legacy/core/App/components/misc/NoNewUpdates.tsx
+++ b/packages/legacy/core/App/components/misc/NoNewUpdates.tsx
@@ -5,11 +5,17 @@ import { StyleSheet, Text } from 'react-native'
 import { useTheme } from '../../contexts/theme'
 import { testIdWithKey } from '../../utils/testable'
 import InfoTextBox from '../texts/InfoTextBox'
+import { View } from 'react-native'
 
 const NoNewUpdates: React.FC = () => {
   const { t } = useTranslation()
-  const { HomeTheme } = useTheme()
+  const { HomeTheme, ColorPallet } = useTheme()
   const styles = StyleSheet.create({
+    noNewUpdatesContainer: {
+      paddingHorizontal: 20,
+      paddingVertical: 20,
+      backgroundColor: ColorPallet.brand.secondaryBackground,
+    },
     noNewUpdatesText: {
       ...HomeTheme.noNewUpdatesText,
       alignSelf: 'center',
@@ -19,11 +25,13 @@ const NoNewUpdates: React.FC = () => {
   })
 
   return (
-    <InfoTextBox>
-      <Text style={styles.noNewUpdatesText} testID={testIdWithKey('NoNewUpdates')}>
-        {t('Home.NoNewUpdates')}
-      </Text>
-    </InfoTextBox>
+    <View style={styles.noNewUpdatesContainer}>
+      <InfoTextBox>
+        <Text style={styles.noNewUpdatesText} testID={testIdWithKey('NoNewUpdates')}>
+          {t('Home.NoNewUpdates')}
+        </Text>
+      </InfoTextBox>
+    </View>
   )
 }
 

--- a/packages/legacy/core/App/container-api.ts
+++ b/packages/legacy/core/App/container-api.ts
@@ -50,6 +50,7 @@ export const SCREEN_TOKENS = {
 
 export const COMPONENT_TOKENS = {
   COMPONENT_HOME_HEADER: 'component.home.header',
+  COMPONENT_HOME_NOTIFICATIONS_EMPTY_LIST: 'component.home.notifications-empty-list',
   COMPONENT_HOME_FOOTER: 'component.home.footer',
   COMPONENT_CRED_EMPTY_LIST: 'component.cred.empty-list',
   COMPONENT_RECORD: 'component.record',
@@ -157,6 +158,7 @@ export type TokenMapping = {
   [TOKENS.COMPONENT_CRED_LIST_HEADER_RIGHT]: React.FC
   [TOKENS.COMPONENT_CRED_LIST_OPTIONS]: React.FC
   [TOKENS.COMPONENT_HOME_HEADER]: React.FC
+  [TOKENS.COMPONENT_HOME_NOTIFICATIONS_EMPTY_LIST]: React.FC
   [TOKENS.COMPONENT_HOME_FOOTER]: React.FC
   [TOKENS.COMPONENT_CRED_EMPTY_LIST]: React.FC
   [TOKENS.COMPONENT_RECORD]: React.FC

--- a/packages/legacy/core/App/container-impl.ts
+++ b/packages/legacy/core/App/container-impl.ts
@@ -40,6 +40,7 @@ import HomeHeaderView from './components/views/HomeHeaderView'
 import HomeFooterView from './components/views/HomeFooterView'
 import EmptyList from './components/misc/EmptyList'
 import Record from './components/record/Record'
+import NoNewUpdates from './components/misc/NoNewUpdates'
 
 export const defaultConfig = {
   PINSecurity: { rules: PINRules, displayHelper: false },
@@ -94,6 +95,7 @@ export class MainContainer implements Container {
     this._container.registerInstance(TOKENS.COMPONENT_CRED_LIST_HEADER_RIGHT, () => null)
     this._container.registerInstance(TOKENS.COMPONENT_CRED_LIST_OPTIONS, () => null)
     this._container.registerInstance(TOKENS.COMPONENT_HOME_HEADER, HomeHeaderView)
+    this._container.registerInstance(TOKENS.COMPONENT_HOME_NOTIFICATIONS_EMPTY_LIST, NoNewUpdates)
     this._container.registerInstance(TOKENS.COMPONENT_HOME_FOOTER, HomeFooterView)
     this._container.registerInstance(TOKENS.COMPONENT_CRED_EMPTY_LIST, EmptyList)
     this._container.registerInstance(TOKENS.COMPONENT_RECORD, Record)

--- a/packages/legacy/core/App/screens/Home.tsx
+++ b/packages/legacy/core/App/screens/Home.tsx
@@ -117,7 +117,7 @@ const Home: React.FC<HomeProps> = () => {
         showsVerticalScrollIndicator={false}
         scrollEnabled={notifications?.length > 0 ? true : false}
         decelerationRate="fast"
-        ListEmptyComponent={() => <NoNewUpdates />}
+        ListEmptyComponent={NoNewUpdates}
         ListHeaderComponent={() => <HomeHeaderView />}
         ListFooterComponent={() => <HomeFooterView />}
         data={notifications}

--- a/packages/legacy/core/App/screens/Home.tsx
+++ b/packages/legacy/core/App/screens/Home.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next'
 import { FlatList, View, StyleSheet } from 'react-native'
 
 import NotificationListItem, { NotificationType } from '../components/listItems/NotificationListItem'
-import NoNewUpdates from '../components/misc/NoNewUpdates'
 import AppGuideModal from '../components/modals/AppGuideModal'
 import { TOKENS, useServices } from '../container-api'
 import { DispatchAction } from '../contexts/reducers/store'
@@ -18,8 +17,15 @@ import { TourID } from '../types/tour'
 type HomeProps = StackScreenProps<HomeStackParams, Screens.Home>
 
 const Home: React.FC<HomeProps> = () => {
-  const [HomeHeaderView, HomeFooterView, { enableTours: enableToursConfig }, { customNotificationConfig: customNotification, useNotifications }] = useServices([
+  const [
+    HomeHeaderView,
+    NoNewUpdates,
+    HomeFooterView,
+    { enableTours: enableToursConfig },
+    { customNotificationConfig: customNotification, useNotifications },
+  ] = useServices([
     TOKENS.COMPONENT_HOME_HEADER,
+    TOKENS.COMPONENT_HOME_NOTIFICATIONS_EMPTY_LIST,
     TOKENS.COMPONENT_HOME_FOOTER,
     TOKENS.CONFIG,
     TOKENS.NOTIFICATIONS,
@@ -36,11 +42,6 @@ const Home: React.FC<HomeProps> = () => {
   const styles = StyleSheet.create({
     flatlist: {
       marginBottom: 35,
-    },
-    noNewUpdatesContainer: {
-      paddingHorizontal: 20,
-      paddingVertical: 20,
-      backgroundColor: ColorPallet.brand.secondaryBackground,
     },
   })
 
@@ -116,11 +117,7 @@ const Home: React.FC<HomeProps> = () => {
         showsVerticalScrollIndicator={false}
         scrollEnabled={notifications?.length > 0 ? true : false}
         decelerationRate="fast"
-        ListEmptyComponent={() => (
-          <View style={styles.noNewUpdatesContainer}>
-            <NoNewUpdates />
-          </View>
-        )}
+        ListEmptyComponent={() => <NoNewUpdates />}
         ListHeaderComponent={() => <HomeHeaderView />}
         ListFooterComponent={() => <HomeFooterView />}
         data={notifications}

--- a/packages/legacy/core/__tests__/components/__snapshots__/NoNewUpdates.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/NoNewUpdates.test.tsx.snap
@@ -5,52 +5,62 @@ exports[`NoNewUpdates Component Renders correctly 1`] = `
   style={
     Object {
       "backgroundColor": "#313132",
-      "borderColor": "#0099FF",
-      "borderRadius": 5,
-      "borderWidth": 1,
-      "padding": 10,
+      "paddingHorizontal": 20,
+      "paddingVertical": 20,
     }
   }
 >
   <View
     style={
       Object {
-        "alignItems": "center",
-        "flexDirection": "row",
-        "justifyContent": "space-between",
+        "backgroundColor": "#313132",
+        "borderColor": "#0099FF",
+        "borderRadius": 5,
+        "borderWidth": 1,
+        "padding": 10,
       }
     }
   >
     <View
       style={
         Object {
-          "alignSelf": "flex-start",
-          "marginLeft": 0,
-          "marginRight": 10,
+          "alignItems": "center",
+          "flexDirection": "row",
+          "justifyContent": "space-between",
         }
       }
     >
-      <Icon
-        color="#0099FF"
-        name="info"
-        size={30}
-      />
+      <View
+        style={
+          Object {
+            "alignSelf": "flex-start",
+            "marginLeft": 0,
+            "marginRight": 10,
+          }
+        }
+      >
+        <Icon
+          color="#0099FF"
+          name="info"
+          size={30}
+        />
+      </View>
+      <Text
+        style={
+          Object {
+            "alignSelf": "center",
+            "color": "#FFFFFF",
+            "flex": 1,
+            "flexWrap": "wrap",
+            "fontSize": 18,
+            "fontWeight": "normal",
+          }
+        }
+        testID="com.ariesbifold:id/NoNewUpdates"
+      >
+        Home.NoNewUpdates
+      </Text>
     </View>
-    <Text
-      style={
-        Object {
-          "alignSelf": "center",
-          "color": "#FFFFFF",
-          "flex": 1,
-          "flexWrap": "wrap",
-          "fontSize": 18,
-          "fontWeight": "normal",
-        }
-      }
-      testID="com.ariesbifold:id/NoNewUpdates"
-    >
-      Home.NoNewUpdates
-    </Text>
   </View>
 </View>
 `;


### PR DESCRIPTION
# Summary of Changes

This PR makes the empty notifications list component injectable in the Home screen. This way, other wallets can change the look of the component in the container-impl.ts.

For example, instead of having this look:

<img width="464" alt="image" src="https://github.com/user-attachments/assets/2f2be4c9-bb14-4c3b-9fd2-d3eb59e99e7b">

You could create a component for the notifications empty list that would look, for example, like this:

<img width="350" alt="image" src="https://github.com/user-attachments/assets/4fb3f4f1-e6e0-4097-8362-b1a0a8e64afb">


# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
