### PR TITLE
fix: double biometrics

### DIFF
--- a/packages/legacy/core/__tests__/screens/PINEnter.test.tsx
+++ b/packages/legacy/core/__tests__/screens/PINEnter.test.tsx
@@ -1,6 +1,9 @@
 import { render } from '@testing-library/react-native'
 import React from 'react'
+import { container } from 'tsyringe'
 
+import { ContainerProvider } from '../../App/container-api'
+import { MainContainer } from '../../App/container-impl'
 import { AuthContext } from '../../App/contexts/auth'
 import { StoreProvider, defaultState } from '../../App/contexts/store'
 import PINEnter from '../../App/screens/PINEnter'
@@ -9,34 +12,40 @@ import authContext from '../contexts/auth'
 
 describe('displays a PIN Enter screen', () => {
   test('PIN Enter renders correctly', () => {
+    const main = new MainContainer(container.createChildContainer()).init()
     const tree = render(
-      <StoreProvider
-        initialState={{
-          ...defaultState,
-        }}
-      >
-        <AuthContext.Provider value={authContext}>
-          <PINEnter setAuthenticated={jest.fn()} />
-        </AuthContext.Provider>
-      </StoreProvider>
+      <ContainerProvider value={main}>
+        <StoreProvider
+          initialState={{
+            ...defaultState,
+          }}
+        >
+          <AuthContext.Provider value={authContext}>
+            <PINEnter setAuthenticated={jest.fn()} />
+          </AuthContext.Provider>
+        </StoreProvider>
+      </ContainerProvider>
     )
     expect(tree).toMatchSnapshot()
   })
 
   test('PIN Enter renders correctly when logged out message is present', async () => {
+    const main = new MainContainer(container.createChildContainer()).init()
     const tree = render(
-      <StoreProvider
-        initialState={{
-          ...defaultState,
-          lockout: {
-            displayNotification: true,
-          },
-        }}
-      >
-        <AuthContext.Provider value={authContext}>
-          <PINEnter setAuthenticated={jest.fn()} />
-        </AuthContext.Provider>
-      </StoreProvider>
+      <ContainerProvider value={main}>
+        <StoreProvider
+          initialState={{
+            ...defaultState,
+            lockout: {
+              displayNotification: true,
+            },
+          }}
+        >
+          <AuthContext.Provider value={authContext}>
+            <PINEnter setAuthenticated={jest.fn()} />
+          </AuthContext.Provider>
+        </StoreProvider>
+      </ContainerProvider>
     )
     const textNotice = await tree.findByText('PINEnter.LockedOut')
     expect(textNotice).not.toBeNull()
@@ -44,16 +53,19 @@ describe('displays a PIN Enter screen', () => {
   })
 
   test('PIN Enter button exists', async () => {
+    const main = new MainContainer(container.createChildContainer()).init()
     const tree = render(
-      <StoreProvider
-        initialState={{
-          ...defaultState,
-        }}
-      >
-        <AuthContext.Provider value={authContext}>
-          <PINEnter setAuthenticated={jest.fn()} />
-        </AuthContext.Provider>
-      </StoreProvider>
+      <ContainerProvider value={main}>
+        <StoreProvider
+          initialState={{
+            ...defaultState,
+          }}
+        >
+          <AuthContext.Provider value={authContext}>
+            <PINEnter setAuthenticated={jest.fn()} />
+          </AuthContext.Provider>
+        </StoreProvider>
+      </ContainerProvider>
     )
     const EnterButton = await tree.getByTestId(testIdWithKey('Enter'))
     expect(EnterButton).not.toBeNull()


### PR DESCRIPTION
# Summary of Changes

After lockout, there was some unfinished UI threads running (navigation animations from rapid route changing) that were interrupted by biometrics being triggered which caused duplicate biometrics popups. This PR prevents the first popup from appearing until after the main thread is finished. There is *still* the issue of the notifications not coming through properly after lockout. That issue remains.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
