### PR TITLE
chore: remove extra style prop array wrapping

### DIFF
--- a/packages/legacy/core/App/components/animated/ButtonLoading.tsx
+++ b/packages/legacy/core/App/components/animated/ButtonLoading.tsx
@@ -22,7 +22,7 @@ const ButtonLoading: React.FC = () => {
   }, [rotationAnim])
 
   return (
-    <Animated.View style={[{ transform: [{ rotate: rotation }] }]}>
+    <Animated.View style={{ transform: [{ rotate: rotation }] }}>
       <Icon style={{ color: ColorPallet.brand.icon }} size={25} name="refresh" />
     </Animated.View>
   )

--- a/packages/legacy/core/App/components/animated/CredentialAdded.tsx
+++ b/packages/legacy/core/App/components/animated/CredentialAdded.tsx
@@ -56,16 +56,16 @@ const CredentialAdded: React.FC = () => {
   }, [])
 
   return (
-    <View style={[style.container]}>
+    <View style={style.container}>
       <Animated.View style={[{ opacity: checkFadeAnim }, style.check]}>
         <CheckInCircle {...{ height: 45, width: 45 }} />
       </Animated.View>
       <View>
-        <WalletBack style={[style.back]} {...{ height: 110, width: 110 }} />
-        <Animated.View style={[{ opacity: cardFadeAnim, transform: [{ translateY: tranAnim }] }]}>
-          <CredentialCard style={[style.card]} {...{ height: 110, width: 110 }} />
+        <WalletBack style={style.back} {...{ height: 110, width: 110 }} />
+        <Animated.View style={{ opacity: cardFadeAnim, transform: [{ translateY: tranAnim }] }}>
+          <CredentialCard style={style.card} {...{ height: 110, width: 110 }} />
         </Animated.View>
-        <WalletFront style={[style.front]} {...{ height: 140, width: 140 }} />
+        <WalletFront style={style.front} {...{ height: 140, width: 140 }} />
       </View>
     </View>
   )

--- a/packages/legacy/core/App/components/animated/CredentialPending.tsx
+++ b/packages/legacy/core/App/components/animated/CredentialPending.tsx
@@ -48,12 +48,12 @@ const CredentialPending: React.FC = () => {
   }, [])
 
   return (
-    <View style={[style.container]}>
-      <WalletBack style={[style.back]} {...{ height: 110, width: 110 }} />
-      <Animated.View style={[{ opacity: fadeAnim, transform: [{ translateY: tranAnim }] }]}>
-        <CredentialCard style={[style.card]} {...{ height: 110, width: 110 }} />
+    <View style={style.container}>
+      <WalletBack style={style.back} {...{ height: 110, width: 110 }} />
+      <Animated.View style={{ opacity: fadeAnim, transform: [{ translateY: tranAnim }] }}>
+        <CredentialCard style={style.card} {...{ height: 110, width: 110 }} />
       </Animated.View>
-      <WalletFront style={[style.front]} {...{ height: 140, width: 140 }} />
+      <WalletFront style={style.front} {...{ height: 140, width: 140 }} />
     </View>
   )
 }

--- a/packages/legacy/core/App/components/animated/RecordLoading.tsx
+++ b/packages/legacy/core/App/components/animated/RecordLoading.tsx
@@ -43,8 +43,8 @@ const RecordLoading: React.FC = () => {
   }
 
   return (
-    <View style={[style.container]} testID={testIdWithKey('RecordLoading')}>
-      <Animated.View style={[{ opacity: rowFadeAnim }]}>
+    <View style={style.container} testID={testIdWithKey('RecordLoading')}>
+      <Animated.View style={{ opacity: rowFadeAnim }}>
         {makeARow()}
         {makeARow()}
       </Animated.View>

--- a/packages/legacy/core/App/components/animated/SentProof.tsx
+++ b/packages/legacy/core/App/components/animated/SentProof.tsx
@@ -68,7 +68,7 @@ const SentProof: React.FC = () => {
         </Animated.View>
       </View>
       <View style={style.ring}>
-        <Animated.View style={[{ opacity: ringFadeAnim }]}>
+        <Animated.View style={{ opacity: ringFadeAnim }}>
           <ActivityIndicator {...animatedCircleDisplayOptions} />
         </Animated.View>
       </View>

--- a/packages/legacy/core/App/components/buttons/HeaderButton.tsx
+++ b/packages/legacy/core/App/components/buttons/HeaderButton.tsx
@@ -50,7 +50,7 @@ const HeaderButton: React.FC<HeaderButtonProps> = ({
 
   const myIcon = () => <Icon name={icon} size={defaultIconSize} color={iconTintColor ?? ColorPallet.brand.headerIcon} />
 
-  const myText = () => (text ? <Text style={[style.title]}>{text}</Text> : null)
+  const myText = () => (text ? <Text style={style.title}>{text}</Text> : null)
 
   const layoutForButtonLocation = (buttonLocation: ButtonLocation) => {
     switch (buttonLocation) {

--- a/packages/legacy/core/App/components/chat/ChatEvent.tsx
+++ b/packages/legacy/core/App/components/chat/ChatEvent.tsx
@@ -21,7 +21,7 @@ export const ChatEvent: React.FC<ChatEventProps> = ({ userLabel, actionLabel, ro
         </Text>
       )}
       {actionLabel && (
-        <Text style={[role === Role.me ? ChatTheme.rightTextHighlighted : ChatTheme.leftTextHighlighted]}>
+        <Text style={role === Role.me ? ChatTheme.rightTextHighlighted : ChatTheme.leftTextHighlighted}>
           {actionLabel}
         </Text>
       )}

--- a/packages/legacy/core/App/components/misc/CredentialCard10.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard10.tsx
@@ -159,8 +159,8 @@ const CredentialCard10: React.FC<CredentialCard10Props> = ({ credential, style =
 
   const CredentialCardHeader: React.FC = () => {
     return (
-      <View style={[styles.outerHeaderContainer]}>
-        <View testID={testIdWithKey('CredentialCardHeader')} style={[styles.innerHeaderContainer]}>
+      <View style={styles.outerHeaderContainer}>
+        <View testID={testIdWithKey('CredentialCardHeader')} style={styles.innerHeaderContainer}>
           {overlay?.brandingOverlay?.header?.imageSource && (
             <Image
               source={toImageSource(overlay?.brandingOverlay?.header?.imageSource)}

--- a/packages/legacy/core/App/components/misc/CredentialCard11.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard11.tsx
@@ -439,7 +439,7 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
             </View>
           )}
           {!error && item?.satisfied != undefined && item?.satisfied === false ? (
-            <Text style={[styles.errorText]} numberOfLines={1}>
+            <Text style={styles.errorText} numberOfLines={1}>
               {t('ProofRequest.PredicateNotSatisfied')}
             </Text>
           ) : null}
@@ -491,9 +491,9 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
         </View>
         {(error || isProofRevoked) && (
           <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-            <Icon style={[styles.errorIcon]} name="close" size={30} />
+            <Icon style={styles.errorIcon} name="close" size={30} />
 
-            <Text style={[styles.errorText]} testID={testIdWithKey('RevokedOrNotAvailable')} numberOfLines={1}>
+            <Text style={styles.errorText} testID={testIdWithKey('RevokedOrNotAvailable')} numberOfLines={1}>
               {error ? t('ProofRequest.NotAvailableInYourWallet') : t('CredentialDetails.Revoked')}
             </Text>
           </View>
@@ -586,7 +586,7 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
               />
             </View>
           ) : (
-            <View style={[styles.statusContainer]} />
+            <View style={styles.statusContainer} />
           )}
         </>
       )

--- a/packages/legacy/core/App/components/misc/UnorderedList.tsx
+++ b/packages/legacy/core/App/components/misc/UnorderedList.tsx
@@ -14,7 +14,7 @@ const UnorderedList: React.FC<UnorderedListProps> = ({ unorderedListItems }) => 
     <>
       {unorderedListItems.map((item: string, i: number) => {
         return (
-          <View key={i} style={[{ display: 'flex', flexDirection: 'row', marginBottom: 5 }]}>
+          <View key={i} style={{ display: 'flex', flexDirection: 'row', marginBottom: 5 }}>
             <Text
               style={[TextTheme.normal, { color: ColorPallet.brand.unorderedList, paddingLeft: 5 }]}
             >{`\u2022`}</Text>

--- a/packages/legacy/core/App/components/modals/AlertModal.tsx
+++ b/packages/legacy/core/App/components/modals/AlertModal.tsx
@@ -27,7 +27,7 @@ const AlertModal: React.FC<AlertModalProps> = ({ title, message, submit }) => {
   })
 
   return (
-    <SafeAreaView style={[styles.container]}>
+    <SafeAreaView style={styles.container}>
       <PopupModal
         notificationType={InfoBoxType.Info}
         title={title}

--- a/packages/legacy/core/App/components/modals/CameraDisclosureModal.tsx
+++ b/packages/legacy/core/App/components/modals/CameraDisclosureModal.tsx
@@ -79,14 +79,14 @@ const CameraDisclosureModal: React.FC<CameraDisclosureModalProps> = ({ requestCa
         />
       )}
       <SafeAreaView style={{ backgroundColor: ColorPallet.brand.modalPrimaryBackground }}>
-        <ScrollView style={[styles.container]}>
-          <Text style={[TextTheme.modalHeadingOne]} testID={testIdWithKey('AllowCameraUse')}>
+        <ScrollView style={styles.container}>
+          <Text style={TextTheme.modalHeadingOne} testID={testIdWithKey('AllowCameraUse')}>
             {t('CameraDisclosure.AllowCameraUse')}
           </Text>
           <Text style={[TextTheme.modalNormal, styles.messageText]}>{t('CameraDisclosure.CameraDisclosure')}</Text>
           <Text style={[TextTheme.modalNormal, styles.messageText]}>{t('CameraDisclosure.ToContinueUsing')}</Text>
         </ScrollView>
-        <View style={[styles.controlsContainer]}>
+        <View style={styles.controlsContainer}>
           <View style={styles.buttonContainer}>
             <Button
               title={t('Global.Continue')}

--- a/packages/legacy/core/App/components/modals/CommonRemoveModal.tsx
+++ b/packages/legacy/core/App/components/modals/CommonRemoveModal.tsx
@@ -53,7 +53,7 @@ const Dropdown: React.FC<RemoveProps> = ({ title, content }) => {
       </TouchableOpacity>
       <Collapsible collapsed={isCollapsed} enablePointerEvents={true}>
         <View
-          style={[{ marginTop: 10, borderLeftWidth: 2, borderLeftColor: ColorPallet.brand.modalSecondaryBackground }]}
+          style={{ marginTop: 10, borderLeftWidth: 2, borderLeftColor: ColorPallet.brand.modalSecondaryBackground }}
         >
           <UnorderedList unorderedListItems={content} />
         </View>
@@ -184,12 +184,12 @@ const CommonRemoveModal: React.FC<CommonRemoveModalProps> = ({ usage, visible, o
     switch (usage) {
       case ModalUsage.ContactRemove:
         return (
-          <View style={[{ marginBottom: 25 }]}>
-            <View style={[{ marginBottom: 25 }]}>
-              <Text style={[TextTheme.modalTitle]}>{t('ContactDetails.RemoveTitle')}</Text>
+          <View style={{ marginBottom: 25 }}>
+            <View style={{ marginBottom: 25 }}>
+              <Text style={TextTheme.modalTitle}>{t('ContactDetails.RemoveTitle')}</Text>
             </View>
             <View>
-              <Text style={[styles.bodyText]}>{t('ContactDetails.RemoveContactMessageTop')}</Text>
+              <Text style={styles.bodyText}>{t('ContactDetails.RemoveContactMessageTop')}</Text>
               <BulletPoint text={t('ContactDetails.RemoveContactsBulletPoint1')} textStyle={styles.bodyText} />
               <BulletPoint text={t('ContactDetails.RemoveContactsBulletPoint2')} textStyle={styles.bodyText} />
               <BulletPoint text={t('ContactDetails.RemoveContactsBulletPoint3')} textStyle={styles.bodyText} />
@@ -200,12 +200,12 @@ const CommonRemoveModal: React.FC<CommonRemoveModalProps> = ({ usage, visible, o
         )
       case ModalUsage.CredentialRemove:
         return (
-          <View style={[{ marginBottom: 25 }]}>
-            <View style={[{ marginBottom: 25 }]}>
-              <Text style={[TextTheme.modalTitle]}>{t('CredentialDetails.RemoveTitle')}</Text>
+          <View style={{ marginBottom: 25 }}>
+            <View style={{ marginBottom: 25 }}>
+              <Text style={TextTheme.modalTitle}>{t('CredentialDetails.RemoveTitle')}</Text>
             </View>
             <View>
-              <Text style={[TextTheme.modalNormal]}>{t('CredentialDetails.RemoveCaption')}</Text>
+              <Text style={TextTheme.modalNormal}>{t('CredentialDetails.RemoveCaption')}</Text>
             </View>
             <View style={{ marginTop: 25 }}>
               <Dropdown
@@ -226,40 +226,40 @@ const CommonRemoveModal: React.FC<CommonRemoveModalProps> = ({ usage, visible, o
         )
       case ModalUsage.ContactRemoveWithCredentials:
         return (
-          <View style={[{ marginBottom: 25 }]}>
-            <View style={[{ marginBottom: 25 }]}>
-              <Text style={[TextTheme.modalTitle]}>{t('ContactDetails.UnableToRemoveTitle')}</Text>
+          <View style={{ marginBottom: 25 }}>
+            <View style={{ marginBottom: 25 }}>
+              <Text style={TextTheme.modalTitle}>{t('ContactDetails.UnableToRemoveTitle')}</Text>
             </View>
             <View>
-              <Text style={[styles.bodyText]}>{t('ContactDetails.UnableToRemoveCaption')}</Text>
+              <Text style={styles.bodyText}>{t('ContactDetails.UnableToRemoveCaption')}</Text>
             </View>
           </View>
         )
       case ModalUsage.CredentialOfferDecline:
         return (
-          <View style={[{ marginBottom: 25 }]}>
-            <Text style={[TextTheme.modalTitle]}>{t('CredentialOffer.DeclineTitle')}</Text>
+          <View style={{ marginBottom: 25 }}>
+            <Text style={TextTheme.modalTitle}>{t('CredentialOffer.DeclineTitle')}</Text>
             <Text style={[styles.declineBodyText, { marginTop: 30 }]}>{t('CredentialOffer.DeclineParagraph1')}</Text>
-            <Text style={[styles.declineBodyText]}>{t('CredentialOffer.DeclineParagraph2')}</Text>
+            <Text style={styles.declineBodyText}>{t('CredentialOffer.DeclineParagraph2')}</Text>
           </View>
         )
       case ModalUsage.ProofRequestDecline:
         return (
-          <View style={[{ marginBottom: 25 }]}>
-            <Text style={[TextTheme.modalTitle]}>{t('ProofRequest.DeclineTitle')}</Text>
+          <View style={{ marginBottom: 25 }}>
+            <Text style={TextTheme.modalTitle}>{t('ProofRequest.DeclineTitle')}</Text>
             <Text style={[styles.declineBodyText, { marginTop: 30 }]}>{t('ProofRequest.DeclineBulletPoint1')}</Text>
-            <Text style={[styles.declineBodyText]}>{t('ProofRequest.DeclineBulletPoint2')}</Text>
-            <Text style={[styles.declineBodyText]}>{t('ProofRequest.DeclineBulletPoint3')}</Text>
+            <Text style={styles.declineBodyText}>{t('ProofRequest.DeclineBulletPoint2')}</Text>
+            <Text style={styles.declineBodyText}>{t('ProofRequest.DeclineBulletPoint3')}</Text>
           </View>
         )
       case ModalUsage.CustomNotificationDecline:
         return (
-          <View style={[{ marginBottom: 25 }]}>
-            <Text style={[TextTheme.modalTitle]}>{t('CredentialOffer.CustomOfferTitle')}</Text>
+          <View style={{ marginBottom: 25 }}>
+            <Text style={TextTheme.modalTitle}>{t('CredentialOffer.CustomOfferTitle')}</Text>
             <Text style={[styles.declineBodyText, { marginTop: 30 }]}>
               {t('CredentialOffer.CustomOfferParagraph1')}
             </Text>
-            <Text style={[styles.declineBodyText]}>{t('CredentialOffer.CustomOfferParagraph2')}</Text>
+            <Text style={styles.declineBodyText}>{t('CredentialOffer.CustomOfferParagraph2')}</Text>
           </View>
         )
       default:

--- a/packages/legacy/core/App/components/modals/ErrorModal.tsx
+++ b/packages/legacy/core/App/components/modals/ErrorModal.tsx
@@ -61,7 +61,7 @@ const ErrorModal: React.FC<ErrorModalProps> = ({ reportProblemAction }) => {
   return (
     <Modal visible={modalVisible} transparent={true}>
       <StatusBar hidden={true} />
-      <SafeAreaView style={[styles.container]}>
+      <SafeAreaView style={styles.container}>
         <InfoBox
           notificationType={InfoBoxType.Error}
           title={error ? error.title : t('Error.Unknown')}

--- a/packages/legacy/core/App/components/record/RecordField.tsx
+++ b/packages/legacy/core/App/components/record/RecordField.tsx
@@ -98,7 +98,7 @@ const RecordField: React.FC<RecordFieldProps> = ({
         {fieldLabel ? (
           fieldLabel(field)
         ) : (
-          <Text style={[ListItems.recordAttributeLabel]} testID={testIdWithKey('AttributeName')}>
+          <Text style={ListItems.recordAttributeLabel} testID={testIdWithKey('AttributeName')}>
             {field.label ?? startCase(field.name || '')}
           </Text>
         )}

--- a/packages/legacy/core/App/components/texts/HighlightTextBox.tsx
+++ b/packages/legacy/core/App/components/texts/HighlightTextBox.tsx
@@ -30,8 +30,8 @@ const HighlightTextBox: React.FC<TextBoxProps> = ({ children }) => {
     },
   })
   return (
-    <View style={[style.container]}>
-      <View style={[style.accentBox]} />
+    <View style={style.container}>
+      <View style={style.accentBox} />
       <Text style={[style.headerText, { paddingTop: offset, paddingBottom: offset }]}>{children}</Text>
     </View>
   )

--- a/packages/legacy/core/App/components/toast/BaseToast.tsx
+++ b/packages/legacy/core/App/components/toast/BaseToast.tsx
@@ -96,8 +96,8 @@ const BaseToast: React.FC<BaseToastProps> = ({ title, body, toastType, onPress =
   return (
     <TouchableOpacity activeOpacity={1} onPress={() => onPress()}>
       <View style={[styles.container, { backgroundColor, borderColor, width: width - width * 0.1 }]}>
-        <Icon style={[styles.icon]} name={iconName} color={iconColor} size={iconSize} />
-        <View style={[styles.textContainer]}>
+        <Icon style={styles.icon} name={iconName} color={iconColor} size={iconSize} />
+        <View style={styles.textContainer}>
           <Text style={[TextTheme.normal, styles.title, { color: textColor }]} testID={testIdWithKey('ToastTitle')}>
             {title}
           </Text>

--- a/packages/legacy/core/App/components/tour/TourBox.tsx
+++ b/packages/legacy/core/App/components/tour/TourBox.tsx
@@ -183,7 +183,7 @@ export function TourBox(props: TourBoxProps): ReactElement {
             {title}
           </Text>
         </View>
-        <View style={[styles.dismissIcon]}>
+        <View style={styles.dismissIcon}>
           <TouchableOpacity
             onPress={stop}
             testID={testIdWithKey('Close')}

--- a/packages/legacy/core/App/components/views/HomeFooterView.tsx
+++ b/packages/legacy/core/App/components/views/HomeFooterView.tsx
@@ -64,13 +64,13 @@ const HomeFooterView: React.FC<HomeFooterViewProps> = ({ children }) => {
     return (
       <>
         {notifications.length === 0 && (
-          <View style={[styles.messageContainer]}>
+          <View style={styles.messageContainer}>
             <Text adjustsFontSizeToFit style={[HomeTheme.welcomeHeader, { marginTop: offset, marginBottom: 20 }]}>
               {t('Home.Welcome')}
             </Text>
           </View>
         )}
-        <View style={[styles.messageContainer]}>
+        <View style={styles.messageContainer}>
           <Text style={[HomeTheme.credentialMsg, { marginTop: offset, textAlign: 'center' }]}>{credentialMsg}</Text>
         </View>
       </>

--- a/packages/legacy/core/App/components/views/LoadingView.tsx
+++ b/packages/legacy/core/App/components/views/LoadingView.tsx
@@ -20,7 +20,7 @@ const LoadingView: React.FC = () => {
   })
 
   return (
-    <SafeAreaView style={[styles.container]}>
+    <SafeAreaView style={styles.container}>
       <LoadingIndicator />
     </SafeAreaView>
   )

--- a/packages/legacy/core/App/screens/CredentialOfferAccept.tsx
+++ b/packages/legacy/core/App/screens/CredentialOfferAccept.tsx
@@ -107,8 +107,8 @@ const CredentialOfferAccept: React.FC<CredentialOfferAcceptProps> = ({ visible, 
   return (
     <Modal visible={visible} transparent={true} animationType={'none'}>
       <SafeAreaView style={{ ...ListItems.credentialOfferBackground }}>
-        <ScrollView style={[styles.container]}>
-          <View style={[styles.messageContainer]}>
+        <ScrollView style={styles.container}>
+          <View style={styles.messageContainer}>
             {credentialDeliveryStatus === DeliveryStatus.Pending && (
               <Text
                 style={[ListItems.credentialOfferTitle, styles.messageText]}
@@ -143,7 +143,7 @@ const CredentialOfferAccept: React.FC<CredentialOfferAcceptProps> = ({ visible, 
           )}
         </ScrollView>
 
-        <View style={[styles.controlsContainer]}>
+        <View style={styles.controlsContainer}>
           {credentialDeliveryStatus === DeliveryStatus.Pending && (
             <View>
               <Button

--- a/packages/legacy/core/App/screens/DataRetention.tsx
+++ b/packages/legacy/core/App/screens/DataRetention.tsx
@@ -47,9 +47,9 @@ const DataRetention: React.FC = () => {
   }
 
   return (
-    <SafeAreaView style={[styles.container]}>
+    <SafeAreaView style={styles.container}>
       <View style={[styles.section, styles.sectionRow]}>
-        <Text style={[TextTheme.title]}>{t('Global.On')}</Text>
+        <Text style={TextTheme.title}>{t('Global.On')}</Text>
         <BouncyCheckbox
           accessibilityLabel={t('Global.On')}
           disableText
@@ -65,10 +65,10 @@ const DataRetention: React.FC = () => {
         />
       </View>
       <View style={{ backgroundColor: SettingsTheme.groupBackground }}>
-        <View style={[styles.itemSeparator]}></View>
+        <View style={styles.itemSeparator}></View>
       </View>
       <View style={[styles.section, styles.sectionRow]}>
-        <Text style={[TextTheme.title]}>{t('Global.Off')}</Text>
+        <Text style={TextTheme.title}>{t('Global.Off')}</Text>
         <BouncyCheckbox
           accessibilityLabel={t('Global.Off')}
           disableText

--- a/packages/legacy/core/App/screens/Language.tsx
+++ b/packages/legacy/core/App/screens/Language.tsx
@@ -59,14 +59,14 @@ const Language = () => {
   }
 
   return (
-    <SafeAreaView style={[styles.container]}>
+    <SafeAreaView style={styles.container}>
       <FlatList
         data={languages}
         renderItem={({ item: language }) => {
           const { id, value }: Language = language
           return (
             <View style={[styles.section, styles.sectionRow]}>
-              <Text style={[TextTheme.title]}>{value}</Text>
+              <Text style={TextTheme.title}>{value}</Text>
               <BouncyCheckbox
                 accessibilityLabel={value}
                 disableText
@@ -85,7 +85,7 @@ const Language = () => {
         }}
         ItemSeparatorComponent={() => (
           <View style={{ backgroundColor: SettingsTheme.groupBackground }}>
-            <View style={[styles.itemSeparator]}></View>
+            <View style={styles.itemSeparator}></View>
           </View>
         )}
       />

--- a/packages/legacy/core/App/screens/MobileVerifierLoading.tsx
+++ b/packages/legacy/core/App/screens/MobileVerifierLoading.tsx
@@ -68,18 +68,18 @@ const MobileVerifierLoading: React.FC<MobileVerifierLoadingProps> = ({ navigatio
   return (
     <Modal transparent animationType={'slide'}>
       <SafeAreaView style={{ backgroundColor: ColorPallet.brand.modalPrimaryBackground }}>
-        <ScrollView style={[styles.container]}>
-          <View style={[styles.messageContainer]}>
+        <ScrollView style={styles.container}>
+          <View style={styles.messageContainer}>
             <Text style={[TextTheme.modalHeadingThree, styles.messageText]} testID={testIdWithKey('VerifierLoading')}>
               {t('Verifier.WaitingForResponse')}
             </Text>
           </View>
 
-          <View style={[styles.image]}>
+          <View style={styles.image}>
             <PresentationLoading />
           </View>
         </ScrollView>
-        <View style={[styles.controlsContainer]}>
+        <View style={styles.controlsContainer}>
           <Button
             title={t('Global.GoBack')}
             accessibilityLabel={t('Global.GoBack')}

--- a/packages/legacy/core/App/screens/Onboarding.tsx
+++ b/packages/legacy/core/App/screens/Onboarding.tsx
@@ -140,7 +140,7 @@ const Onboarding: React.FC<OnboardingProps> = ({
         horizontal
         pagingEnabled
         showsHorizontalScrollIndicator={false}
-        style={[{ width }]}
+        style={{ width }}
         data={pages}
         renderItem={renderItem}
         viewabilityConfig={viewabilityConfigRef.current}

--- a/packages/legacy/core/App/screens/OnboardingPages.tsx
+++ b/packages/legacy/core/App/screens/OnboardingPages.tsx
@@ -97,7 +97,7 @@ const CustomPages = (onTutorialCompleted: GenericFn, OnboardingTheme: any) => {
           <SecureImage {...imageDisplayOptions} />
         </View>
         <View style={{ marginBottom: 20 }}>
-          <Text style={[styles.headerText]} testID={testIdWithKey('HeaderText')}>
+          <Text style={styles.headerText} testID={testIdWithKey('HeaderText')}>
             Ornare suspendisse sed nisi lacus
           </Text>
           <Text style={[styles.bodyText, { marginTop: 25 }]} testID={testIdWithKey('BodyText')}>
@@ -144,7 +144,7 @@ export const createPageWith = (
   const styles = createStyles(OnboardingTheme)
   const imageDisplayOptions = createImageDisplayOptions(OnboardingTheme)
   const titleElement = (
-    <Text style={[styles.headerText]} testID={testIdWithKey('HeaderText')}>
+    <Text style={styles.headerText} testID={testIdWithKey('HeaderText')}>
       {title}
     </Text>
   )

--- a/packages/legacy/core/App/screens/Preface.tsx
+++ b/packages/legacy/core/App/screens/Preface.tsx
@@ -44,7 +44,7 @@ const Preface: React.FC = () => {
         <View style={style.screenContainer}>
           <View style={style.contentContainer}>
             <Assets.svg.preface style={{ alignSelf: 'center', marginBottom: 20 }} height={200} />
-            <Text style={[TextTheme.headingTwo]}>{t('Preface.PrimaryHeading')}</Text>
+            <Text style={TextTheme.headingTwo}>{t('Preface.PrimaryHeading')}</Text>
             <Text style={[TextTheme.normal, { marginTop: 20, marginBottom: 20 }]}>{t('Preface.Paragraph1')}</Text>
           </View>
           <View style={style.controlsContainer}>
@@ -57,7 +57,7 @@ const Preface: React.FC = () => {
               reverse
               titleStyle={{ fontWeight: TextTheme.bold.fontWeight }}
             />
-            <View style={[{ paddingTop: 10 }]}>
+            <View style={{ paddingTop: 10 }}>
               <Button
                 title={t('Global.Continue')}
                 accessibilityLabel={t('Global.Continue')}

--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -517,18 +517,18 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
 
                   <Text style={styles.headerText} testID={testIdWithKey('HeaderText')}>
                     {t('ProofRequest.YouDoNotHaveDataPredicate')}{' '}
-                    <Text style={[TextTheme.title]}>
+                    <Text style={TextTheme.title}>
                       {proofConnectionLabel || outOfBandInvitation?.label || t('ContactDetails.AContact')}
                     </Text>
                   </Text>
                 </View>
               ) : (
                 <Text style={styles.headerText} testID={testIdWithKey('HeaderText')}>
-                  <Text style={[TextTheme.title]}>
+                  <Text style={TextTheme.title}>
                     {proofConnectionLabel || outOfBandInvitation?.label || t('ContactDetails.AContact')}
                   </Text>{' '}
                   <Text>{t('ProofRequest.IsRequestingYouToShare')}</Text>
-                  <Text style={[TextTheme.title]}>{` ${activeCreds?.length} `}</Text>
+                  <Text style={TextTheme.title}>{` ${activeCreds?.length} `}</Text>
                   <Text>{activeCreds?.length > 1 ? t('ProofRequest.Credentials') : t('ProofRequest.Credential')}</Text>
                 </Text>
               )}

--- a/packages/legacy/core/App/screens/ProofRequestAccept.tsx
+++ b/packages/legacy/core/App/screens/ProofRequestAccept.tsx
@@ -73,8 +73,8 @@ const ProofRequestAccept: React.FC<ProofRequestAcceptProps> = ({ visible, proofI
   return (
     <Modal visible={visible} transparent={true} animationType={'none'}>
       <SafeAreaView style={{ backgroundColor: ColorPallet.brand.modalPrimaryBackground }}>
-        <ScrollView style={[styles.container]}>
-          <View style={[styles.messageContainer]}>
+        <ScrollView style={styles.container}>
+          <View style={styles.messageContainer}>
             {proofDeliveryStatus === ProofState.RequestReceived && (
               <Text
                 style={[TextTheme.modalHeadingThree, styles.messageText]}
@@ -102,7 +102,7 @@ const ProofRequestAccept: React.FC<ProofRequestAcceptProps> = ({ visible, proofI
           </View>
         </ScrollView>
 
-        <View style={[styles.controlsContainer]}>
+        <View style={styles.controlsContainer}>
           <View>
             <Button
               title={t('Loading.BackToHome')}

--- a/packages/legacy/core/App/screens/PushNotification.tsx
+++ b/packages/legacy/core/App/screens/PushNotification.tsx
@@ -125,7 +125,7 @@ const PushNotification: React.FC<StackScreenProps<ParamListBase, Screens.UsePush
             </View>
           ) : (
             <>
-              <Text style={[TextTheme.normal]}>{t('PushNotifications.BeNotified')}</Text>
+              <Text style={TextTheme.normal}>{t('PushNotifications.BeNotified')}</Text>
               {list.map((item, index) => (
                 <View style={{ flexDirection: 'row', marginTop: 20 }} key={index}>
                   <Text style={TextTheme.normal}>{'\u2022'}</Text>

--- a/packages/legacy/core/App/screens/Settings.tsx
+++ b/packages/legacy/core/App/screens/Settings.tsx
@@ -355,10 +355,10 @@ const Settings: React.FC<SettingsProps> = ({ navigation }) => {
         }) => <SectionHeader icon={icon} iconRight={iconRight} title={title} titleTestID={titleTestID} />}
         ItemSeparatorComponent={() => (
           <View style={{ backgroundColor: SettingsTheme.groupBackground }}>
-            <View style={[styles.itemSeparator]}></View>
+            <View style={styles.itemSeparator}></View>
           </View>
         )}
-        SectionSeparatorComponent={() => <View style={[styles.sectionSeparator]}></View>}
+        SectionSeparatorComponent={() => <View style={styles.sectionSeparator}></View>}
         ListFooterComponent={() => (
           <View style={styles.footer}>
             <TouchableWithoutFeedback

--- a/packages/legacy/core/App/screens/Terms.tsx
+++ b/packages/legacy/core/App/screens/Terms.tsx
@@ -73,7 +73,7 @@ const Terms: React.FC = () => {
 
   return (
     <SafeAreaView edges={['left', 'right', 'bottom']}>
-      <ScrollView style={[style.container]}>
+      <ScrollView style={style.container}>
         <InfoTextBox>Please agree to the terms and conditions below before using this application.</InfoTextBox>
         <Text style={[style.bodyText, { marginTop: 20, marginBottom: 20 }]}>
           <Text style={[style.bodyText, { fontWeight: TextTheme.bold.fontWeight }]}>
@@ -94,7 +94,7 @@ const Terms: React.FC = () => {
           pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
           est laborum.
         </Text>
-        <View style={[style.controlsContainer]}>
+        <View style={style.controlsContainer}>
           {!agreedToPreviousTerms && (
             <CheckBoxRow
               title={t('Terms.Attestation')}
@@ -104,7 +104,7 @@ const Terms: React.FC = () => {
               onPress={() => setChecked(!checked)}
             />
           )}
-          <View style={[{ paddingTop: 10 }]}>
+          <View style={{ paddingTop: 10 }}>
             <Button
               title={agreedToPreviousTerms ? t('Global.Accept') : t('Global.Continue')}
               accessibilityLabel={agreedToPreviousTerms ? t('Global.Accept') : t('Global.Continue')}
@@ -115,7 +115,7 @@ const Terms: React.FC = () => {
             />
           </View>
           {!agreedToPreviousTerms && (
-            <View style={[{ paddingTop: 10, marginBottom: 20 }]}>
+            <View style={{ paddingTop: 10, marginBottom: 20 }}>
               <Button
                 title={t('Global.Back')}
                 accessibilityLabel={t('Global.Back')}

--- a/packages/legacy/core/App/screens/Tours.tsx
+++ b/packages/legacy/core/App/screens/Tours.tsx
@@ -54,14 +54,14 @@ const Tours: React.FC = () => {
   }
 
   return (
-    <SafeAreaView style={[styles.container]}>
+    <SafeAreaView style={styles.container}>
       <FlatList
         data={options}
         renderItem={({ item: option }) => {
           const { value, bool }: Option = option
           return (
             <View style={[styles.section, styles.sectionRow]}>
-              <Text style={[TextTheme.title]}>{value}</Text>
+              <Text style={TextTheme.title}>{value}</Text>
               <BouncyCheckbox
                 accessibilityLabel={value}
                 disableText
@@ -79,7 +79,7 @@ const Tours: React.FC = () => {
         }}
         ItemSeparatorComponent={() => (
           <View style={{ backgroundColor: SettingsTheme.groupBackground }}>
-            <View style={[styles.itemSeparator]}></View>
+            <View style={styles.itemSeparator}></View>
           </View>
         )}
       />

--- a/packages/legacy/core/App/screens/UseBiometry.tsx
+++ b/packages/legacy/core/App/screens/UseBiometry.tsx
@@ -126,22 +126,22 @@ const UseBiometry: React.FC = () => {
     <SafeAreaView edges={['left', 'right', 'bottom']}>
       <ScrollView style={styles.container}>
         <View style={{ alignItems: 'center' }}>
-          <Assets.svg.biometrics style={[styles.image]} />
+          <Assets.svg.biometrics style={styles.image} />
         </View>
         {biometryAvailable ? (
           <View>
-            <Text style={[TextTheme.normal]}>{t('Biometry.EnabledText1')}</Text>
+            <Text style={TextTheme.normal}>{t('Biometry.EnabledText1')}</Text>
             <Text></Text>
-            <Text style={[TextTheme.normal]}>
+            <Text style={TextTheme.normal}>
               {t('Biometry.EnabledText2')}
-              <Text style={[TextTheme.bold]}> {t('Biometry.Warning')}</Text>
+              <Text style={TextTheme.bold}> {t('Biometry.Warning')}</Text>
             </Text>
           </View>
         ) : (
           <View>
-            <Text style={[TextTheme.normal]}>{t('Biometry.NotEnabledText1')}</Text>
+            <Text style={TextTheme.normal}>{t('Biometry.NotEnabledText1')}</Text>
             <Text></Text>
-            <Text style={[TextTheme.normal]}>{t('Biometry.NotEnabledText2')}</Text>
+            <Text style={TextTheme.normal}>{t('Biometry.NotEnabledText2')}</Text>
           </View>
         )}
         <View
@@ -151,7 +151,7 @@ const UseBiometry: React.FC = () => {
           }}
         >
           <View style={{ flexShrink: 1, marginRight: 10, justifyContent: 'center' }}>
-            <Text style={[TextTheme.bold]}>{t('Biometry.UseToUnlock')}</Text>
+            <Text style={TextTheme.bold}>{t('Biometry.UseToUnlock')}</Text>
           </View>
           <View style={{ justifyContent: 'center' }}>
             <Pressable

--- a/packages/legacy/core/__tests__/components/__snapshots__/BaseToast.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/BaseToast.test.tsx.snap
@@ -63,12 +63,10 @@ exports[`BaseToast Component Error renders correctly 1`] = `
             "color": "#D8292F",
             "fontSize": 24,
           },
-          Array [
-            Object {
-              "marginHorizontal": 15,
-              "marginTop": 15,
-            },
-          ],
+          Object {
+            "marginHorizontal": 15,
+            "marginTop": 15,
+          },
           Object {
             "fontFamily": "Material Icons",
             "fontStyle": "normal",
@@ -82,13 +80,11 @@ exports[`BaseToast Component Error renders correctly 1`] = `
     </Text>
     <View
       style={
-        Array [
-          Object {
-            "flexShrink": 1,
-            "marginRight": 10,
-            "marginVertical": 15,
-          },
-        ]
+        Object {
+          "flexShrink": 1,
+          "marginRight": 10,
+          "marginVertical": 15,
+        }
       }
     >
       <Text
@@ -199,12 +195,10 @@ exports[`BaseToast Component Info renders correctly 1`] = `
             "color": "#0099FF",
             "fontSize": 24,
           },
-          Array [
-            Object {
-              "marginHorizontal": 15,
-              "marginTop": 15,
-            },
-          ],
+          Object {
+            "marginHorizontal": 15,
+            "marginTop": 15,
+          },
           Object {
             "fontFamily": "Material Icons",
             "fontStyle": "normal",
@@ -218,13 +212,11 @@ exports[`BaseToast Component Info renders correctly 1`] = `
     </Text>
     <View
       style={
-        Array [
-          Object {
-            "flexShrink": 1,
-            "marginRight": 10,
-            "marginVertical": 15,
-          },
-        ]
+        Object {
+          "flexShrink": 1,
+          "marginRight": 10,
+          "marginVertical": 15,
+        }
       }
     >
       <Text
@@ -335,12 +327,10 @@ exports[`BaseToast Component Success renders correctly 1`] = `
             "color": "#2E8540",
             "fontSize": 24,
           },
-          Array [
-            Object {
-              "marginHorizontal": 15,
-              "marginTop": 15,
-            },
-          ],
+          Object {
+            "marginHorizontal": 15,
+            "marginTop": 15,
+          },
           Object {
             "fontFamily": "Material Icons",
             "fontStyle": "normal",
@@ -354,13 +344,11 @@ exports[`BaseToast Component Success renders correctly 1`] = `
     </Text>
     <View
       style={
-        Array [
-          Object {
-            "flexShrink": 1,
-            "marginRight": 10,
-            "marginVertical": 15,
-          },
-        ]
+        Object {
+          "flexShrink": 1,
+          "marginRight": 10,
+          "marginVertical": 15,
+        }
       }
     >
       <Text
@@ -471,12 +459,10 @@ exports[`BaseToast Component Warn renders correctly 1`] = `
             "color": "#FCBA19",
             "fontSize": 24,
           },
-          Array [
-            Object {
-              "marginHorizontal": 15,
-              "marginTop": 15,
-            },
-          ],
+          Object {
+            "marginHorizontal": 15,
+            "marginTop": 15,
+          },
           Object {
             "fontFamily": "Material Icons",
             "fontStyle": "normal",
@@ -490,13 +476,11 @@ exports[`BaseToast Component Warn renders correctly 1`] = `
     </Text>
     <View
       style={
-        Array [
-          Object {
-            "flexShrink": 1,
-            "marginRight": 10,
-            "marginVertical": 15,
-          },
-        ]
+        Object {
+          "flexShrink": 1,
+          "marginRight": 10,
+          "marginVertical": 15,
+        }
       }
     >
       <Text

--- a/packages/legacy/core/__tests__/components/__snapshots__/HeaderButton.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/HeaderButton.test.tsx.snap
@@ -217,14 +217,12 @@ exports[`HeaderButton Component Right alignment with text renders correctly 1`] 
   >
     <Text
       style={
-        Array [
-          Object {
-            "color": "#FFFFFF",
-            "fontSize": 14,
-            "fontWeight": "bold",
-            "marginRight": 4,
-          },
-        ]
+        Object {
+          "color": "#FFFFFF",
+          "fontSize": 14,
+          "fontWeight": "bold",
+          "marginRight": 4,
+        }
       }
     >
       RightButton

--- a/packages/legacy/core/__tests__/components/__snapshots__/HighlightTextBox.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/HighlightTextBox.test.tsx.snap
@@ -3,23 +3,19 @@
 exports[`HighlightTextBox Component Renders correctly 1`] = `
 <View
   style={
-    Array [
-      Object {
-        "backgroundColor": "#000000",
-        "flexDirection": "row",
-      },
-    ]
+    Object {
+      "backgroundColor": "#000000",
+      "flexDirection": "row",
+    }
   }
 >
   <View
     style={
-      Array [
-        Object {
-          "backgroundColor": "#FCBA19",
-          "marginRight": 10,
-          "width": 8,
-        },
-      ]
+      Object {
+        "backgroundColor": "#FCBA19",
+        "marginRight": 10,
+        "width": 8,
+      }
     }
   />
   <Text

--- a/packages/legacy/core/__tests__/components/__snapshots__/HomeFooterView.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/HomeFooterView.test.tsx.snap
@@ -12,14 +12,12 @@ exports[`HomeFooterView Component Renders correctly with no notifications 1`] = 
   >
     <View
       style={
-        Array [
-          Object {
-            "alignItems": "center",
-            "justifyContent": "center",
-            "marginHorizontal": 25,
-            "marginTop": 35,
-          },
-        ]
+        Object {
+          "alignItems": "center",
+          "justifyContent": "center",
+          "marginHorizontal": 25,
+          "marginTop": 35,
+        }
       }
     >
       <Text
@@ -43,14 +41,12 @@ exports[`HomeFooterView Component Renders correctly with no notifications 1`] = 
     </View>
     <View
       style={
-        Array [
-          Object {
-            "alignItems": "center",
-            "justifyContent": "center",
-            "marginHorizontal": 25,
-            "marginTop": 35,
-          },
-        ]
+        Object {
+          "alignItems": "center",
+          "justifyContent": "center",
+          "marginHorizontal": 25,
+          "marginTop": 35,
+        }
       }
     >
       <Text
@@ -87,14 +83,12 @@ exports[`HomeFooterView Component Renders correctly with notifications 1`] = `
   >
     <View
       style={
-        Array [
-          Object {
-            "alignItems": "center",
-            "justifyContent": "center",
-            "marginHorizontal": 25,
-            "marginTop": 35,
-          },
-        ]
+        Object {
+          "alignItems": "center",
+          "justifyContent": "center",
+          "marginHorizontal": 25,
+          "marginTop": 35,
+        }
       }
     >
       <Text

--- a/packages/legacy/core/__tests__/components/__snapshots__/LoadingView.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/LoadingView.test.tsx.snap
@@ -3,15 +3,13 @@
 exports[`LoadingView Component renders correctly 1`] = `
 <RNCSafeAreaView
   style={
-    Array [
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "#000000",
-        "flexDirection": "column",
-        "justifyContent": "center",
-        "minHeight": 1334,
-      },
-    ]
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#000000",
+      "flexDirection": "column",
+      "justifyContent": "center",
+      "minHeight": 1334,
+    }
   }
 >
   <View

--- a/packages/legacy/core/__tests__/components/__snapshots__/RecordField.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/RecordField.test.tsx.snap
@@ -21,13 +21,11 @@ exports[`RecordField Component Shown binary field should render a binary field 1
   >
     <Text
       style={
-        Array [
-          Object {
-            "color": "#FFFFFF",
-            "fontSize": 18,
-            "fontWeight": "bold",
-          },
-        ]
+        Object {
+          "color": "#FFFFFF",
+          "fontSize": 18,
+          "fontWeight": "bold",
+        }
       }
       testID="com.ariesbifold:id/AttributeName"
     >
@@ -145,13 +143,11 @@ exports[`RecordField Component Shown date field should render a date field 1`] =
   >
     <Text
       style={
-        Array [
-          Object {
-            "color": "#FFFFFF",
-            "fontSize": 18,
-            "fontWeight": "bold",
-          },
-        ]
+        Object {
+          "color": "#FFFFFF",
+          "fontSize": 18,
+          "fontWeight": "bold",
+        }
       }
       testID="com.ariesbifold:id/AttributeName"
     >

--- a/packages/legacy/core/__tests__/components/__snapshots__/TourBox.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/TourBox.test.tsx.snap
@@ -48,11 +48,9 @@ exports[`TourBox Component Renders properly with defaults 1`] = `
     </View>
     <View
       style={
-        Array [
-          Object {
-            "alignSelf": "flex-end",
-          },
-        ]
+        Object {
+          "alignSelf": "flex-end",
+        }
       }
     >
       <View

--- a/packages/legacy/core/__tests__/components/__snapshots__/UnorderedList.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/UnorderedList.test.tsx.snap
@@ -4,13 +4,11 @@ exports[`UnorderedList Component Renders correctly 1`] = `
 Array [
   <View
     style={
-      Array [
-        Object {
-          "display": "flex",
-          "flexDirection": "row",
-          "marginBottom": 5,
-        },
-      ]
+      Object {
+        "display": "flex",
+        "flexDirection": "row",
+        "marginBottom": 5,
+      }
     }
   >
     <Text
@@ -51,13 +49,11 @@ Array [
   </View>,
   <View
     style={
-      Array [
-        Object {
-          "display": "flex",
-          "flexDirection": "row",
-          "marginBottom": 5,
-        },
-      ]
+      Object {
+        "display": "flex",
+        "flexDirection": "row",
+        "marginBottom": 5,
+      }
     }
   >
     <Text
@@ -98,13 +94,11 @@ Array [
   </View>,
   <View
     style={
-      Array [
-        Object {
-          "display": "flex",
-          "flexDirection": "row",
-          "marginBottom": 5,
-        },
-      ]
+      Object {
+        "display": "flex",
+        "flexDirection": "row",
+        "marginBottom": 5,
+      }
     }
   >
     <Text

--- a/packages/legacy/core/__tests__/modals/__snapshots__/AlertModal.test.tsx.snap
+++ b/packages/legacy/core/__tests__/modals/__snapshots__/AlertModal.test.tsx.snap
@@ -3,14 +3,12 @@
 exports[`AlertModal Component Renders correctly 1`] = `
 <RNCSafeAreaView
   style={
-    Array [
-      Object {
-        "alignItems": "center",
-        "flexDirection": "column",
-        "justifyContent": "center",
-        "minHeight": 1334,
-      },
-    ]
+    Object {
+      "alignItems": "center",
+      "flexDirection": "column",
+      "justifyContent": "center",
+      "minHeight": 1334,
+    }
   }
 >
   <Modal

--- a/packages/legacy/core/__tests__/modals/__snapshots__/CameraDisclosureModal.test.tsx.snap
+++ b/packages/legacy/core/__tests__/modals/__snapshots__/CameraDisclosureModal.test.tsx.snap
@@ -22,25 +22,21 @@ exports[`CameraDisclosureModal Component Renders correctly 1`] = `
   >
     <RCTScrollView
       style={
-        Array [
-          Object {
-            "backgroundColor": "#000000",
-            "height": "100%",
-            "padding": 20,
-          },
-        ]
+        Object {
+          "backgroundColor": "#000000",
+          "height": "100%",
+          "padding": 20,
+        }
       }
     >
       <View>
         <Text
           style={
-            Array [
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 38,
-                "fontWeight": "bold",
-              },
-            ]
+            Object {
+              "color": "#FFFFFF",
+              "fontSize": 38,
+              "fontWeight": "bold",
+            }
           }
           testID="com.ariesbifold:id/AllowCameraUse"
         >
@@ -82,13 +78,11 @@ exports[`CameraDisclosureModal Component Renders correctly 1`] = `
     </RCTScrollView>
     <View
       style={
-        Array [
-          Object {
-            "backgroundColor": "#000000",
-            "margin": 20,
-            "marginTop": "auto",
-          },
-        ]
+        Object {
+          "backgroundColor": "#000000",
+          "margin": 20,
+          "marginTop": "auto",
+        }
       }
     >
       <View

--- a/packages/legacy/core/__tests__/modals/__snapshots__/CommonRemoveModal.test.tsx.snap
+++ b/packages/legacy/core/__tests__/modals/__snapshots__/CommonRemoveModal.test.tsx.snap
@@ -135,22 +135,18 @@ exports[`CommonRemoveModal Component Credential offer decline renders correctly 
           </View>
           <View
             style={
-              Array [
-                Object {
-                  "marginBottom": 25,
-                },
-              ]
+              Object {
+                "marginBottom": 25,
+              }
             }
           >
             <Text
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 24,
-                    "fontWeight": "bold",
-                  },
-                ]
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 24,
+                  "fontWeight": "bold",
+                }
               }
             >
               CredentialOffer.DeclineTitle
@@ -174,14 +170,12 @@ exports[`CommonRemoveModal Component Credential offer decline renders correctly 
             </Text>
             <Text
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "normal",
-                    "marginTop": 25,
-                  },
-                ]
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                  "marginTop": 25,
+                }
               }
             >
               CredentialOffer.DeclineParagraph2
@@ -575,22 +569,18 @@ exports[`CommonRemoveModal Component Custom notification decline renders correct
           </View>
           <View
             style={
-              Array [
-                Object {
-                  "marginBottom": 25,
-                },
-              ]
+              Object {
+                "marginBottom": 25,
+              }
             }
           >
             <Text
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 24,
-                    "fontWeight": "bold",
-                  },
-                ]
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 24,
+                  "fontWeight": "bold",
+                }
               }
             >
               CredentialOffer.CustomOfferTitle
@@ -614,14 +604,12 @@ exports[`CommonRemoveModal Component Custom notification decline renders correct
             </Text>
             <Text
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "normal",
-                    "marginTop": 25,
-                  },
-                ]
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                  "marginTop": 25,
+                }
               }
             >
               CredentialOffer.CustomOfferParagraph2
@@ -1010,22 +998,18 @@ exports[`CommonRemoveModal Component Proof request decline renders correctly 1`]
           </View>
           <View
             style={
-              Array [
-                Object {
-                  "marginBottom": 25,
-                },
-              ]
+              Object {
+                "marginBottom": 25,
+              }
             }
           >
             <Text
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 24,
-                    "fontWeight": "bold",
-                  },
-                ]
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 24,
+                  "fontWeight": "bold",
+                }
               }
             >
               ProofRequest.DeclineTitle
@@ -1049,28 +1033,24 @@ exports[`CommonRemoveModal Component Proof request decline renders correctly 1`]
             </Text>
             <Text
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "normal",
-                    "marginTop": 25,
-                  },
-                ]
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                  "marginTop": 25,
+                }
               }
             >
               ProofRequest.DeclineBulletPoint2
             </Text>
             <Text
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "normal",
-                    "marginTop": 25,
-                  },
-                ]
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                  "marginTop": 25,
+                }
               }
             >
               ProofRequest.DeclineBulletPoint3
@@ -1454,31 +1434,25 @@ exports[`CommonRemoveModal Component Remove contact renders correctly 1`] = `
           />
           <View
             style={
-              Array [
-                Object {
-                  "marginBottom": 25,
-                },
-              ]
+              Object {
+                "marginBottom": 25,
+              }
             }
           >
             <View
               style={
-                Array [
-                  Object {
-                    "marginBottom": 25,
-                  },
-                ]
+                Object {
+                  "marginBottom": 25,
+                }
               }
             >
               <Text
                 style={
-                  Array [
-                    Object {
-                      "color": "#FFFFFF",
-                      "fontSize": 24,
-                      "fontWeight": "bold",
-                    },
-                  ]
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 24,
+                    "fontWeight": "bold",
+                  }
                 }
               >
                 ContactDetails.RemoveTitle
@@ -1487,13 +1461,11 @@ exports[`CommonRemoveModal Component Remove contact renders correctly 1`] = `
             <View>
               <Text
                 style={
-                  Array [
-                    Object {
-                      "color": "#FFFFFF",
-                      "fontSize": 18,
-                      "fontWeight": "normal",
-                    },
-                  ]
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "normal",
+                  }
                 }
               >
                 ContactDetails.RemoveContactMessageTop
@@ -2118,31 +2090,25 @@ exports[`CommonRemoveModal Component Remove contact renders correctly2 1`] = `
           />
           <View
             style={
-              Array [
-                Object {
-                  "marginBottom": 25,
-                },
-              ]
+              Object {
+                "marginBottom": 25,
+              }
             }
           >
             <View
               style={
-                Array [
-                  Object {
-                    "marginBottom": 25,
-                  },
-                ]
+                Object {
+                  "marginBottom": 25,
+                }
               }
             >
               <Text
                 style={
-                  Array [
-                    Object {
-                      "color": "#FFFFFF",
-                      "fontSize": 24,
-                      "fontWeight": "bold",
-                    },
-                  ]
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 24,
+                    "fontWeight": "bold",
+                  }
                 }
               >
                 ContactDetails.UnableToRemoveTitle
@@ -2151,13 +2117,11 @@ exports[`CommonRemoveModal Component Remove contact renders correctly2 1`] = `
             <View>
               <Text
                 style={
-                  Array [
-                    Object {
-                      "color": "#FFFFFF",
-                      "fontSize": 18,
-                      "fontWeight": "normal",
-                    },
-                  ]
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "normal",
+                  }
                 }
               >
                 ContactDetails.UnableToRemoveCaption
@@ -2542,31 +2506,25 @@ exports[`CommonRemoveModal Component Remove credential renders correctly 1`] = `
           />
           <View
             style={
-              Array [
-                Object {
-                  "marginBottom": 25,
-                },
-              ]
+              Object {
+                "marginBottom": 25,
+              }
             }
           >
             <View
               style={
-                Array [
-                  Object {
-                    "marginBottom": 25,
-                  },
-                ]
+                Object {
+                  "marginBottom": 25,
+                }
               }
             >
               <Text
                 style={
-                  Array [
-                    Object {
-                      "color": "#FFFFFF",
-                      "fontSize": 24,
-                      "fontWeight": "bold",
-                    },
-                  ]
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 24,
+                    "fontWeight": "bold",
+                  }
                 }
               >
                 CredentialDetails.RemoveTitle
@@ -2575,13 +2533,11 @@ exports[`CommonRemoveModal Component Remove credential renders correctly 1`] = `
             <View>
               <Text
                 style={
-                  Array [
-                    Object {
-                      "color": "#FFFFFF",
-                      "fontSize": 18,
-                      "fontWeight": "normal",
-                    },
-                  ]
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "normal",
+                  }
                 }
               >
                 CredentialDetails.RemoveCaption
@@ -2690,24 +2646,20 @@ exports[`CommonRemoveModal Component Remove credential renders correctly 1`] = `
                 >
                   <View
                     style={
-                      Array [
-                        Object {
-                          "borderLeftColor": "#313132",
-                          "borderLeftWidth": 2,
-                          "marginTop": 10,
-                        },
-                      ]
+                      Object {
+                        "borderLeftColor": "#313132",
+                        "borderLeftWidth": 2,
+                        "marginTop": 10,
+                      }
                     }
                   >
                     <View
                       style={
-                        Array [
-                          Object {
-                            "display": "flex",
-                            "flexDirection": "row",
-                            "marginBottom": 5,
-                          },
-                        ]
+                        Object {
+                          "display": "flex",
+                          "flexDirection": "row",
+                          "marginBottom": 5,
+                        }
                       }
                     >
                       <Text
@@ -2748,13 +2700,11 @@ exports[`CommonRemoveModal Component Remove credential renders correctly 1`] = `
                     </View>
                     <View
                       style={
-                        Array [
-                          Object {
-                            "display": "flex",
-                            "flexDirection": "row",
-                            "marginBottom": 5,
-                          },
-                        ]
+                        Object {
+                          "display": "flex",
+                          "flexDirection": "row",
+                          "marginBottom": 5,
+                        }
                       }
                     >
                       <Text
@@ -2900,24 +2850,20 @@ exports[`CommonRemoveModal Component Remove credential renders correctly 1`] = `
                 >
                   <View
                     style={
-                      Array [
-                        Object {
-                          "borderLeftColor": "#313132",
-                          "borderLeftWidth": 2,
-                          "marginTop": 10,
-                        },
-                      ]
+                      Object {
+                        "borderLeftColor": "#313132",
+                        "borderLeftWidth": 2,
+                        "marginTop": 10,
+                      }
                     }
                   >
                     <View
                       style={
-                        Array [
-                          Object {
-                            "display": "flex",
-                            "flexDirection": "row",
-                            "marginBottom": 5,
-                          },
-                        ]
+                        Object {
+                          "display": "flex",
+                          "flexDirection": "row",
+                          "marginBottom": 5,
+                        }
                       }
                     >
                       <Text
@@ -3339,31 +3285,25 @@ exports[`CommonRemoveModal Component Rerenders correctly when not visible 1`] = 
           />
           <View
             style={
-              Array [
-                Object {
-                  "marginBottom": 25,
-                },
-              ]
+              Object {
+                "marginBottom": 25,
+              }
             }
           >
             <View
               style={
-                Array [
-                  Object {
-                    "marginBottom": 25,
-                  },
-                ]
+                Object {
+                  "marginBottom": 25,
+                }
               }
             >
               <Text
                 style={
-                  Array [
-                    Object {
-                      "color": "#FFFFFF",
-                      "fontSize": 24,
-                      "fontWeight": "bold",
-                    },
-                  ]
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 24,
+                    "fontWeight": "bold",
+                  }
                 }
               >
                 ContactDetails.RemoveTitle
@@ -3372,13 +3312,11 @@ exports[`CommonRemoveModal Component Rerenders correctly when not visible 1`] = 
             <View>
               <Text
                 style={
-                  Array [
-                    Object {
-                      "color": "#FFFFFF",
-                      "fontSize": 18,
-                      "fontWeight": "normal",
-                    },
-                  ]
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "normal",
+                  }
                 }
               >
                 ContactDetails.RemoveContactMessageTop

--- a/packages/legacy/core/__tests__/modals/__snapshots__/ErrorModal.test.tsx.snap
+++ b/packages/legacy/core/__tests__/modals/__snapshots__/ErrorModal.test.tsx.snap
@@ -16,15 +16,13 @@ exports[`ErrorModal Component Renders correctly 1`] = `
 >
   <RNCSafeAreaView
     style={
-      Array [
-        Object {
-          "alignItems": "center",
-          "backgroundColor": "#000000",
-          "flexDirection": "column",
-          "justifyContent": "center",
-          "minHeight": 1334,
-        },
-      ]
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#000000",
+        "flexDirection": "column",
+        "justifyContent": "center",
+        "minHeight": 1334,
+      }
     }
   >
     <View

--- a/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
@@ -559,17 +559,15 @@ exports[`CredentialOffer Screen accepting a credential 1`] = `
                       >
                         <View
                           style={
-                            Array [
-                              Object {
-                                "alignItems": "center",
-                                "backgroundColor": "rgba(0, 0, 0, 0)",
-                                "borderBottomLeftRadius": 10,
-                                "borderTopRightRadius": 10,
-                                "height": 90,
-                                "justifyContent": "center",
-                                "width": 90,
-                              },
-                            ]
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "rgba(0, 0, 0, 0)",
+                              "borderBottomLeftRadius": 10,
+                              "borderTopRightRadius": 10,
+                              "height": 90,
+                              "justifyContent": "center",
+                              "width": 90,
+                            }
                           }
                         />
                       </View>
@@ -606,13 +604,11 @@ exports[`CredentialOffer Screen accepting a credential 1`] = `
           >
             <Text
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                ]
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                }
               }
               testID="com.ariesbifold:id/AttributeName"
             >
@@ -691,13 +687,11 @@ exports[`CredentialOffer Screen accepting a credential 1`] = `
           >
             <Text
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                ]
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                }
               }
               testID="com.ariesbifold:id/AttributeName"
             >
@@ -776,13 +770,11 @@ exports[`CredentialOffer Screen accepting a credential 1`] = `
           >
             <Text
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                ]
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                }
               }
               testID="com.ariesbifold:id/AttributeName"
             >
@@ -861,13 +853,11 @@ exports[`CredentialOffer Screen accepting a credential 1`] = `
           >
             <Text
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                ]
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                }
               }
               testID="com.ariesbifold:id/AttributeName"
             >
@@ -946,13 +936,11 @@ exports[`CredentialOffer Screen accepting a credential 1`] = `
           >
             <Text
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                ]
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                }
               }
               testID="com.ariesbifold:id/AttributeName"
             >
@@ -1202,23 +1190,19 @@ exports[`CredentialOffer Screen accepting a credential 1`] = `
     >
       <RCTScrollView
         style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "height": "100%",
-              "padding": 20,
-            },
-          ]
+          Object {
+            "backgroundColor": "#000000",
+            "height": "100%",
+            "padding": 20,
+          }
         }
       >
         <View>
           <View
             style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                },
-              ]
+              Object {
+                "alignItems": "center",
+              }
             }
           >
             <Text
@@ -1256,23 +1240,19 @@ exports[`CredentialOffer Screen accepting a credential 1`] = `
           >
             <View
               style={
-                Array [
-                  Object {
-                    "flexDirection": "column",
-                  },
-                ]
+                Object {
+                  "flexDirection": "column",
+                }
               }
             >
               <
                 height={110}
                 style={
-                  Array [
-                    Object {
-                      "backgroundColor": "transparent",
-                      "marginTop": -30,
-                      "position": "absolute",
-                    },
-                  ]
+                  Object {
+                    "backgroundColor": "transparent",
+                    "marginTop": -30,
+                    "position": "absolute",
+                  }
                 }
                 width={110}
               />
@@ -1292,13 +1272,11 @@ exports[`CredentialOffer Screen accepting a credential 1`] = `
                 <
                   height={110}
                   style={
-                    Array [
-                      Object {
-                        "backgroundColor": "transparent",
-                        "marginLeft": 10,
-                        "position": "absolute",
-                      },
-                    ]
+                    Object {
+                      "backgroundColor": "transparent",
+                      "marginLeft": 10,
+                      "position": "absolute",
+                    }
                   }
                   width={110}
                 />
@@ -1306,11 +1284,9 @@ exports[`CredentialOffer Screen accepting a credential 1`] = `
               <
                 height={140}
                 style={
-                  Array [
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ]
+                  Object {
+                    "backgroundColor": "transparent",
+                  }
                 }
                 width={140}
               />
@@ -1320,12 +1296,10 @@ exports[`CredentialOffer Screen accepting a credential 1`] = `
       </RCTScrollView>
       <View
         style={
-          Array [
-            Object {
-              "margin": 20,
-              "marginTop": "auto",
-            },
-          ]
+          Object {
+            "margin": 20,
+            "marginTop": "auto",
+          }
         }
       >
         <View>
@@ -1970,17 +1944,15 @@ exports[`CredentialOffer Screen declining a credential 1`] = `
                       >
                         <View
                           style={
-                            Array [
-                              Object {
-                                "alignItems": "center",
-                                "backgroundColor": "rgba(0, 0, 0, 0)",
-                                "borderBottomLeftRadius": 10,
-                                "borderTopRightRadius": 10,
-                                "height": 90,
-                                "justifyContent": "center",
-                                "width": 90,
-                              },
-                            ]
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "rgba(0, 0, 0, 0)",
+                              "borderBottomLeftRadius": 10,
+                              "borderTopRightRadius": 10,
+                              "height": 90,
+                              "justifyContent": "center",
+                              "width": 90,
+                            }
                           }
                         />
                       </View>
@@ -2017,13 +1989,11 @@ exports[`CredentialOffer Screen declining a credential 1`] = `
           >
             <Text
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                ]
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                }
               }
               testID="com.ariesbifold:id/AttributeName"
             >
@@ -2102,13 +2072,11 @@ exports[`CredentialOffer Screen declining a credential 1`] = `
           >
             <Text
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                ]
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                }
               }
               testID="com.ariesbifold:id/AttributeName"
             >
@@ -2187,13 +2155,11 @@ exports[`CredentialOffer Screen declining a credential 1`] = `
           >
             <Text
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                ]
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                }
               }
               testID="com.ariesbifold:id/AttributeName"
             >
@@ -2272,13 +2238,11 @@ exports[`CredentialOffer Screen declining a credential 1`] = `
           >
             <Text
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                ]
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                }
               }
               testID="com.ariesbifold:id/AttributeName"
             >
@@ -2357,13 +2321,11 @@ exports[`CredentialOffer Screen declining a credential 1`] = `
           >
             <Text
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                ]
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                }
               }
               testID="com.ariesbifold:id/AttributeName"
             >
@@ -2738,22 +2700,18 @@ exports[`CredentialOffer Screen declining a credential 1`] = `
             </View>
             <View
               style={
-                Array [
-                  Object {
-                    "marginBottom": 25,
-                  },
-                ]
+                Object {
+                  "marginBottom": 25,
+                }
               }
             >
               <Text
                 style={
-                  Array [
-                    Object {
-                      "color": "#FFFFFF",
-                      "fontSize": 24,
-                      "fontWeight": "bold",
-                    },
-                  ]
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 24,
+                    "fontWeight": "bold",
+                  }
                 }
               >
                 CredentialOffer.DeclineTitle
@@ -2777,14 +2735,12 @@ exports[`CredentialOffer Screen declining a credential 1`] = `
               </Text>
               <Text
                 style={
-                  Array [
-                    Object {
-                      "color": "#FFFFFF",
-                      "fontSize": 18,
-                      "fontWeight": "normal",
-                      "marginTop": 25,
-                    },
-                  ]
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "normal",
+                    "marginTop": 25,
+                  }
                 }
               >
                 CredentialOffer.DeclineParagraph2
@@ -3598,17 +3554,15 @@ exports[`CredentialOffer Screen renders correctly 1`] = `
                       >
                         <View
                           style={
-                            Array [
-                              Object {
-                                "alignItems": "center",
-                                "backgroundColor": "rgba(0, 0, 0, 0)",
-                                "borderBottomLeftRadius": 10,
-                                "borderTopRightRadius": 10,
-                                "height": 90,
-                                "justifyContent": "center",
-                                "width": 90,
-                              },
-                            ]
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "rgba(0, 0, 0, 0)",
+                              "borderBottomLeftRadius": 10,
+                              "borderTopRightRadius": 10,
+                              "height": 90,
+                              "justifyContent": "center",
+                              "width": 90,
+                            }
                           }
                         />
                       </View>
@@ -3645,13 +3599,11 @@ exports[`CredentialOffer Screen renders correctly 1`] = `
           >
             <Text
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                ]
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                }
               }
               testID="com.ariesbifold:id/AttributeName"
             >
@@ -3730,13 +3682,11 @@ exports[`CredentialOffer Screen renders correctly 1`] = `
           >
             <Text
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                ]
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                }
               }
               testID="com.ariesbifold:id/AttributeName"
             >
@@ -3815,13 +3765,11 @@ exports[`CredentialOffer Screen renders correctly 1`] = `
           >
             <Text
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                ]
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                }
               }
               testID="com.ariesbifold:id/AttributeName"
             >
@@ -3900,13 +3848,11 @@ exports[`CredentialOffer Screen renders correctly 1`] = `
           >
             <Text
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                ]
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                }
               }
               testID="com.ariesbifold:id/AttributeName"
             >
@@ -3985,13 +3931,11 @@ exports[`CredentialOffer Screen renders correctly 1`] = `
           >
             <Text
               style={
-                Array [
-                  Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
-                  },
-                ]
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "bold",
+                }
               }
               testID="com.ariesbifold:id/AttributeName"
             >

--- a/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOfferAccept.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOfferAccept.test.tsx.snap
@@ -16,23 +16,19 @@ exports[`CredentialOfferAccept Screen renders correctly 1`] = `
   >
     <RCTScrollView
       style={
-        Array [
-          Object {
-            "backgroundColor": "#000000",
-            "height": "100%",
-            "padding": 20,
-          },
-        ]
+        Object {
+          "backgroundColor": "#000000",
+          "height": "100%",
+          "padding": 20,
+        }
       }
     >
       <View>
         <View
           style={
-            Array [
-              Object {
-                "alignItems": "center",
-              },
-            ]
+            Object {
+              "alignItems": "center",
+            }
           }
         >
           <Text
@@ -70,23 +66,19 @@ exports[`CredentialOfferAccept Screen renders correctly 1`] = `
         >
           <View
             style={
-              Array [
-                Object {
-                  "flexDirection": "column",
-                },
-              ]
+              Object {
+                "flexDirection": "column",
+              }
             }
           >
             <
               height={110}
               style={
-                Array [
-                  Object {
-                    "backgroundColor": "transparent",
-                    "marginTop": -30,
-                    "position": "absolute",
-                  },
-                ]
+                Object {
+                  "backgroundColor": "transparent",
+                  "marginTop": -30,
+                  "position": "absolute",
+                }
               }
               width={110}
             />
@@ -106,13 +98,11 @@ exports[`CredentialOfferAccept Screen renders correctly 1`] = `
               <
                 height={110}
                 style={
-                  Array [
-                    Object {
-                      "backgroundColor": "transparent",
-                      "marginLeft": 10,
-                      "position": "absolute",
-                    },
-                  ]
+                  Object {
+                    "backgroundColor": "transparent",
+                    "marginLeft": 10,
+                    "position": "absolute",
+                  }
                 }
                 width={110}
               />
@@ -120,11 +110,9 @@ exports[`CredentialOfferAccept Screen renders correctly 1`] = `
             <
               height={140}
               style={
-                Array [
-                  Object {
-                    "backgroundColor": "transparent",
-                  },
-                ]
+                Object {
+                  "backgroundColor": "transparent",
+                }
               }
               width={140}
             />
@@ -134,12 +122,10 @@ exports[`CredentialOfferAccept Screen renders correctly 1`] = `
     </RCTScrollView>
     <View
       style={
-        Array [
-          Object {
-            "margin": 20,
-            "marginTop": "auto",
-          },
-        ]
+        Object {
+          "margin": 20,
+          "marginTop": "auto",
+        }
       }
     >
       <View>
@@ -234,23 +220,19 @@ exports[`CredentialOfferAccept Screen transitions to offer accepted 1`] = `
   >
     <RCTScrollView
       style={
-        Array [
-          Object {
-            "backgroundColor": "#000000",
-            "height": "100%",
-            "padding": 20,
-          },
-        ]
+        Object {
+          "backgroundColor": "#000000",
+          "height": "100%",
+          "padding": 20,
+        }
       }
     >
       <View>
         <View
           style={
-            Array [
-              Object {
-                "alignItems": "center",
-              },
-            ]
+            Object {
+              "alignItems": "center",
+            }
           }
         >
           <Text
@@ -288,11 +270,9 @@ exports[`CredentialOfferAccept Screen transitions to offer accepted 1`] = `
         >
           <View
             style={
-              Array [
-                Object {
-                  "flexDirection": "column",
-                },
-              ]
+              Object {
+                "flexDirection": "column",
+              }
             }
           >
             <View
@@ -314,13 +294,11 @@ exports[`CredentialOfferAccept Screen transitions to offer accepted 1`] = `
               <
                 height={110}
                 style={
-                  Array [
-                    Object {
-                      "backgroundColor": "transparent",
-                      "marginTop": -30,
-                      "position": "absolute",
-                    },
-                  ]
+                  Object {
+                    "backgroundColor": "transparent",
+                    "marginTop": -30,
+                    "position": "absolute",
+                  }
                 }
                 width={110}
               />
@@ -340,13 +318,11 @@ exports[`CredentialOfferAccept Screen transitions to offer accepted 1`] = `
                 <
                   height={110}
                   style={
-                    Array [
-                      Object {
-                        "backgroundColor": "transparent",
-                        "marginLeft": 10,
-                        "position": "absolute",
-                      },
-                    ]
+                    Object {
+                      "backgroundColor": "transparent",
+                      "marginLeft": 10,
+                      "position": "absolute",
+                    }
                   }
                   width={110}
                 />
@@ -354,11 +330,9 @@ exports[`CredentialOfferAccept Screen transitions to offer accepted 1`] = `
               <
                 height={140}
                 style={
-                  Array [
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ]
+                  Object {
+                    "backgroundColor": "transparent",
+                  }
                 }
                 width={140}
               />
@@ -369,12 +343,10 @@ exports[`CredentialOfferAccept Screen transitions to offer accepted 1`] = `
     </RCTScrollView>
     <View
       style={
-        Array [
-          Object {
-            "margin": 20,
-            "marginTop": "auto",
-          },
-        ]
+        Object {
+          "margin": 20,
+          "marginTop": "auto",
+        }
       }
     >
       <View>
@@ -468,23 +440,19 @@ exports[`CredentialOfferAccept Screen transitions to taking too delay message 1`
   >
     <RCTScrollView
       style={
-        Array [
-          Object {
-            "backgroundColor": "#000000",
-            "height": "100%",
-            "padding": 20,
-          },
-        ]
+        Object {
+          "backgroundColor": "#000000",
+          "height": "100%",
+          "padding": 20,
+        }
       }
     >
       <View>
         <View
           style={
-            Array [
-              Object {
-                "alignItems": "center",
-              },
-            ]
+            Object {
+              "alignItems": "center",
+            }
           }
         >
           <Text
@@ -522,23 +490,19 @@ exports[`CredentialOfferAccept Screen transitions to taking too delay message 1`
         >
           <View
             style={
-              Array [
-                Object {
-                  "flexDirection": "column",
-                },
-              ]
+              Object {
+                "flexDirection": "column",
+              }
             }
           >
             <
               height={110}
               style={
-                Array [
-                  Object {
-                    "backgroundColor": "transparent",
-                    "marginTop": -30,
-                    "position": "absolute",
-                  },
-                ]
+                Object {
+                  "backgroundColor": "transparent",
+                  "marginTop": -30,
+                  "position": "absolute",
+                }
               }
               width={110}
             />
@@ -558,13 +522,11 @@ exports[`CredentialOfferAccept Screen transitions to taking too delay message 1`
               <
                 height={110}
                 style={
-                  Array [
-                    Object {
-                      "backgroundColor": "transparent",
-                      "marginLeft": 10,
-                      "position": "absolute",
-                    },
-                  ]
+                  Object {
+                    "backgroundColor": "transparent",
+                    "marginLeft": 10,
+                    "position": "absolute",
+                  }
                 }
                 width={110}
               />
@@ -572,11 +534,9 @@ exports[`CredentialOfferAccept Screen transitions to taking too delay message 1`
             <
               height={140}
               style={
-                Array [
-                  Object {
-                    "backgroundColor": "transparent",
-                  },
-                ]
+                Object {
+                  "backgroundColor": "transparent",
+                }
               }
               width={140}
             />
@@ -604,12 +564,10 @@ exports[`CredentialOfferAccept Screen transitions to taking too delay message 1`
     </RCTScrollView>
     <View
       style={
-        Array [
-          Object {
-            "margin": 20,
-            "marginTop": "auto",
-          },
-        ]
+        Object {
+          "margin": 20,
+          "marginTop": "auto",
+        }
       }
     >
       <View>

--- a/packages/legacy/core/__tests__/screens/__snapshots__/DataRetention.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/DataRetention.test.tsx.snap
@@ -3,12 +3,10 @@
 exports[`DataRetention Screen screen renders correctly 1`] = `
 <RNCSafeAreaView
   style={
-    Array [
-      Object {
-        "backgroundColor": "#000000",
-        "width": "100%",
-      },
-    ]
+    Object {
+      "backgroundColor": "#000000",
+      "width": "100%",
+    }
   }
 >
   <View
@@ -29,13 +27,11 @@ exports[`DataRetention Screen screen renders correctly 1`] = `
   >
     <Text
       style={
-        Array [
-          Object {
-            "color": "#FFFFFF",
-            "fontSize": 20,
-            "fontWeight": "bold",
-          },
-        ]
+        Object {
+          "color": "#FFFFFF",
+          "fontSize": 20,
+          "fontWeight": "bold",
+        }
       }
     >
       Global.On
@@ -166,13 +162,11 @@ exports[`DataRetention Screen screen renders correctly 1`] = `
   >
     <View
       style={
-        Array [
-          Object {
-            "borderBottomColor": "#000000",
-            "borderBottomWidth": 1,
-            "marginHorizontal": 25,
-          },
-        ]
+        Object {
+          "borderBottomColor": "#000000",
+          "borderBottomWidth": 1,
+          "marginHorizontal": 25,
+        }
       }
     />
   </View>
@@ -194,13 +188,11 @@ exports[`DataRetention Screen screen renders correctly 1`] = `
   >
     <Text
       style={
-        Array [
-          Object {
-            "color": "#FFFFFF",
-            "fontSize": 20,
-            "fontWeight": "bold",
-          },
-        ]
+        Object {
+          "color": "#FFFFFF",
+          "fontSize": 20,
+          "fontWeight": "bold",
+        }
       }
     >
       Global.Off

--- a/packages/legacy/core/__tests__/screens/__snapshots__/Home.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/Home.test.tsx.snap
@@ -129,14 +129,12 @@ exports[`Home Screen renders correctly 1`] = `
         >
           <View
             style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                  "marginHorizontal": 25,
-                  "marginTop": 35,
-                },
-              ]
+              Object {
+                "alignItems": "center",
+                "justifyContent": "center",
+                "marginHorizontal": 25,
+                "marginTop": 35,
+              }
             }
           >
             <Text
@@ -160,14 +158,12 @@ exports[`Home Screen renders correctly 1`] = `
           </View>
           <View
             style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                  "marginHorizontal": 25,
-                  "marginTop": 35,
-                },
-              ]
+              Object {
+                "alignItems": "center",
+                "justifyContent": "center",
+                "marginHorizontal": 25,
+                "marginTop": 35,
+              }
             }
           >
             <Text

--- a/packages/legacy/core/__tests__/screens/__snapshots__/Onboarding.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/Onboarding.test.tsx.snap
@@ -55,11 +55,7 @@ exports[`Onboarding Screen Onboarding Developer mode 1`] = `
               testID="com.ariesbifold:id/DeveloperModeTouch"
             >
               <Text
-                style={
-                  Array [
-                    Object {},
-                  ]
-                }
+                style={Object {}}
                 testID="com.ariesbifold:id/HeaderText"
               >
                 test
@@ -103,11 +99,9 @@ exports[`Onboarding Screen Onboarding Developer mode 1`] = `
     showsHorizontalScrollIndicator={false}
     stickyHeaderIndices={Array []}
     style={
-      Array [
-        Object {
-          "width": 750,
-        },
-      ]
+      Object {
+        "width": 750,
+      }
     }
     viewabilityConfig={
       Object {
@@ -201,11 +195,7 @@ exports[`Onboarding Screen Onboarding Developer mode 1`] = `
                   onResponderTerminate={[Function]}
                   onResponderTerminationRequest={[Function]}
                   onStartShouldSetResponder={[Function]}
-                  style={
-                    Array [
-                      Object {},
-                    ]
-                  }
+                  style={Object {}}
                   testID="com.ariesbifold:id/DeveloperModeTouch"
                 >
                   test
@@ -469,11 +459,9 @@ exports[`Onboarding Screen Renders correctly 1`] = `
     showsHorizontalScrollIndicator={false}
     stickyHeaderIndices={Array []}
     style={
-      Array [
-        Object {
-          "width": 750,
-        },
-      ]
+      Object {
+        "width": 750,
+      }
     }
     viewabilityConfig={
       Object {

--- a/packages/legacy/core/__tests__/screens/__snapshots__/Preface.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/Preface.test.tsx.snap
@@ -47,13 +47,11 @@ exports[`Preface Screen Button enabled by checkbox being checked 1`] = `
           />
           <Text
             style={
-              Array [
-                Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 32,
-                  "fontWeight": "bold",
-                },
-              ]
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 32,
+                "fontWeight": "bold",
+              }
             }
           >
             Preface.PrimaryHeading
@@ -177,11 +175,9 @@ exports[`Preface Screen Button enabled by checkbox being checked 1`] = `
           </View>
           <View
             style={
-              Array [
-                Object {
-                  "paddingTop": 10,
-                },
-              ]
+              Object {
+                "paddingTop": 10,
+              }
             }
           >
             <View
@@ -307,13 +303,11 @@ exports[`Preface Screen Renders correctly 1`] = `
           />
           <Text
             style={
-              Array [
-                Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 32,
-                  "fontWeight": "bold",
-                },
-              ]
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 32,
+                "fontWeight": "bold",
+              }
             }
           >
             Preface.PrimaryHeading
@@ -437,11 +431,9 @@ exports[`Preface Screen Renders correctly 1`] = `
           </View>
           <View
             style={
-              Array [
-                Object {
-                  "paddingTop": 10,
-                },
-              ]
+              Object {
+                "paddingTop": 10,
+              }
             }
           >
             <View

--- a/packages/legacy/core/__tests__/screens/__snapshots__/PushNotification.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/PushNotification.test.tsx.snap
@@ -59,13 +59,11 @@ exports[`PushNotification Screen Push notification screen renders correctly in s
         </Text>
         <Text
           style={
-            Array [
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 18,
-                "fontWeight": "normal",
-              },
-            ]
+            Object {
+              "color": "#FFFFFF",
+              "fontSize": 18,
+              "fontWeight": "normal",
+            }
           }
         >
           PushNotifications.BeNotified

--- a/packages/legacy/core/__tests__/screens/__snapshots__/Scan.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/Scan.test.tsx.snap
@@ -3,15 +3,13 @@
 exports[`Scan Screen Renders correctly 1`] = `
 <RNCSafeAreaView
   style={
-    Array [
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "#000000",
-        "flexDirection": "column",
-        "justifyContent": "center",
-        "minHeight": 1334,
-      },
-    ]
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#000000",
+      "flexDirection": "column",
+      "justifyContent": "center",
+      "minHeight": 1334,
+    }
   }
 >
   <View

--- a/packages/legacy/core/__tests__/screens/__snapshots__/Settings.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/Settings.test.tsx.snap
@@ -184,11 +184,9 @@ exports[`Settings Screen Renders correctly 1`] = `
         <View>
           <View
             style={
-              Array [
-                Object {
-                  "marginBottom": 10,
-                },
-              ]
+              Object {
+                "marginBottom": 10,
+              }
             }
           />
           <RCTScrollView
@@ -290,13 +288,11 @@ exports[`Settings Screen Renders correctly 1`] = `
           >
             <View
               style={
-                Array [
-                  Object {
-                    "borderBottomColor": "#000000",
-                    "borderBottomWidth": 1,
-                    "marginHorizontal": 25,
-                  },
-                ]
+                Object {
+                  "borderBottomColor": "#000000",
+                  "borderBottomWidth": 1,
+                  "marginHorizontal": 25,
+                }
               }
             />
           </View>
@@ -400,11 +396,9 @@ exports[`Settings Screen Renders correctly 1`] = `
           </RCTScrollView>
           <View
             style={
-              Array [
-                Object {
-                  "marginBottom": 10,
-                },
-              ]
+              Object {
+                "marginBottom": 10,
+              }
             }
           />
         </View>
@@ -490,11 +484,9 @@ exports[`Settings Screen Renders correctly 1`] = `
         <View>
           <View
             style={
-              Array [
-                Object {
-                  "marginBottom": 10,
-                },
-              ]
+              Object {
+                "marginBottom": 10,
+              }
             }
           />
           <RCTScrollView
@@ -598,13 +590,11 @@ exports[`Settings Screen Renders correctly 1`] = `
           >
             <View
               style={
-                Array [
-                  Object {
-                    "borderBottomColor": "#000000",
-                    "borderBottomWidth": 1,
-                    "marginHorizontal": 25,
-                  },
-                ]
+                Object {
+                  "borderBottomColor": "#000000",
+                  "borderBottomWidth": 1,
+                  "marginHorizontal": 25,
+                }
               }
             />
           </View>
@@ -715,13 +705,11 @@ exports[`Settings Screen Renders correctly 1`] = `
           >
             <View
               style={
-                Array [
-                  Object {
-                    "borderBottomColor": "#000000",
-                    "borderBottomWidth": 1,
-                    "marginHorizontal": 25,
-                  },
-                ]
+                Object {
+                  "borderBottomColor": "#000000",
+                  "borderBottomWidth": 1,
+                  "marginHorizontal": 25,
+                }
               }
             />
           </View>
@@ -834,13 +822,11 @@ exports[`Settings Screen Renders correctly 1`] = `
           >
             <View
               style={
-                Array [
-                  Object {
-                    "borderBottomColor": "#000000",
-                    "borderBottomWidth": 1,
-                    "marginHorizontal": 25,
-                  },
-                ]
+                Object {
+                  "borderBottomColor": "#000000",
+                  "borderBottomWidth": 1,
+                  "marginHorizontal": 25,
+                }
               }
             />
           </View>
@@ -944,11 +930,9 @@ exports[`Settings Screen Renders correctly 1`] = `
           </RCTScrollView>
           <View
             style={
-              Array [
-                Object {
-                  "marginBottom": 10,
-                },
-              ]
+              Object {
+                "marginBottom": 10,
+              }
             }
           />
         </View>

--- a/packages/legacy/core/__tests__/screens/__snapshots__/Terms.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/Terms.test.tsx.snap
@@ -12,12 +12,10 @@ exports[`Terms Screen Button enabled by checkbox being checked 1`] = `
 >
   <RCTScrollView
     style={
-      Array [
-        Object {
-          "backgroundColor": "#000000",
-          "padding": 20,
-        },
-      ]
+      Object {
+        "backgroundColor": "#000000",
+        "padding": 20,
+      }
     }
   >
     <View>
@@ -126,23 +124,19 @@ exports[`Terms Screen Button enabled by checkbox being checked 1`] = `
       </Text>
       <View
         style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "flexDirection": "row",
-            },
-          ]
+          Object {
+            "backgroundColor": "#000000",
+            "flexDirection": "row",
+          }
         }
       >
         <View
           style={
-            Array [
-              Object {
-                "backgroundColor": "#FCBA19",
-                "marginRight": 10,
-                "width": 8,
-              },
-            ]
+            Object {
+              "backgroundColor": "#FCBA19",
+              "marginRight": 10,
+              "width": 8,
+            }
           }
         />
         <Text
@@ -183,12 +177,10 @@ exports[`Terms Screen Button enabled by checkbox being checked 1`] = `
       </Text>
       <View
         style={
-          Array [
-            Object {
-              "marginBottom": 20,
-              "marginTop": "auto",
-            },
-          ]
+          Object {
+            "marginBottom": 20,
+            "marginTop": "auto",
+          }
         }
       >
         <View
@@ -287,11 +279,9 @@ exports[`Terms Screen Button enabled by checkbox being checked 1`] = `
         </View>
         <View
           style={
-            Array [
-              Object {
-                "paddingTop": 10,
-              },
-            ]
+            Object {
+              "paddingTop": 10,
+            }
           }
         >
           <View
@@ -370,12 +360,10 @@ exports[`Terms Screen Button enabled by checkbox being checked 1`] = `
         </View>
         <View
           style={
-            Array [
-              Object {
-                "marginBottom": 20,
-                "paddingTop": 10,
-              },
-            ]
+            Object {
+              "marginBottom": 20,
+              "paddingTop": 10,
+            }
           }
         >
           <View
@@ -466,12 +454,10 @@ exports[`Terms Screen Renders correctly 1`] = `
 >
   <RCTScrollView
     style={
-      Array [
-        Object {
-          "backgroundColor": "#000000",
-          "padding": 20,
-        },
-      ]
+      Object {
+        "backgroundColor": "#000000",
+        "padding": 20,
+      }
     }
   >
     <View>
@@ -580,23 +566,19 @@ exports[`Terms Screen Renders correctly 1`] = `
       </Text>
       <View
         style={
-          Array [
-            Object {
-              "backgroundColor": "#000000",
-              "flexDirection": "row",
-            },
-          ]
+          Object {
+            "backgroundColor": "#000000",
+            "flexDirection": "row",
+          }
         }
       >
         <View
           style={
-            Array [
-              Object {
-                "backgroundColor": "#FCBA19",
-                "marginRight": 10,
-                "width": 8,
-              },
-            ]
+            Object {
+              "backgroundColor": "#FCBA19",
+              "marginRight": 10,
+              "width": 8,
+            }
           }
         />
         <Text
@@ -637,12 +619,10 @@ exports[`Terms Screen Renders correctly 1`] = `
       </Text>
       <View
         style={
-          Array [
-            Object {
-              "marginBottom": 20,
-              "marginTop": "auto",
-            },
-          ]
+          Object {
+            "marginBottom": 20,
+            "marginTop": "auto",
+          }
         }
       >
         <View
@@ -741,11 +721,9 @@ exports[`Terms Screen Renders correctly 1`] = `
         </View>
         <View
           style={
-            Array [
-              Object {
-                "paddingTop": 10,
-              },
-            ]
+            Object {
+              "paddingTop": 10,
+            }
           }
         >
           <View
@@ -824,12 +802,10 @@ exports[`Terms Screen Renders correctly 1`] = `
         </View>
         <View
           style={
-            Array [
-              Object {
-                "marginBottom": 20,
-                "paddingTop": 10,
-              },
-            ]
+            Object {
+              "marginBottom": 20,
+              "paddingTop": 10,
+            }
           }
         >
           <View

--- a/packages/legacy/core/__tests__/screens/__snapshots__/UseBiometry.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/UseBiometry.test.tsx.snap
@@ -29,26 +29,22 @@ exports[`UseBiometry Screen Renders correctly when biometry available 1`] = `
       >
         <
           style={
-            Array [
-              Object {
-                "marginBottom": 66,
-                "minHeight": 200,
-                "minWidth": 200,
-              },
-            ]
+            Object {
+              "marginBottom": 66,
+              "minHeight": 200,
+              "minWidth": 200,
+            }
           }
         />
       </View>
       <View>
         <Text
           style={
-            Array [
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 18,
-                "fontWeight": "normal",
-              },
-            ]
+            Object {
+              "color": "#FFFFFF",
+              "fontSize": 18,
+              "fontWeight": "normal",
+            }
           }
         >
           Biometry.EnabledText1
@@ -56,25 +52,21 @@ exports[`UseBiometry Screen Renders correctly when biometry available 1`] = `
         <Text />
         <Text
           style={
-            Array [
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 18,
-                "fontWeight": "normal",
-              },
-            ]
+            Object {
+              "color": "#FFFFFF",
+              "fontSize": 18,
+              "fontWeight": "normal",
+            }
           }
         >
           Biometry.EnabledText2
           <Text
             style={
-              Array [
-                Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
-                },
-              ]
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 18,
+                "fontWeight": "bold",
+              }
             }
           >
              
@@ -101,13 +93,11 @@ exports[`UseBiometry Screen Renders correctly when biometry available 1`] = `
         >
           <Text
             style={
-              Array [
-                Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
-                },
-              ]
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 18,
+                "fontWeight": "bold",
+              }
             }
           >
             Biometry.UseToUnlock
@@ -302,26 +292,22 @@ exports[`UseBiometry Screen Renders correctly when biometry not available 1`] = 
       >
         <
           style={
-            Array [
-              Object {
-                "marginBottom": 66,
-                "minHeight": 200,
-                "minWidth": 200,
-              },
-            ]
+            Object {
+              "marginBottom": 66,
+              "minHeight": 200,
+              "minWidth": 200,
+            }
           }
         />
       </View>
       <View>
         <Text
           style={
-            Array [
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 18,
-                "fontWeight": "normal",
-              },
-            ]
+            Object {
+              "color": "#FFFFFF",
+              "fontSize": 18,
+              "fontWeight": "normal",
+            }
           }
         >
           Biometry.NotEnabledText1
@@ -329,13 +315,11 @@ exports[`UseBiometry Screen Renders correctly when biometry not available 1`] = 
         <Text />
         <Text
           style={
-            Array [
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 18,
-                "fontWeight": "normal",
-              },
-            ]
+            Object {
+              "color": "#FFFFFF",
+              "fontSize": 18,
+              "fontWeight": "normal",
+            }
           }
         >
           Biometry.NotEnabledText2
@@ -360,13 +344,11 @@ exports[`UseBiometry Screen Renders correctly when biometry not available 1`] = 
         >
           <Text
             style={
-              Array [
-                Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
-                },
-              ]
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 18,
+                "fontWeight": "bold",
+              }
             }
           >
             Biometry.UseToUnlock
@@ -561,26 +543,22 @@ exports[`UseBiometry Screen Toggles use biometrics ok 1`] = `
       >
         <
           style={
-            Array [
-              Object {
-                "marginBottom": 66,
-                "minHeight": 200,
-                "minWidth": 200,
-              },
-            ]
+            Object {
+              "marginBottom": 66,
+              "minHeight": 200,
+              "minWidth": 200,
+            }
           }
         />
       </View>
       <View>
         <Text
           style={
-            Array [
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 18,
-                "fontWeight": "normal",
-              },
-            ]
+            Object {
+              "color": "#FFFFFF",
+              "fontSize": 18,
+              "fontWeight": "normal",
+            }
           }
         >
           Biometry.EnabledText1
@@ -588,25 +566,21 @@ exports[`UseBiometry Screen Toggles use biometrics ok 1`] = `
         <Text />
         <Text
           style={
-            Array [
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 18,
-                "fontWeight": "normal",
-              },
-            ]
+            Object {
+              "color": "#FFFFFF",
+              "fontSize": 18,
+              "fontWeight": "normal",
+            }
           }
         >
           Biometry.EnabledText2
           <Text
             style={
-              Array [
-                Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
-                },
-              ]
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 18,
+                "fontWeight": "bold",
+              }
             }
           >
              
@@ -633,13 +607,11 @@ exports[`UseBiometry Screen Toggles use biometrics ok 1`] = `
         >
           <Text
             style={
-              Array [
-                Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
-                },
-              ]
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 18,
+                "fontWeight": "bold",
+              }
             }
           >
             Biometry.UseToUnlock

--- a/packages/legacy/core/__tests__/screens/__snapshots__/W3cProofRequest.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/W3cProofRequest.test.tsx.snap
@@ -58,13 +58,11 @@ exports[`displays a proof request screen ProofRequest Screen, W3C displays a pro
                   >
                     <Text
                       style={
-                        Array [
-                          Object {
-                            "color": "#FFFFFF",
-                            "fontSize": 20,
-                            "fontWeight": "bold",
-                          },
-                        ]
+                        Object {
+                          "color": "#FFFFFF",
+                          "fontSize": 20,
+                          "fontWeight": "bold",
+                        }
                       }
                     >
                       ContactDetails.AContact
@@ -75,13 +73,11 @@ exports[`displays a proof request screen ProofRequest Screen, W3C displays a pro
                     </Text>
                     <Text
                       style={
-                        Array [
-                          Object {
-                            "color": "#FFFFFF",
-                            "fontSize": 20,
-                            "fontWeight": "bold",
-                          },
-                        ]
+                        Object {
+                          "color": "#FFFFFF",
+                          "fontSize": 20,
+                          "fontWeight": "bold",
+                        }
                       }
                     >
                        2 
@@ -244,13 +240,11 @@ exports[`displays a proof request screen ProofRequest Screen, W3C displays a pro
                   >
                     <Text
                       style={
-                        Array [
-                          Object {
-                            "color": "#FFFFFF",
-                            "fontSize": 20,
-                            "fontWeight": "bold",
-                          },
-                        ]
+                        Object {
+                          "color": "#FFFFFF",
+                          "fontSize": 20,
+                          "fontWeight": "bold",
+                        }
                       }
                     >
                       ContactDetails.AContact
@@ -261,13 +255,11 @@ exports[`displays a proof request screen ProofRequest Screen, W3C displays a pro
                     </Text>
                     <Text
                       style={
-                        Array [
-                          Object {
-                            "color": "#FFFFFF",
-                            "fontSize": 20,
-                            "fontWeight": "bold",
-                          },
-                        ]
+                        Object {
+                          "color": "#FFFFFF",
+                          "fontSize": 20,
+                          "fontWeight": "bold",
+                        }
                       }
                     >
                        2 
@@ -766,17 +758,15 @@ exports[`displays a proof request screen ProofRequest Screen, W3C displays a pro
                             >
                               <View
                                 style={
-                                  Array [
-                                    Object {
-                                      "alignItems": "center",
-                                      "backgroundColor": "rgba(0, 0, 0, 0)",
-                                      "borderBottomLeftRadius": 10,
-                                      "borderTopRightRadius": 10,
-                                      "height": 90,
-                                      "justifyContent": "center",
-                                      "width": 90,
-                                    },
-                                  ]
+                                  Object {
+                                    "alignItems": "center",
+                                    "backgroundColor": "rgba(0, 0, 0, 0)",
+                                    "borderBottomLeftRadius": 10,
+                                    "borderTopRightRadius": 10,
+                                    "height": 90,
+                                    "justifyContent": "center",
+                                    "width": 90,
+                                  }
                                 }
                               />
                             </View>
@@ -1150,11 +1140,9 @@ exports[`displays a proof request screen ProofRequest Screen, W3C displays a pro
                                         "color": undefined,
                                         "fontSize": 30,
                                       },
-                                      Array [
-                                        Object {
-                                          "color": "#D8292F",
-                                        },
-                                      ],
+                                      Object {
+                                        "color": "#D8292F",
+                                      },
                                       Object {
                                         "fontFamily": "Material Icons",
                                         "fontStyle": "normal",
@@ -1169,13 +1157,11 @@ exports[`displays a proof request screen ProofRequest Screen, W3C displays a pro
                                 <Text
                                   numberOfLines={1}
                                   style={
-                                    Array [
-                                      Object {
-                                        "color": "#D8292F",
-                                        "fontSize": 18,
-                                        "fontWeight": "normal",
-                                      },
-                                    ]
+                                    Object {
+                                      "color": "#D8292F",
+                                      "fontSize": 18,
+                                      "fontWeight": "normal",
+                                    }
                                   }
                                   testID="com.ariesbifold:id/RevokedOrNotAvailable"
                                 >
@@ -1336,17 +1322,15 @@ exports[`displays a proof request screen ProofRequest Screen, W3C displays a pro
                             >
                               <View
                                 style={
-                                  Array [
-                                    Object {
-                                      "alignItems": "center",
-                                      "backgroundColor": "rgba(0, 0, 0, 0)",
-                                      "borderBottomLeftRadius": 10,
-                                      "borderTopRightRadius": 10,
-                                      "height": 90,
-                                      "justifyContent": "center",
-                                      "width": 90,
-                                    },
-                                  ]
+                                  Object {
+                                    "alignItems": "center",
+                                    "backgroundColor": "rgba(0, 0, 0, 0)",
+                                    "borderBottomLeftRadius": 10,
+                                    "borderTopRightRadius": 10,
+                                    "height": 90,
+                                    "justifyContent": "center",
+                                    "width": 90,
+                                  }
                                 }
                               />
                             </View>


### PR DESCRIPTION
# Summary of Changes

Wrapping single style objects in an array causes unnecessary array flattening and re-renders, as un-memoized arrays are always treated as new props. This PR is an easy win to prevent extra re-renders and speed things up, however slightly.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
