### PR TITLE
fix: manage agent state

### DIFF
--- a/packages/legacy/core/App/contexts/auth.tsx
+++ b/packages/legacy/core/App/contexts/auth.tsx
@@ -66,6 +66,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     if (!secret) {
       return
     }
+
     setWalletSecret(secret)
 
     return secret

--- a/packages/legacy/core/App/navigators/RootStack.tsx
+++ b/packages/legacy/core/App/navigators/RootStack.tsx
@@ -35,7 +35,6 @@ import ProofRequestStack from './ProofRequestStack'
 import SettingStack from './SettingStack'
 import TabStack from './TabStack'
 import { useDefaultStackOptions } from './defaultStackOptions'
-import { use } from 'i18next'
 
 const RootStack: React.FC = () => {
   const [state, dispatch] = useStore()

--- a/packages/legacy/core/App/navigators/RootStack.tsx
+++ b/packages/legacy/core/App/navigators/RootStack.tsx
@@ -161,19 +161,19 @@ const RootStack: React.FC = () => {
       return
     }
 
-    agent?.mediationRecipient
+    agent.mediationRecipient
       .stopMessagePickup()
       .then(() => {
-        logger.info('Stopping agent message pickup')
+        logger.info('Stopped agent message pickup')
       })
       .catch((err) => {
         logger.error(`Error stopping agent message pickup, ${err}`)
       })
 
-    agent?.wallet
+    agent.wallet
       .close()
       .then(() => {
-        logger.info('Closing agent wallet')
+        logger.info('Closed agent wallet')
       })
       .catch((err) => {
         logger.error(`Error closing agent wallet, ${err}`)

--- a/packages/legacy/core/App/screens/Splash.tsx
+++ b/packages/legacy/core/App/screens/Splash.tsx
@@ -230,6 +230,8 @@ const Splash: React.FC = () => {
           return
         }
 
+        await (ocaBundleResolver as RemoteOCABundleResolver).checkForUpdates?.()
+
         if (agent) {
           logger.info('Agent already initialized, restarting...')
 
@@ -255,8 +257,6 @@ const Splash: React.FC = () => {
         }
 
         logger.info('No agent initialized, creating a new one')
-
-        await (ocaBundleResolver as RemoteOCABundleResolver).checkForUpdates?.()
 
         const newAgent = new Agent({
           config: {

--- a/packages/legacy/core/App/screens/Splash.tsx
+++ b/packages/legacy/core/App/screens/Splash.tsx
@@ -241,7 +241,14 @@ const Splash: React.FC = () => {
               key: walletSecret.key,
             })
           } catch (error: unknown) {
-            logger.error('Error opening existing wallet', error as Error)
+            logger.error('Error opening existing wallet', error as BifoldError)
+
+            throw new BifoldError(
+              'Wallet Service',
+              'There was a problem unlocking the wallet.',
+              (error as Error).message,
+              1047
+            )
           }
 
           await agent.mediationRecipient.initiateMessagePickup()

--- a/packages/legacy/core/App/screens/Splash.tsx
+++ b/packages/legacy/core/App/screens/Splash.tsx
@@ -87,7 +87,7 @@ const resumeOnboardingAt = (
  * of this view.
  */
 const Splash: React.FC = () => {
-  const { setAgent } = useAgent()
+  const { agent, setAgent } = useAgent()
   const { t } = useTranslation()
   const [store, dispatch] = useStore()
   const navigation = useNavigation()
@@ -96,24 +96,24 @@ const Splash: React.FC = () => {
   const { LoadingIndicator } = useAnimatedComponents()
   const [mounted, setMounted] = useState(false)
   const [
-    cacheSchemas, 
-    cacheCredDefs, 
-    { version: TermsVersion }, 
-    logger, 
-    indyLedgers, 
-    { showPreface, enablePushNotifications }, 
+    cacheSchemas,
+    cacheCredDefs,
+    { version: TermsVersion },
+    logger,
+    indyLedgers,
+    { showPreface, enablePushNotifications },
     ocaBundleResolver,
     historyEnabled,
-  ] = useServices(
-    [TOKENS.CACHE_SCHEMAS, 
-    TOKENS.CACHE_CRED_DEFS, 
-    TOKENS.SCREEN_TERMS, 
-    TOKENS.UTIL_LOGGER, 
-    TOKENS.UTIL_LEDGERS, 
-    TOKENS.CONFIG, 
-    TOKENS.UTIL_OCA_RESOLVER, 
-    TOKENS.HISTORY_ENABLED]
-  )
+  ] = useServices([
+    TOKENS.CACHE_SCHEMAS,
+    TOKENS.CACHE_CRED_DEFS,
+    TOKENS.SCREEN_TERMS,
+    TOKENS.UTIL_LOGGER,
+    TOKENS.UTIL_LEDGERS,
+    TOKENS.CONFIG,
+    TOKENS.UTIL_OCA_RESOLVER,
+    TOKENS.HISTORY_ENABLED,
+  ])
   const styles = StyleSheet.create({
     container: {
       flex: 1,
@@ -230,6 +230,32 @@ const Splash: React.FC = () => {
           return
         }
 
+        if (agent) {
+          logger.info('Agent already initialized, restarting...')
+
+          try {
+            await agent.wallet.open({
+              id: walletSecret.id,
+              key: walletSecret.key,
+            })
+          } catch (error: unknown) {
+            logger.error('Error opening existing wallet', error as Error)
+          }
+
+          await agent.mediationRecipient.initiateMessagePickup()
+
+          navigation.dispatch(
+            CommonActions.reset({
+              index: 0,
+              routes: [{ name: Stacks.TabStack }],
+            })
+          )
+
+          return
+        }
+
+        logger.info('No agent initialized, creating a new one')
+
         await (ocaBundleResolver as RemoteOCABundleResolver).checkForUpdates?.()
 
         const newAgent = new Agent({
@@ -310,7 +336,7 @@ const Splash: React.FC = () => {
     initAgent()
   }, [mounted, store.authentication.didAuthenticate, store.onboarding.didConsiderBiometry, walletSecret])
 
-  useEffect(()=>{
+  useEffect(() => {
     if (!mounted || !historyEnabled) {
       return
     }
@@ -318,7 +344,7 @@ const Splash: React.FC = () => {
       type: DispatchAction.HISTORY_CAPABILITY,
       payload: [true],
     })
-  },[mounted, historyEnabled])
+  }, [mounted, historyEnabled])
 
   return (
     <SafeAreaView style={styles.container}>

--- a/packages/legacy/core/App/screens/Splash.tsx
+++ b/packages/legacy/core/App/screens/Splash.tsx
@@ -240,6 +240,8 @@ const Splash: React.FC = () => {
               id: walletSecret.id,
               key: walletSecret.key,
             })
+
+            logger.info('Opened agent wallet')
           } catch (error: unknown) {
             logger.error('Error opening existing wallet', error as BifoldError)
 


### PR DESCRIPTION
# Summary of Changes

Shutting down and re-creating the agent in the Splash team is heavy handed and unnecessary. It may also be causing an inconsitent state in the Credo Agent resulting it it not picking up messages. This PR changes the logic so that when the app is backgrounded it stops message pickup and closes the wallet. Then, when the application is once again brought into the foreground it just needs to unlock the wallet and resume message pickup. This speeds up subsequent restarts and allows for faster initialization.

# Related Issues

Please reference here any issue #'s that are relevant to this PR, or simply enter "N/A" if this PR does not relate to any existing issues.

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
