### PR TITLE
feat: added ability to disable data retention

### DIFF
--- a/packages/legacy/core/App/screens/Settings.tsx
+++ b/packages/legacy/core/App/screens/Settings.tsx
@@ -234,16 +234,17 @@ const Settings: React.FC<SettingsProps> = ({ navigation }) => {
         },
       ],
     })
-
-    const section = settingsSections.find((item) => item.header.title === t('Settings.AppSettings'))
-    if (section) {
-      section.data.splice(3, 0, {
-        title: t('Settings.DataRetention'),
-        value: store.preferences.useDataRetention ? t('Global.On') : t('Global.Off'),
-        accessibilityLabel: t('Settings.DataRetention'),
-        testID: testIdWithKey('DataRetention'),
-        onPress: () => navigation.navigate(Screens.DataRetention),
-      })
+    if (!store.preferences.disableDataRetentionOption) {
+      const section = settingsSections.find((item) => item.header.title === t('Settings.AppSettings'))
+      if (section) {
+        section.data.splice(3, 0, {
+          title: t('Settings.DataRetention'),
+          value: store.preferences.useDataRetention ? t('Global.On') : t('Global.Off'),
+          accessibilityLabel: t('Settings.DataRetention'),
+          testID: testIdWithKey('DataRetention'),
+          onPress: () => navigation.navigate(Screens.DataRetention),
+        })
+      }
     }
   }
 

--- a/packages/legacy/core/App/types/state.ts
+++ b/packages/legacy/core/App/types/state.ts
@@ -28,6 +28,7 @@ export interface Preferences {
   walletName: string
   acceptDevCredentials: boolean
   useDataRetention: boolean
+  disableDataRetentionOption?: boolean
   preventAutoLock: boolean
   enableShareableLink: boolean
   alternateContactNames: Record<string, string>


### PR DESCRIPTION
# Summary of Changes

Previously there was no way of disabling the proof request history option (data retention) option in the settings screen.

# Related Issues

Please reference here any issue #'s that are relevant to this PR, or simply enter "N/A" if this PR does not relate to any existing issues.

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
