### PR TITLE
fix: import UseBiometry Screen in SettingsStack from container

### DIFF
--- a/packages/legacy/core/App/navigators/SettingStack.tsx
+++ b/packages/legacy/core/App/navigators/SettingStack.tsx
@@ -15,7 +15,6 @@ import PINCreate from '../screens/PINCreate'
 import PushNotification from '../screens/PushNotification'
 import Settings from '../screens/Settings'
 import Tours from '../screens/Tours'
-import UseBiometry from '../screens/UseBiometry'
 import { Screens, SettingStackParams } from '../types/navigators'
 import { testIdWithKey } from '../utils/testable'
 
@@ -27,7 +26,12 @@ const SettingStack: React.FC = () => {
   const theme = useTheme()
   const [biometryUpdatePending, setBiometryUpdatePending] = useState<boolean>(false)
   const { t } = useTranslation()
-  const [pages, { screen: terms }, developer] = useServices([TOKENS.SCREEN_ONBOARDING_PAGES, TOKENS.SCREEN_TERMS, TOKENS.SCREEN_DEVELOPER])
+  const [pages, { screen: terms }, UseBiometry, developer] = useServices([
+    TOKENS.SCREEN_ONBOARDING_PAGES,
+    TOKENS.SCREEN_TERMS,
+    TOKENS.SCREEN_USE_BIOMETRY,
+    TOKENS.SCREEN_DEVELOPER,
+  ])
   const defaultStackOptions = useDefaultStackOptions(theme)
   const OnboardingTheme = theme.OnboardingTheme
   const carousel = createCarouselStyle(OnboardingTheme)


### PR DESCRIPTION
# Summary of Changes

The UseBiometry Screen should come from the useServices function and not be imported like this: `import UseBiometry from '../screens/UseBiometry'`

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
