### PR TITLE
chore: expose navigators stacks

### DIFF
--- a/packages/legacy/core/App/index.ts
+++ b/packages/legacy/core/App/index.ts
@@ -28,12 +28,12 @@ import { homeTourSteps } from './components/tour/HomeTourSteps'
 import { proofRequestTourSteps } from './components/tour/ProofRequestTourSteps'
 import { TourBox } from './components/tour/TourBox'
 import HomeFooterView from './components/views/HomeFooterView'
+import NotificationListItem from './components/listItems/NotificationListItem'
 import * as contexts from './contexts'
 import { AuthProvider } from './contexts/auth'
 import { NetworkProvider } from './contexts/network'
 import { useTour } from './contexts/tour/tour-context'
 import { TourProvider } from './contexts/tour/tour-provider'
-import RootStack from './navigators/RootStack'
 import AttemptLockout from './screens/AttemptLockout'
 import Developer from './screens/Developer'
 import OnboardingPages from './screens/OnboardingPages'
@@ -45,15 +45,16 @@ import { loadLoginAttempt } from './services/keychain'
 import * as types from './types'
 import Scan from './screens/Scan'
 import Onboarding from './screens/Onboarding'
-import { PINRules } from './constants'
-import NotificationListItem from './components/listItems/NotificationListItem'
+import { PINRules, walletTimeout } from './constants'
 
+export * from './navigators'
 export * from './services/storage'
 export * from './types/attestation'
 export { LocalStorageKeys } from './constants'
 export { initLanguages, initStoredLanguage, translationResources, Locales } from './localization'
 export { defaultState, mergeReducers, StoreProvider, StoreContext, useStore } from './contexts/store'
 export { default as Store, DispatchAction, reducer } from './contexts/reducers/store'
+export { useDeepLinks } from './hooks/deep-links'
 export { Assets as ImageAssets } from './theme'
 export { ThemeProvider, useTheme } from './contexts/theme'
 export { AnimatedComponentsProvider, useAnimatedComponents } from './contexts/animated-components'
@@ -70,7 +71,7 @@ export { BifoldError } from './types/error'
 export { EventTypes } from './constants'
 export { didMigrateToAskar, migrateToAskar } from './utils/migration'
 export { createLinkSecretIfRequired, getAgentModules } from './utils/agent'
-export { removeExistingInvitationIfRequired } from './utils/helpers'
+export { removeExistingInvitationIfRequired, connectFromScanOrDeepLink } from './utils/helpers'
 
 export type { AnimatedComponents } from './animated-components'
 export type {
@@ -132,7 +133,6 @@ export {
   Link,
   ToastType,
   toastConfig,
-  RootStack,
   NetInfo,
   OnboardingPages,
   NotificationListItem,
@@ -154,5 +154,6 @@ export {
   Button,
   BulletPoint,
   PINRules,
+  walletTimeout,
 }
 export type { IButton }

--- a/packages/legacy/core/App/navigators/index.ts
+++ b/packages/legacy/core/App/navigators/index.ts
@@ -1,0 +1,27 @@
+import ConnectStack from './ConnectStack'
+import ContactStack from './ContactStack'
+import CredentialStack from './CredentialStack'
+import DeliveryStack from './DeliveryStack'
+import HomeStack from './HomeStack'
+import NotificationStack from './NotificationStack'
+import OnboardingStack from './OnboardingStack'
+import ProofRequestStack from './ProofRequestStack'
+import RootStack from './RootStack'
+import SettingStack from './SettingStack'
+import TabStack from './TabStack'
+import { useDefaultStackOptions } from './defaultStackOptions'
+
+export {
+  ConnectStack,
+  ContactStack,
+  CredentialStack,
+  DeliveryStack,
+  HomeStack,
+  NotificationStack,
+  OnboardingStack,
+  ProofRequestStack,
+  RootStack,
+  SettingStack,
+  TabStack,
+  useDefaultStackOptions,
+}


### PR DESCRIPTION
# Summary of Changes

This PR exposes all navigators stacks. It will allow other wallets to fully customize the navigation, by using the available stacks and/or adding their own navigation stacks.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
