### PR TITLE
fix: blank proof notification and double splash nav

### DIFF
--- a/packages/legacy/core/App/components/listItems/NotificationListItem.tsx
+++ b/packages/legacy/core/App/components/listItems/NotificationListItem.tsx
@@ -4,6 +4,7 @@ import {
   BasicMessageRecord,
   BasicMessageRepository,
   CredentialExchangeRecord,
+  CredoError,
   ProofExchangeRecord,
   ProofState,
 } from '@credo-ts/core'
@@ -255,23 +256,28 @@ const NotificationListItem: React.FC<NotificationListItemProps> = ({
           break
         case NotificationType.ProofRequest: {
           const proofId = (notification as ProofExchangeRecord).id
-          agent?.proofs.findRequestMessage(proofId).then((message) => {
-            if (message instanceof V1RequestPresentationMessage && message.indyProofRequest) {
-              details = {
-                type: InfoBoxType.Info,
-                title: t('ProofRequest.NewProofRequest'),
-                body: message.indyProofRequest.name ?? message.comment ?? '',
-                buttonTitle: undefined,
-              }
-            } else {
-              details = {
-                type: InfoBoxType.Info,
-                title: t('ProofRequest.NewProofRequest'),
-                body: '',
-                buttonTitle: undefined,
-              }
+          let message
+          try {
+            message = await agent?.proofs.findRequestMessage(proofId)
+          } catch (error) {
+            agent?.config.logger.error('Error finding request message:', error as CredoError)
+          }
+
+          if (message instanceof V1RequestPresentationMessage && message.indyProofRequest) {
+            details = {
+              type: InfoBoxType.Info,
+              title: t('ProofRequest.NewProofRequest'),
+              body: message.indyProofRequest.name ?? message.comment ?? '',
+              buttonTitle: undefined,
             }
-          })
+          } else {
+            details = {
+              type: InfoBoxType.Info,
+              title: t('ProofRequest.NewProofRequest'),
+              body: '',
+              buttonTitle: undefined,
+            }
+          }
           break
         }
         case NotificationType.Revocation:

--- a/packages/legacy/core/App/components/listItems/NotificationListItem.tsx
+++ b/packages/legacy/core/App/components/listItems/NotificationListItem.tsx
@@ -385,7 +385,7 @@ const NotificationListItem: React.FC<NotificationListItemProps> = ({
     }
     setAction(() => onPress)
     setCloseAction(() => onClose)
-  }, [navigation, notification, notificationType, toggleDeclineModalVisible, dismissBasicMessage])
+  }, [navigation, notification, notificationType, logger, toggleDeclineModalVisible, dismissBasicMessage])
 
   useEffect(() => {
     switch (details.type) {

--- a/packages/legacy/core/App/components/listItems/NotificationListItem.tsx
+++ b/packages/legacy/core/App/components/listItems/NotificationListItem.tsx
@@ -18,6 +18,7 @@ import { DeviceEventEmitter, StyleSheet, Text, TextStyle, TouchableOpacity, View
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
 import { EventTypes, hitSlop } from '../../constants'
+import { TOKENS, useServices } from '../../container-api'
 import { useStore } from '../../contexts/store'
 import { useTheme } from '../../contexts/theme'
 import { BifoldError } from '../../types/error'
@@ -90,6 +91,7 @@ const NotificationListItem: React.FC<NotificationListItemProps> = ({
   const [declineModalVisible, setDeclineModalVisible] = useState(false)
   const [action, setAction] = useState<any>()
   const [closeAction, setCloseAction] = useState<any>()
+  const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const connectionId =
     notification instanceof BasicMessageRecord ||
     notification instanceof CredentialExchangeRecord ||
@@ -260,7 +262,7 @@ const NotificationListItem: React.FC<NotificationListItemProps> = ({
           try {
             message = await agent?.proofs.findRequestMessage(proofId)
           } catch (error) {
-            agent?.config.logger.error('Error finding request message:', error as CredoError)
+            logger.error('Error finding request message:', error as CredoError)
           }
 
           if (message instanceof V1RequestPresentationMessage && message.indyProofRequest) {

--- a/packages/legacy/core/App/screens/Splash.tsx
+++ b/packages/legacy/core/App/screens/Splash.tsx
@@ -4,7 +4,7 @@ import { useAgent } from '@credo-ts/react-hooks'
 import { agentDependencies } from '@credo-ts/react-native'
 import { GetCredentialDefinitionRequest, GetSchemaRequest } from '@hyperledger/indy-vdr-shared'
 import { useNavigation, CommonActions } from '@react-navigation/native'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { DeviceEventEmitter, StyleSheet } from 'react-native'
 import { Config } from 'react-native-config'
@@ -97,6 +97,7 @@ const Splash: React.FC = () => {
   const { ColorPallet } = useTheme()
   const { LoadingIndicator } = useAnimatedComponents()
   const [mounted, setMounted] = useState(false)
+  const initializing = useRef(false)
   const [
     cacheSchemas,
     cacheCredDefs,
@@ -260,6 +261,7 @@ const Splash: React.FC = () => {
       try {
         if (
           !mounted ||
+          initializing.current ||
           !store.authentication.didAuthenticate ||
           !store.onboarding.didConsiderBiometry ||
           !walletSecret?.id ||
@@ -267,6 +269,7 @@ const Splash: React.FC = () => {
         ) {
           return
         }
+        initializing.current = true
 
         await (ocaBundleResolver as RemoteOCABundleResolver).checkForUpdates?.()
 


### PR DESCRIPTION
# Summary of Changes

This PR adds two small fixes. One to prevent blank notifications for proof requests on the home screen, and one to prevent a duplicate navigation from the splash screen.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [ ] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
