### PR TITLE
chore: update flakey firewall check

### DIFF
--- a/packages/legacy/core/App/components/network/NetInfo.tsx
+++ b/packages/legacy/core/App/components/network/NetInfo.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import Toast from 'react-native-toast-message'
-
 import { useNetwork } from '../../contexts/network'
 
 const NetInfo: React.FC = () => {
@@ -21,7 +20,7 @@ const NetInfo: React.FC = () => {
         Toast.show({
           type: 'warn',
           autoHide: false,
-          text1: t('NetInfo.LedgerConnectivityIssueMessage'),
+          text1: t('NetInfo.NoInternetConnectionMessage'),
         })
       })
 

--- a/packages/legacy/core/App/contexts/network.tsx
+++ b/packages/legacy/core/App/contexts/network.tsx
@@ -3,8 +3,8 @@ import * as React from 'react'
 import { createContext, useContext, useState } from 'react'
 
 import NetInfoModal from '../components/modals/NetInfoModal'
-import { fetchLedgerNodes, canConnectToLedgerNode } from '../utils/ledger'
-
+import { hostnameFromURL, canConnectToHost } from '../utils/network'
+import { Config } from 'react-native-config'
 export interface NetworkContext {
   silentAssertConnectedNetwork: () => boolean
   assertConnectedNetwork: () => boolean
@@ -41,13 +41,15 @@ export const NetworkProvider: React.FC<React.PropsWithChildren> = ({ children })
   }
 
   const assertLedgerConnectivity = async (): Promise<boolean> => {
-    const nodes = fetchLedgerNodes()
+    const hostname = hostnameFromURL(Config.MEDIATOR_URL!)
 
-    if (typeof nodes === 'undefined' || nodes.length === 0) {
+    if (hostname === null || hostname.length === 0) {
       return false
     }
 
-    const connections = await Promise.all(nodes.map((n: { host: string; port: number }) => canConnectToLedgerNode(n)))
+    const nodes = [{ host: hostname, port: 443 }]
+    const connections = await Promise.all(nodes.map((n: { host: string; port: number }) => canConnectToHost(n)))
+
     return connections.includes(true)
   }
 

--- a/packages/legacy/core/App/localization/en/index.ts
+++ b/packages/legacy/core/App/localization/en/index.ts
@@ -771,8 +771,6 @@ const translation = {
   "NetInfo": {
     "NoInternetConnectionTitle": "No internet connection",
     "NoInternetConnectionMessage": "You're unable to access services using Bifold or receive credentials until you're back online.\n\nPlease check your internet connection.",
-    "LedgerConnectivityIssueTitle": "Wallet Services",
-    "LedgerConnectivityIssueMessage": "A firewall may be preventing you from connecting to wallet related services.",
   },
   "Onboarding": {
     "SkipA11y": "Skip introduction to Aries Bifold",

--- a/packages/legacy/core/App/localization/fr/index.ts
+++ b/packages/legacy/core/App/localization/fr/index.ts
@@ -748,8 +748,6 @@ const translation = {
     "NetInfo": {
         "NoInternetConnectionTitle": "Aucune connexion Internet",
         "NoInternetConnectionMessage": "Vous ne pouvez pas accéder aux services à l'aide de Bifold ou recevoir des informations d'identification tant que vous n'êtes pas de nouveau en ligne.\n\nS'il vous plait, vérifiez votre connexion internet.",
-        "LedgerConnectivityIssueTitle": "Services de portefeuille",
-        "LedgerConnectivityIssueMessage": "Il se peut qu'un pare-feu vous empêche de vous connecter aux services liés au portefeuille.",
     },
     "Onboarding": {
         "SkipA11y": "Passer l'introduction à Aries Bifold",

--- a/packages/legacy/core/App/localization/pt-br/index.ts
+++ b/packages/legacy/core/App/localization/pt-br/index.ts
@@ -731,8 +731,6 @@ const translation = {
   "NetInfo": {
     "NoInternetConnectionTitle": "Sem conexão com a internet",
     "NoInternetConnectionMessage": "Não é possivel acessar serviços utilizando a Bifold ou receber credenciais até você voltar a estar online.\n\nFavor checkar sua conexão com a internet.",
-    "LedgerConnectivityIssueTitle": "Serviços de Carteira",
-    "LedgerConnectivityIssueMessage": "Um firewall pode estar te impedindo de conectar-se a serviços relacionados a carteira.",
   },
   "Onboarding": {
     "SkipA11y": "Pular introdução a Aries Bifold",

--- a/packages/legacy/core/App/utils/helpers.ts
+++ b/packages/legacy/core/App/utils/helpers.ts
@@ -1010,12 +1010,12 @@ export const connectFromScanOrDeepLink = async (
     if (isOpenIDInvitation) {
       navigation.navigate(Stacks.ConnectionStack as any, {
         screen: Screens.Connection,
-        params: { oobRecordId: "", openIDUri: uri },
+        params: { oobRecordId: '', openIDUri: uri },
       })
 
       return
     }
-    
+
     const aUrl = processBetaUrlIfRequired(uri)
     const receivedInvitation = await connectFromInvitation(aUrl, agent, implicitInvitations, reuseConnection)
 
@@ -1170,5 +1170,6 @@ export function generateRandomWalletName() {
   for (let i = 0; i < 4; i++) {
     name = name.concat(Math.floor(Math.random() * 10).toString())
   }
+
   return name
 }

--- a/packages/legacy/core/App/utils/network.tsx
+++ b/packages/legacy/core/App/utils/network.tsx
@@ -3,10 +3,10 @@ import TcpSocket from 'react-native-tcp-socket'
 import pools from '../configs/ledgers/indy'
 import { GenesisTransaction } from '../types/genesis'
 
-export const canConnectToLedgerNode = async (node: { host: string; port: number }): Promise<boolean> =>
+export const canConnectToHost = async (host: { host: string; port: number }): Promise<boolean> =>
   new Promise((resolve) => {
     const socketTimeoutInMs = 3000
-    const client = TcpSocket.createConnection(node, () => {
+    const client = TcpSocket.createConnection(host, () => {
       resolve(true)
       client.destroy()
     })
@@ -52,4 +52,28 @@ export const fetchLedgerNodes = (indyNamespace = 'sovrin'): Array<{ host: string
   })
 
   return nodes
+}
+
+export const hostnameFromURL = (fullUrl: string): string | null => {
+  try {
+    // Start of the hostname after "//"
+    let startIndex = fullUrl.indexOf('//') + 2
+
+    // End of the hostname (before the next '/' or '?')
+    let endIndex = fullUrl.indexOf('/', startIndex)
+
+    // If no '/', look for '?'
+    if (endIndex === -1) {
+      endIndex = fullUrl.indexOf('?', startIndex)
+    }
+
+    // If no '/' or '?', hostname is till the end
+    if (endIndex === -1) {
+      endIndex = fullUrl.length
+    }
+
+    return fullUrl.substring(startIndex, endIndex)
+  } catch (error) {
+    return null
+  }
 }

--- a/packages/legacy/core/App/utils/network.tsx
+++ b/packages/legacy/core/App/utils/network.tsx
@@ -57,7 +57,7 @@ export const fetchLedgerNodes = (indyNamespace = 'sovrin'): Array<{ host: string
 export const hostnameFromURL = (fullUrl: string): string | null => {
   try {
     // Start of the hostname after "//"
-    let startIndex = fullUrl.indexOf('//') + 2
+    const startIndex = fullUrl.indexOf('//') + 2
 
     // End of the hostname (before the next '/' or '?')
     let endIndex = fullUrl.indexOf('/', startIndex)

--- a/packages/legacy/core/__tests__/ledger.test.ts
+++ b/packages/legacy/core/__tests__/ledger.test.ts
@@ -1,4 +1,4 @@
-import { canConnectToLedgerNode, fetchLedgerNodes } from '../App/utils/ledger'
+import { canConnectToLedgerNode, fetchLedgerNodes } from '../App/utils/network'
 
 jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter')
 jest.mock('../App/configs/ledgers/indy')

--- a/packages/legacy/core/__tests__/ledger.test.ts
+++ b/packages/legacy/core/__tests__/ledger.test.ts
@@ -1,4 +1,4 @@
-import { canConnectToLedgerNode, fetchLedgerNodes } from '../App/utils/network'
+import { canConnectToHost, fetchLedgerNodes } from '../App/utils/network'
 
 jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter')
 jest.mock('../App/configs/ledgers/indy')
@@ -27,19 +27,19 @@ describe('Ledger utility', () => {
   })
 
   test('An available host returns "true"', async () => {
-    const result = await canConnectToLedgerNode({ host: '192.168.100.1', port: ports.connect })
+    const result = await canConnectToHost({ host: '192.168.100.1', port: ports.connect })
 
     expect(result).toBe(true)
   })
 
   test('An un-available host returns "false"', async () => {
-    const result = await canConnectToLedgerNode({ host: '192.168.100.1', port: ports.timeout })
+    const result = await canConnectToHost({ host: '192.168.100.1', port: ports.timeout })
 
     expect(result).toBe(false)
   })
 
   test('An bad host returns "false"', async () => {
-    const result = await canConnectToLedgerNode({ host: '192.168.100.1', port: ports.error })
+    const result = await canConnectToHost({ host: '192.168.100.1', port: ports.error })
 
     expect(result).toBe(false)
   })


### PR DESCRIPTION
# Summary of Changes

The firewall check if flakey at best because of it drawing on the genesis transactions which may or may not (most likely not) represent existing nodes. Because its so hit and miss we elected just check the mediator for network connectivity. If this fails a toast is shown indicating such. If it works, nothing is displayed.

A future enhancement would be to get a connect node list form IndyVDR and test a sample of them.

# Related Issues

n/a

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
