### PR TITLE
feat: add injectable stack nav, re-add theming

### DIFF
--- a/packages/legacy/core/App/components/inputs/PINInput.tsx
+++ b/packages/legacy/core/App/components/inputs/PINInput.tsx
@@ -50,6 +50,7 @@ const PINInputComponent = (
       paddingVertical: 4,
       justifyContent: 'flex-start',
       alignItems: 'center',
+      ...PINInputTheme.cell,
     },
     codeFieldContainer: {
       flex: 1,
@@ -57,6 +58,7 @@ const PINInputComponent = (
     cell: {
       height: cellHeight,
       paddingHorizontal: 2,
+      backgroundColor: PINInputTheme.cell.backgroundColor,
     },
     cellText: {
       ...TextTheme.headingThree,

--- a/packages/legacy/core/App/container-api.ts
+++ b/packages/legacy/core/App/container-api.ts
@@ -46,6 +46,10 @@ export const SCREEN_TOKENS = {
   SCREEN_USE_BIOMETRY: 'screen.use-biometry',
 } as const
 
+export const NAV_TOKENS = {
+  CUSTOM_NAV_STACK_1: 'nav.slot1',
+} as const
+
 export const COMPONENT_TOKENS = {
   COMPONENT_HOME_HEADER: 'component.home.header',
   COMPONENT_HOME_NOTIFICATIONS_EMPTY_LIST: 'component.home.notifications-empty-list',
@@ -113,6 +117,7 @@ export const TOKENS = {
   ...PROOF_TOKENS,
   ...COMPONENT_TOKENS,
   ...SCREEN_TOKENS,
+  ...NAV_TOKENS,
   ...SERVICE_TOKENS,
   ...STACK_TOKENS,
   ...NOTIFICATION_TOKENS,
@@ -172,6 +177,7 @@ export type TokenMapping = {
   [TOKENS.COMPONENT_HOME_FOOTER]: React.FC
   [TOKENS.COMPONENT_CRED_EMPTY_LIST]: React.FC
   [TOKENS.COMPONENT_RECORD]: React.FC
+  [TOKENS.CUSTOM_NAV_STACK_1]: React.FC
 }
 
 export interface Container {

--- a/packages/legacy/core/App/container-impl.ts
+++ b/packages/legacy/core/App/container-impl.ts
@@ -127,6 +127,7 @@ export class MainContainer implements Container {
     this._container.registerInstance(TOKENS.FN_LOAD_HISTORY, (agent: Agent<any>): IHistoryManager => {
       return new HistoryManager(agent)
     })
+    this._container.registerInstance(TOKENS.CUSTOM_NAV_STACK_1, false)
     this._container.registerInstance(TOKENS.LOAD_STATE, async (dispatch: React.Dispatch<ReducerAction<unknown>>) => {
       const loadState = async <Type>(key: LocalStorageKeys, updateVal: (newVal: Type) => void) => {
         const data = await this.storage.getValueForKey(key)

--- a/packages/legacy/core/App/index.ts
+++ b/packages/legacy/core/App/index.ts
@@ -45,6 +45,7 @@ import { loadLoginAttempt } from './services/keychain'
 import * as types from './types'
 import Scan from './screens/Scan'
 import Onboarding from './screens/Onboarding'
+import { useDefaultStackOptions } from './navigators/defaultStackOptions'
 import { PINRules, walletTimeout } from './constants'
 import { CredentialListFooterProps } from './types/credential-list-footer'
 
@@ -140,6 +141,7 @@ export {
   NetInfo,
   OnboardingPages,
   NotificationListItem,
+  useDefaultStackOptions,
   Splash,
   Developer,
   Terms,

--- a/packages/legacy/core/App/navigators/RootStack.tsx
+++ b/packages/legacy/core/App/navigators/RootStack.tsx
@@ -49,8 +49,8 @@ const RootStack: React.FC = () => {
   const navigation = useNavigation<StackNavigationProp<AuthenticateStackParams>>()
   const theme = useTheme()
   const defaultStackOptions = useDefaultStackOptions(theme)
-  const [splash, { enableImplicitInvitations, enableReuseConnections }, logger, OnboardingStack, loadState] =
-    useServices([TOKENS.SCREEN_SPLASH, TOKENS.CONFIG, TOKENS.UTIL_LOGGER, TOKENS.STACK_ONBOARDING, TOKENS.LOAD_STATE])
+  const [splash, { enableImplicitInvitations, enableReuseConnections }, logger, OnboardingStack, CustomNavStack1, loadState] =
+    useServices([TOKENS.SCREEN_SPLASH, TOKENS.CONFIG, TOKENS.UTIL_LOGGER, TOKENS.STACK_ONBOARDING, TOKENS.CUSTOM_NAV_STACK_1, TOKENS.LOAD_STATE])
 
   useDeepLinks()
 
@@ -98,8 +98,8 @@ const RootStack: React.FC = () => {
       .then(() => {
         dispatch({ type: DispatchAction.STATE_LOADED })
       })
-      .catch((err) => {
-        const error = new BifoldError(t('Error.Title1044'), t('Error.Message1044'), err.message, 1001)
+      .catch((err: unknown) => {
+        const error = new BifoldError(t('Error.Title1044'), t('Error.Message1044'), (err as Error).message, 1001)
         DeviceEventEmitter.emit(EventTypes.ERROR_ADDED, error)
       })
   }, [dispatch, loadState, t])
@@ -311,6 +311,9 @@ const RootStack: React.FC = () => {
             cardStyleInterpolator: forFade,
           }}
         />
+        {CustomNavStack1 ? (
+          <Stack.Screen name={Stacks.CustomNavStack1} component={CustomNavStack1} />
+        ) : null}
       </Stack.Navigator>
     )
   }

--- a/packages/legacy/core/App/types/navigators.ts
+++ b/packages/legacy/core/App/types/navigators.ts
@@ -59,6 +59,7 @@ export enum Stacks {
   NotificationStack = 'Notifications Stack',
   ConnectionStack = 'Connection Stack',
   HistoryStack = 'History Stack',
+  CustomNavStack1 = 'Custom Nav Stack 1',
 }
 
 export enum TabStacks {
@@ -77,6 +78,7 @@ export type RootStackParams = {
   [Stacks.ProofRequestsStack]: NavigatorScreenParams<ProofRequestsStackParams>
   [Stacks.NotificationStack]: NavigatorScreenParams<NotificationStackParams>
   [Stacks.HistoryStack]: NavigatorScreenParams<HistoryStackParams>
+  [Stacks.CustomNavStack1]: undefined
 }
 
 export type TabStackParams = {

--- a/packages/legacy/core/__tests__/screens/__snapshots__/PINEnter.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/PINEnter.test.tsx.snap
@@ -106,7 +106,10 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                     Array [
                       Object {
                         "alignItems": "center",
+                        "backgroundColor": "#313132",
+                        "borderColor": "#FFFFFFFF",
                         "borderRadius": 5,
+                        "borderWidth": 1,
                         "flexDirection": "row",
                         "justifyContent": "flex-start",
                         "paddingHorizontal": 12,
@@ -135,7 +138,10 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                           },
                           Object {
                             "alignItems": "center",
+                            "backgroundColor": "#313132",
+                            "borderColor": "#FFFFFFFF",
                             "borderRadius": 5,
+                            "borderWidth": 1,
                             "flexDirection": "row",
                             "justifyContent": "flex-start",
                             "paddingHorizontal": 12,
@@ -148,6 +154,7 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                         onLayout={[Function]}
                         style={
                           Object {
+                            "backgroundColor": "#313132",
                             "height": 48,
                             "paddingHorizontal": 2,
                           }
@@ -170,6 +177,7 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                         onLayout={[Function]}
                         style={
                           Object {
+                            "backgroundColor": "#313132",
                             "height": 48,
                             "paddingHorizontal": 2,
                           }
@@ -192,6 +200,7 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                         onLayout={[Function]}
                         style={
                           Object {
+                            "backgroundColor": "#313132",
                             "height": 48,
                             "paddingHorizontal": 2,
                           }
@@ -214,6 +223,7 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                         onLayout={[Function]}
                         style={
                           Object {
+                            "backgroundColor": "#313132",
                             "height": 48,
                             "paddingHorizontal": 2,
                           }
@@ -236,6 +246,7 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                         onLayout={[Function]}
                         style={
                           Object {
+                            "backgroundColor": "#313132",
                             "height": 48,
                             "paddingHorizontal": 2,
                           }
@@ -258,6 +269,7 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                         onLayout={[Function]}
                         style={
                           Object {
+                            "backgroundColor": "#313132",
                             "height": 48,
                             "paddingHorizontal": 2,
                           }
@@ -585,7 +597,10 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                     Array [
                       Object {
                         "alignItems": "center",
+                        "backgroundColor": "#313132",
+                        "borderColor": "#FFFFFFFF",
                         "borderRadius": 5,
+                        "borderWidth": 1,
                         "flexDirection": "row",
                         "justifyContent": "flex-start",
                         "paddingHorizontal": 12,
@@ -614,7 +629,10 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                           },
                           Object {
                             "alignItems": "center",
+                            "backgroundColor": "#313132",
+                            "borderColor": "#FFFFFFFF",
                             "borderRadius": 5,
+                            "borderWidth": 1,
                             "flexDirection": "row",
                             "justifyContent": "flex-start",
                             "paddingHorizontal": 12,
@@ -627,6 +645,7 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                         onLayout={[Function]}
                         style={
                           Object {
+                            "backgroundColor": "#313132",
                             "height": 48,
                             "paddingHorizontal": 2,
                           }
@@ -649,6 +668,7 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                         onLayout={[Function]}
                         style={
                           Object {
+                            "backgroundColor": "#313132",
                             "height": 48,
                             "paddingHorizontal": 2,
                           }
@@ -671,6 +691,7 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                         onLayout={[Function]}
                         style={
                           Object {
+                            "backgroundColor": "#313132",
                             "height": 48,
                             "paddingHorizontal": 2,
                           }
@@ -693,6 +714,7 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                         onLayout={[Function]}
                         style={
                           Object {
+                            "backgroundColor": "#313132",
                             "height": 48,
                             "paddingHorizontal": 2,
                           }
@@ -715,6 +737,7 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                         onLayout={[Function]}
                         style={
                           Object {
+                            "backgroundColor": "#313132",
                             "height": 48,
                             "paddingHorizontal": 2,
                           }
@@ -737,6 +760,7 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                         onLayout={[Function]}
                         style={
                           Object {
+                            "backgroundColor": "#313132",
                             "height": 48,
                             "paddingHorizontal": 2,
                           }


### PR DESCRIPTION
# Summary of Changes

This PR allows Bifold wallets to extend the RootStack with an optional custom stack navigator slot. It also reverts a recent change that remove theming from the PINInput.

# Related Issues
N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
