### PR TITLE
feat: add inline error messages for pin enter screen

### DIFF
--- a/packages/legacy/core/App/components/buttons/ToggleButton.tsx
+++ b/packages/legacy/core/App/components/buttons/ToggleButton.tsx
@@ -35,7 +35,7 @@ const ToggleButton: React.FC<ToggleButtonProps> = ({
 
   const backgroundColor = toggleAnim.interpolate({
     inputRange: [0, 1],
-    outputRange: [ColorPallet.grayscale.lightGrey, ColorPallet.brand.primaryDisabled],
+    outputRange: [ColorPallet.grayscale.lightGrey, ColorPallet.brand.primary],
   })
 
   const translateX = toggleAnim.interpolate({

--- a/packages/legacy/core/App/components/inputs/PINInput.tsx
+++ b/packages/legacy/core/App/components/inputs/PINInput.tsx
@@ -51,6 +51,7 @@ const PINInputComponent = (
       justifyContent: 'flex-start',
       alignItems: 'center',
       ...PINInputTheme.cell,
+      borderColor: PINInputTheme.cell.backgroundColor
     },
     codeFieldContainer: {
       flex: 1,

--- a/packages/legacy/core/App/localization/en/index.ts
+++ b/packages/legacy/core/App/localization/en/index.ts
@@ -243,6 +243,8 @@ const translation = {
     "Or": "Or",
     "BiometricsUnlock": "Unlock with biometrics",
     "IncorrectPIN": "Incorrect PIN",
+    "IncorrectPINTries": "Incorrect PIN: {{tries}} tries before timeout",
+    "LastTryBeforeTimeout": "Incorrect PIN: Last try before timeout",
     "RepeatPIN": "Please try your PIN again.",
     "EnableBiometrics": "You have to enable biometrics to be able to load the wallet.",
     "BiometricsNotProvided": "Biometrics not provided, you may use PIN to load the wallet.",

--- a/packages/legacy/core/App/localization/fr/index.ts
+++ b/packages/legacy/core/App/localization/fr/index.ts
@@ -242,6 +242,8 @@ const translation = {
         "Or": "Ou",
         "BiometricsUnlock": "Déverrouiller avec la biométrie",
         "IncorrectPIN": "NIP erroné",
+        "IncorrectPINTries": "Code PIN incorrect : {{tries}} essaie avant l'expiration du délai",
+        "LastTryBeforeTimeout": "Code PIN incorrect : dernier essai avant expiration du délai",
         "RepeatPIN": "Essayez votre NIP à nouveau",
         "EnableBiometrics": "Vous devez activer la biométrie pour pouvoir charger le portefeuille.",
         "BiometricsNotProvided": "Biométrie non fournie, vous pouvez utiliser le NIP pour vous connecter au portefeuille.",

--- a/packages/legacy/core/App/screens/PINEnter.tsx
+++ b/packages/legacy/core/App/screens/PINEnter.tsx
@@ -259,8 +259,10 @@ const PINEnter: React.FC<PINEnterProps> = ({ setAuthenticated, usage = PINEntryU
           } else if (attemptsLeft === 1) {
             setErrorMessage(t('PINEnter.LastTryBeforeTimeout')) // Show last try warning
           } else {
-            // No more attempts left, navigate to lockout screen directly
-            attemptLockout(getLockoutPenalty(newAttempt))
+            const penalty = getLockoutPenalty(newAttempt)
+            if (penalty !== undefined) {
+              attemptLockout(penalty) // Only call attemptLockout if penalty is defined
+            }
             return
           }
 

--- a/packages/legacy/core/__tests__/components/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/ToggleButton.test.tsx.snap
@@ -132,7 +132,7 @@ exports[`ToggleButton Component renders correctly when enabled 1`] = `
     collapsable={false}
     style={
       Object {
-        "backgroundColor": "rgba(53, 130, 63, 0.349)",
+        "backgroundColor": "rgba(66, 128, 62, 1)",
         "borderRadius": 25,
         "height": 30,
         "justifyContent": "center",

--- a/packages/legacy/core/__tests__/screens/__snapshots__/PINEnter.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/PINEnter.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                   "color": "#FFFFFF",
                   "fontSize": 18,
                   "fontWeight": "bold",
-                  "marginBottom": 20,
+                  "marginBottom": 8,
                 }
               }
             >
@@ -107,7 +107,7 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                       Object {
                         "alignItems": "center",
                         "backgroundColor": "#313132",
-                        "borderColor": "#FFFFFFFF",
+                        "borderColor": "#313132",
                         "borderRadius": 5,
                         "borderWidth": 1,
                         "flexDirection": "row",
@@ -139,7 +139,7 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                           Object {
                             "alignItems": "center",
                             "backgroundColor": "#313132",
-                            "borderColor": "#FFFFFFFF",
+                            "borderColor": "#313132",
                             "borderRadius": 5,
                             "borderWidth": 1,
                             "flexDirection": "row",
@@ -571,7 +571,7 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                   "color": "#FFFFFF",
                   "fontSize": 18,
                   "fontWeight": "bold",
-                  "marginBottom": 20,
+                  "marginBottom": 8,
                 }
               }
             >
@@ -598,7 +598,7 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                       Object {
                         "alignItems": "center",
                         "backgroundColor": "#313132",
-                        "borderColor": "#FFFFFFFF",
+                        "borderColor": "#313132",
                         "borderRadius": 5,
                         "borderWidth": 1,
                         "flexDirection": "row",
@@ -630,7 +630,7 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                           Object {
                             "alignItems": "center",
                             "backgroundColor": "#313132",
-                            "borderColor": "#FFFFFFFF",
+                            "borderColor": "#313132",
                             "borderRadius": 5,
                             "borderWidth": 1,
                             "flexDirection": "row",


### PR DESCRIPTION
# Summary of Changes

- add inline error messages for PINEnter screen
- modify the toggleButton colour use for when its enabled, a quick fix from last PR
- add locale for english and french
- fix the border colour for PINInput component

# Related Issues

Previous PRs for bifold that are linked to it
- https://github.com/openwallet-foundation/bifold-wallet/pull/1286
- https://github.com/openwallet-foundation/bifold-wallet/pull/1281

## Screen recording

https://github.com/user-attachments/assets/4d30711a-6d27-428b-9a42-350cd960e398


# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
