### PR TITLE
fix: make input full width, export a couple components

### DIFF
--- a/packages/legacy/core/App/components/inputs/LimitedTextInput.tsx
+++ b/packages/legacy/core/App/components/inputs/LimitedTextInput.tsx
@@ -16,6 +16,7 @@ const LimitedTextInput: React.FC<Props> = ({ label, limit, handleChangeText, ...
   const styles = StyleSheet.create({
     container: {
       marginVertical: 10,
+      width: '100%',
     },
     label: {
       ...TextTheme.normal,

--- a/packages/legacy/core/App/components/inputs/PINInput.tsx
+++ b/packages/legacy/core/App/components/inputs/PINInput.tsx
@@ -63,47 +63,47 @@ const PINInputComponent = (
     <View style={style.container}>
       {label && <Text style={[TextTheme.label, { marginBottom: 8 }]}>{label}</Text>}
       <View style={PINInputTheme.labelAndFieldContainer}>
-          <View style={style.codeFieldContainer}>
-            <CodeField
-              {...props}
-              testID={testID}
-              accessibilityLabel={accessibilityLabel}
-              accessible
-              value={PIN}
-              rootStyle={PINInputTheme.codeFieldRoot}
-              onChangeText={onChangeText}
-              cellCount={minPINLength}
-              keyboardType="numeric"
-              textContentType="password"
-              renderCell={({ index, symbol, isFocused }) => {
-                let child: React.ReactNode | string = ''
-                if (symbol) {
-                  child = showPIN ? symbol : '●' // Show or hide PIN
-                } else if (isFocused) {
-                  child = <Cursor />
-                }
-                return (
-                  <View key={index} style={style.cell} onLayout={getCellOnLayoutHandler(index)}>
-                    <Text style={style.cellText} maxFontSizeMultiplier={1}>
-                      {child}
-                    </Text>
-                  </View>
-                )
-              }}
-              autoFocus={autoFocus}
-              ref={ref}
-            />
-          </View>
-          <TouchableOpacity
-            style={style.hideIcon}
-            accessibilityLabel={showPIN ? t('PINCreate.Hide') : t('PINCreate.Show')}
-            accessibilityRole={'button'}
-            testID={showPIN ? testIdWithKey('Hide') : testIdWithKey('Show')}
-            onPress={() => setShowPIN(!showPIN)}
-            hitSlop={hitSlop}
-          >
-            <Icon color={PINInputTheme.icon.color} name={showPIN ? 'visibility-off' : 'visibility'} size={30} />
-          </TouchableOpacity>
+        <View style={style.codeFieldContainer}>
+          <CodeField
+            {...props}
+            testID={testID}
+            accessibilityLabel={accessibilityLabel}
+            accessible
+            value={PIN}
+            rootStyle={PINInputTheme.codeFieldRoot}
+            onChangeText={onChangeText}
+            cellCount={minPINLength}
+            keyboardType="numeric"
+            textContentType="password"
+            renderCell={({ index, symbol, isFocused }) => {
+              let child: React.ReactNode | string = ''
+              if (symbol) {
+                child = showPIN ? symbol : '●' // Show or hide PIN
+              } else if (isFocused) {
+                child = <Cursor />
+              }
+              return (
+                <View key={index} style={style.cell} onLayout={getCellOnLayoutHandler(index)}>
+                  <Text style={style.cellText} maxFontSizeMultiplier={1}>
+                    {child}
+                  </Text>
+                </View>
+              )
+            }}
+            autoFocus={autoFocus}
+            ref={ref}
+          />
+        </View>
+        <TouchableOpacity
+          style={style.hideIcon}
+          accessibilityLabel={showPIN ? t('PINCreate.Hide') : t('PINCreate.Show')}
+          accessibilityRole={'button'}
+          testID={showPIN ? testIdWithKey('Hide') : testIdWithKey('Show')}
+          onPress={() => setShowPIN(!showPIN)}
+          hitSlop={hitSlop}
+        >
+          <Icon color={PINInputTheme.icon.color} name={showPIN ? 'visibility-off' : 'visibility'} size={30} />
+        </TouchableOpacity>
       </View>
     </View>
   )

--- a/packages/legacy/core/App/index.ts
+++ b/packages/legacy/core/App/index.ts
@@ -27,7 +27,9 @@ import { credentialsTourSteps } from './components/tour/CredentialsTourSteps'
 import { homeTourSteps } from './components/tour/HomeTourSteps'
 import { proofRequestTourSteps } from './components/tour/ProofRequestTourSteps'
 import { TourBox } from './components/tour/TourBox'
+import LimitedTextInput from './components/inputs/LimitedTextInput'
 import HomeFooterView from './components/views/HomeFooterView'
+import KeyboardView from './components/views/KeyboardView'
 import NotificationListItem from './components/listItems/NotificationListItem'
 import * as contexts from './contexts'
 import { AuthProvider } from './contexts/auth'
@@ -161,6 +163,8 @@ export {
   Text,
   loadLoginAttempt,
   Button,
+  LimitedTextInput,
+  KeyboardView,
   BulletPoint,
   PINRules,
   walletTimeout,


### PR DESCRIPTION
# Summary of Changes

This PR exports `KeyboardView` and `LimitedTextInput` and makes the `LimitedTextInput` full width of it's parent container.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
