### PR TITLE
fix: add check for reusable conn to oob hook

### DIFF
--- a/packages/legacy/core/App/hooks/connections.ts
+++ b/packages/legacy/core/App/hooks/connections.ts
@@ -2,15 +2,6 @@ import { ConnectionRecord, OutOfBandRecord } from '@credo-ts/core'
 import { useAgent, useConnectionById, useConnections } from '@credo-ts/react-hooks'
 import { useMemo, useState } from 'react'
 
-export const useConnectionByOutOfBandId = (outOfBandId: string): ConnectionRecord | undefined => {
-  const { records: connections } = useConnections()
-
-  return useMemo(
-    () => connections.find((connection: ConnectionRecord) => connection.outOfBandId === outOfBandId),
-    [connections, outOfBandId]
-  )
-}
-
 export const useOutOfBandById = (oobId: string): OutOfBandRecord | undefined => {
   const { agent } = useAgent()
   const [oob, setOob] = useState<OutOfBandRecord | undefined>(undefined)
@@ -22,6 +13,20 @@ export const useOutOfBandById = (oobId: string): OutOfBandRecord | undefined => 
     })
   }
   return oob
+}
+
+export const useConnectionByOutOfBandId = (outOfBandId: string): ConnectionRecord | undefined => {
+  const reuseConnectionId = useOutOfBandById(outOfBandId)?.reuseConnectionId
+  const { records: connections } = useConnections()
+
+  return useMemo(
+    () => connections.find((connection: ConnectionRecord) => (
+      connection.outOfBandId === outOfBandId ||
+      // Check for a reusable connection
+      (reuseConnectionId && connection.id === reuseConnectionId)
+    )),
+    [connections, outOfBandId, reuseConnectionId]
+  )
 }
 
 export const useOutOfBandByConnectionId = (connectionId: string): OutOfBandRecord | undefined => {


### PR DESCRIPTION
# Summary of Changes

This PR fixes a bug where if reusable connections were enabled, the wallet would hang on the Connection screen if it encountered a reusable connection. This change does not make reusable connections enabled by default, Bifold users still have to specify `enableReuseConnections: true` in their config.

# Related Issues
N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [ ] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
