### PR TITLE
fix: check proof state before fetch

### DIFF
--- a/packages/legacy/core/App/utils/helpers.ts
+++ b/packages/legacy/core/App/utils/helpers.ts
@@ -693,74 +693,84 @@ export const retrieveCredentialsForProof = async (
   t: TFunction<'translation', undefined>,
   groupByReferent?: boolean
 ) => {
+  // This is the only valid state to retrieve credentials for a proof
+  // `getCredentialsForRequest` will fail otherwise.
+  if (proof.state !== ProofState.RequestReceived) {
+    return
+  }
+
   try {
     const format = await agent.proofs.getFormatData(proof.id)
     const hasPresentationExchange = format.request?.presentationExchange !== undefined
     const hasAnonCreds = format.request?.anoncreds !== undefined
     const hasIndy = format.request?.indy !== undefined
-    const credentialsPromise = agent.proofs.getCredentialsForRequest({
-      proofRecordId: proof.id,
-      proofFormats: {
-        // FIXME: Credo will try to use the format, even if the value is undefined (but the key is present)
-        // We should ignore the key, if the value is undefined. For now this is a workaround.
-        ...(hasIndy
-          ? {
-              indy: {
-                // Setting `filterByNonRevocationRequirements` to `false` returns all
-                // credentials even if they are revokable (and revoked). We need this to
-                // be able to show why a proof cannot be satisfied. Otherwise we can only
-                // show failure.
-                filterByNonRevocationRequirements: true,
-              },
-            }
-          : {}),
-        ...(hasAnonCreds
-          ? {
-              anoncreds: {
-                // Setting `filterByNonRevocationRequirements` to `false` returns all
-                // credentials even if they are revokable (and revoked). We need this to
-                // be able to show why a proof cannot be satisfied. Otherwise we can only
-                // show failure.
-                filterByNonRevocationRequirements: true,
-              },
-            }
-          : {}),
-        ...(hasPresentationExchange ? { presentationExchange: {} } : {}),
-      },
-    })
-    const credentialsWithRevokedPromise = agent.proofs.getCredentialsForRequest({
-      proofRecordId: proof.id,
-      proofFormats: {
-        // FIXME: Credo will try to use the format, even if the value is undefined (but the key is present)
-        // We should ignore the key, if the value is undefined. For now this is a workaround.
-        ...(hasIndy
-          ? {
-              indy: {
-                // Setting `filterByNonRevocationRequirements` to `false` returns all
-                // credentials even if they are revokable (and revoked). We need this to
-                // be able to show why a proof cannot be satisfied. Otherwise we can only
-                // show failure.
-                filterByNonRevocationRequirements: false,
-              },
-            }
-          : {}),
-        ...(hasAnonCreds
-          ? {
-              anoncreds: {
-                // Setting `filterByNonRevocationRequirements` to `false` returns all
-                // credentials even if they are revokable (and revoked). We need this to
-                // be able to show why a proof cannot be satisfied. Otherwise we can only
-                // show failure.
-                filterByNonRevocationRequirements: false,
-              },
-            }
-          : {}),
-        ...(hasPresentationExchange ? { presentationExchange: {} } : {}),
-      },
-    })
-    const [credentials, credentialsWithRevoked] = await Promise.all([credentialsPromise, credentialsWithRevokedPromise])
 
-    // in the case where there are only revoked credentials to satisfy a proof, include them for errors on the proof screen, otherwise leave them out
+    // Will fail if credential not in state 'request-received'
+    const credentials = await agent.proofs.getCredentialsForRequest({
+      proofRecordId: proof.id,
+      proofFormats: {
+        // FIXME: Credo will try to use the format, even if the value is undefined (but the key is present)
+        // We should ignore the key, if the value is undefined. For now this is a workaround.
+        ...(hasIndy
+          ? {
+              indy: {
+                // Setting `filterByNonRevocationRequirements` to `false` returns all
+                // credentials even if they are revokable (and revoked). We need this to
+                // be able to show why a proof cannot be satisfied. Otherwise we can only
+                // show failure.
+                filterByNonRevocationRequirements: true,
+              },
+            }
+          : {}),
+        ...(hasAnonCreds
+          ? {
+              anoncreds: {
+                // Setting `filterByNonRevocationRequirements` to `false` returns all
+                // credentials even if they are revokable (and revoked). We need this to
+                // be able to show why a proof cannot be satisfied. Otherwise we can only
+                // show failure.
+                filterByNonRevocationRequirements: true,
+              },
+            }
+          : {}),
+        ...(hasPresentationExchange ? { presentationExchange: {} } : {}),
+      },
+    })
+
+    // Will fail if credential not in state 'request-received'
+    const credentialsWithRevoked = await agent.proofs.getCredentialsForRequest({
+      proofRecordId: proof.id,
+      proofFormats: {
+        // FIXME: Credo will try to use the format, even if the value is undefined (but the key is present)
+        // We should ignore the key, if the value is undefined. For now this is a workaround.
+        ...(hasIndy
+          ? {
+              indy: {
+                // Setting `filterByNonRevocationRequirements` to `false` returns all
+                // credentials even if they are revokable (and revoked). We need this to
+                // be able to show why a proof cannot be satisfied. Otherwise we can only
+                // show failure.
+                filterByNonRevocationRequirements: false,
+              },
+            }
+          : {}),
+        ...(hasAnonCreds
+          ? {
+              anoncreds: {
+                // Setting `filterByNonRevocationRequirements` to `false` returns all
+                // credentials even if they are revokable (and revoked). We need this to
+                // be able to show why a proof cannot be satisfied. Otherwise we can only
+                // show failure.
+                filterByNonRevocationRequirements: false,
+              },
+            }
+          : {}),
+        ...(hasPresentationExchange ? { presentationExchange: {} } : {}),
+      },
+    })
+
+    // In the case where there are only revoked credentials to satisfy a proof,
+    // include them for errors on the proof screen, otherwise leave them out
     const addRevokedCredsIfNeeded = (proofFormat: 'indy' | 'anoncreds', proofItem: 'attributes' | 'predicates') => {
       if (credentials.proofFormats[proofFormat] && credentialsWithRevoked.proofFormats[proofFormat]) {
         Object.keys(credentials.proofFormats[proofFormat]?.[proofItem] ?? {}).forEach((key) => {

--- a/packages/legacy/core/App/utils/helpers.ts
+++ b/packages/legacy/core/App/utils/helpers.ts
@@ -706,7 +706,7 @@ export const retrieveCredentialsForProof = async (
     const hasIndy = format.request?.indy !== undefined
 
     // Will fail if credential not in state 'request-received'
-    const credentials = await agent.proofs.getCredentialsForRequest({
+    const credentialsAsPromise = agent.proofs.getCredentialsForRequest({
       proofRecordId: proof.id,
       proofFormats: {
         // FIXME: Credo will try to use the format, even if the value is undefined (but the key is present)
@@ -738,7 +738,7 @@ export const retrieveCredentialsForProof = async (
     })
 
     // Will fail if credential not in state 'request-received'
-    const credentialsWithRevoked = await agent.proofs.getCredentialsForRequest({
+    const credentialsWithRevokedAsPromise = agent.proofs.getCredentialsForRequest({
       proofRecordId: proof.id,
       proofFormats: {
         // FIXME: Credo will try to use the format, even if the value is undefined (but the key is present)
@@ -768,6 +768,11 @@ export const retrieveCredentialsForProof = async (
         ...(hasPresentationExchange ? { presentationExchange: {} } : {}),
       },
     })
+
+    const [credentials, credentialsWithRevoked] = await Promise.all([
+      credentialsAsPromise,
+      credentialsWithRevokedAsPromise,
+    ])
 
     // In the case where there are only revoked credentials to satisfy a proof,
     // include them for errors on the proof screen, otherwise leave them out


### PR DESCRIPTION
# Summary of Changes

Confirm the state of the proof before fetching credentials for it.

# Related Issues

n/a

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
