### PR TITLE
feat: add inline errors for pin countdown in pin enter screen

### DIFF
--- a/packages/legacy/core/App/components/inputs/InlineErrorText.tsx
+++ b/packages/legacy/core/App/components/inputs/InlineErrorText.tsx
@@ -33,7 +33,7 @@ const InlineErrorText: React.FC<InlineMessageProps> = ({ message, inlineType, co
       ? InputInlineMessage.inlineWarningText.color
       : InputInlineMessage.inlineErrorText.color
 
-  const props: SvgProps = { height: 16, width: 16, color: color, style: style.icon }
+  const props: SvgProps = { height: 24, width: 24, color: color, style: style.icon }
 
   return (
     <View style={[style.container, config.style]}>

--- a/packages/legacy/core/App/components/inputs/PINInput.tsx
+++ b/packages/legacy/core/App/components/inputs/PINInput.tsx
@@ -60,6 +60,9 @@ const PINInputComponent = (
     hideIcon: {
       paddingHorizontal: 10,
     },
+    inlineMessageContainer: {
+      minHeight: 36,
+    },
   })
   const content = () => (
     <View style={PINInputTheme.labelAndFieldContainer}>
@@ -110,15 +113,13 @@ const PINInputComponent = (
   const inlineMessageView = ({ message, inlineType, config }: InlineMessageProps) => (
     <InlineErrorText message={message} inlineType={inlineType} config={config} />
   )
-  const inlineMessagePlaceholder = (placment: InlineErrorPosition) => {
-    if (inlineMessage && inlineMessage.config.position === placment) {
-      return inlineMessageView(inlineMessage)
-    }
-    //This is a fallback in case no position provided
-    if (inlineMessage && placment === InlineErrorPosition.Above && !inlineMessage.config.position) {
-      return inlineMessageView(inlineMessage)
-    }
-  }
+  const inlineMessagePlaceholder = (placement: InlineErrorPosition) => (
+    <View style={style.inlineMessageContainer}>
+      {inlineMessage && (inlineMessage.config.position === placement || !inlineMessage.config.position)
+        ? inlineMessageView(inlineMessage)
+        : null}
+    </View>
+  )
   return (
     <View style={style.container}>
       {label && <Text style={[TextTheme.label, { marginBottom: 8 }]}>{label}</Text>}

--- a/packages/legacy/core/App/components/inputs/PINInput.tsx
+++ b/packages/legacy/core/App/components/inputs/PINInput.tsx
@@ -113,13 +113,23 @@ const PINInputComponent = (
   const inlineMessageView = ({ message, inlineType, config }: InlineMessageProps) => (
     <InlineErrorText message={message} inlineType={inlineType} config={config} />
   )
-  const inlineMessagePlaceholder = (placement: InlineErrorPosition) => (
-    <View style={style.inlineMessageContainer}>
-      {inlineMessage && (inlineMessage.config.position === placement || !inlineMessage.config.position)
-        ? inlineMessageView(inlineMessage)
-        : null}
-    </View>
-  )
+  const inlineMessagePlaceholder = (placement: InlineErrorPosition) => {
+    // Check if inlineMessage exists and if its position matches the placement or falls back to Above
+    if (!inlineMessage) {
+      return <View style={style.inlineMessageContainer} />
+    }
+  
+    const messagePosition = inlineMessage.config.position || InlineErrorPosition.Above // Default to Above
+    if (messagePosition !== placement) {
+      return <View style={style.inlineMessageContainer} />
+    }
+  
+    return (
+      <View style={style.inlineMessageContainer}>
+        {inlineMessageView(inlineMessage)}
+      </View>
+    )
+  }
   return (
     <View style={style.container}>
       {label && <Text style={[TextTheme.label, { marginBottom: 8 }]}>{label}</Text>}

--- a/packages/legacy/core/App/container-impl.ts
+++ b/packages/legacy/core/App/container-impl.ts
@@ -127,7 +127,7 @@ export class MainContainer implements Container {
     this._container.registerInstance(TOKENS.COMPONENT_CONTACT_DETAILS_CRED_LIST_ITEM, ContactCredentialListItem)
     this._container.registerInstance(TOKENS.CACHE_CRED_DEFS, [])
     this._container.registerInstance(TOKENS.CACHE_SCHEMAS, [])
-    this._container.registerInstance(TOKENS.INLINE_ERRORS, { enabled: false, position: InlineErrorPosition.Above })
+    this._container.registerInstance(TOKENS.INLINE_ERRORS, { enabled: true, position: InlineErrorPosition.Above })
     this._container.registerInstance(
       TOKENS.FN_ONBOARDING_DONE,
       (dispatch: React.Dispatch<ReducerAction<unknown>>, navigation: StackNavigationProp<AuthenticateStackParams>) => {

--- a/packages/legacy/core/App/container-impl.ts
+++ b/packages/legacy/core/App/container-impl.ts
@@ -127,7 +127,7 @@ export class MainContainer implements Container {
     this._container.registerInstance(TOKENS.COMPONENT_CONTACT_DETAILS_CRED_LIST_ITEM, ContactCredentialListItem)
     this._container.registerInstance(TOKENS.CACHE_CRED_DEFS, [])
     this._container.registerInstance(TOKENS.CACHE_SCHEMAS, [])
-    this._container.registerInstance(TOKENS.INLINE_ERRORS, { enabled: true, position: InlineErrorPosition.Above })
+    this._container.registerInstance(TOKENS.INLINE_ERRORS, { enabled: false, position: InlineErrorPosition.Above })
     this._container.registerInstance(
       TOKENS.FN_ONBOARDING_DONE,
       (dispatch: React.Dispatch<ReducerAction<unknown>>, navigation: StackNavigationProp<AuthenticateStackParams>) => {

--- a/packages/legacy/core/App/localization/en/index.ts
+++ b/packages/legacy/core/App/localization/en/index.ts
@@ -256,6 +256,8 @@ const translation = {
     "BiometricsUnlock": "Unlock with biometrics",
     "IncorrectPIN": "Incorrect PIN",
     "RepeatPIN": "Please try your PIN again.",
+    "IncorrectPINTries": "Incorrect PIN: {{tries}} tries before timeout",
+    "LastTryBeforeTimeout": "Incorrect PIN: Last try before timeout",
     "EnableBiometrics": "You have to enable biometrics to be able to load the wallet.",
     "BiometricsNotProvided": "Biometrics not provided, you may use PIN to load the wallet.",
     "BiometricsError": "Biometrics were not successful.",

--- a/packages/legacy/core/App/localization/fr/index.ts
+++ b/packages/legacy/core/App/localization/fr/index.ts
@@ -255,6 +255,8 @@ const translation = {
         "BiometricsUnlock": "Déverrouiller avec la biométrie",
         "IncorrectPIN": "NIP erroné",
         "RepeatPIN": "Essayez votre NIP à nouveau",
+        "IncorrectPINTries": "PIN incorrect : {{tries}} essaie avant l'expiration du délai",
+        "LastTryBeforeTimeout": "PIN incorrect : dernier essai avant expiration du délai",
         "EnableBiometrics": "Vous devez activer la biométrie pour pouvoir charger le portefeuille.",
         "BiometricsNotProvided": "Biométrie non fournie, vous pouvez utiliser le NIP pour vous connecter au portefeuille.",
         "BiometricsError": "La biométrie n'a pas réussi.",

--- a/packages/legacy/core/App/screens/PINEnter.tsx
+++ b/packages/legacy/core/App/screens/PINEnter.tsx
@@ -100,7 +100,7 @@ const PINEnter: React.FC<PINEnterProps> = ({ setAuthenticated, usage = PINEntryU
     },
     subText: {
       ...TextTheme.bold,
-      marginBottom: 20,
+      marginBottom: 4,
     },
   })
 

--- a/packages/legacy/core/__tests__/screens/__snapshots__/PINEnter.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/PINEnter.test.tsx.snap
@@ -271,6 +271,7 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                       accessibilityLabel="PINEnter.EnterPIN"
                       accessible={true}
                       autoCapitalize="characters"
+                      autoComplete="one-time-code"
                       autoCorrect={false}
                       autoFocus={true}
                       blurOnSubmit={false}
@@ -289,7 +290,7 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                           "bottom": 0,
                           "fontSize": 1,
                           "left": 0,
-                          "opacity": 0.01,
+                          "opacity": 0.015,
                           "position": "absolute",
                           "right": 0,
                           "top": 0,
@@ -735,6 +736,7 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                       accessibilityLabel="PINEnter.EnterPIN"
                       accessible={true}
                       autoCapitalize="characters"
+                      autoComplete="one-time-code"
                       autoCorrect={false}
                       autoFocus={true}
                       blurOnSubmit={false}
@@ -753,7 +755,7 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                           "bottom": 0,
                           "fontSize": 1,
                           "left": 0,
-                          "opacity": 0.01,
+                          "opacity": 0.015,
                           "position": "absolute",
                           "right": 0,
                           "top": 0,

--- a/packages/legacy/core/__tests__/screens/__snapshots__/PINEnter.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/PINEnter.test.tsx.snap
@@ -390,7 +390,7 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                   Object {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": true,
+                    "disabled": false,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -415,7 +415,7 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                 onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "backgroundColor": "rgba(53, 130, 63, 0.35)",
+                    "backgroundColor": "#42803E",
                     "borderRadius": 4,
                     "opacity": 1,
                     "padding": 16,
@@ -441,12 +441,7 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                           "fontWeight": "bold",
                           "textAlign": "center",
                         },
-                        Object {
-                          "color": "#FFFFFF",
-                          "fontSize": 18,
-                          "fontWeight": "bold",
-                          "textAlign": "center",
-                        },
+                        false,
                         false,
                         false,
                       ]
@@ -859,7 +854,7 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                   Object {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": true,
+                    "disabled": false,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -884,7 +879,7 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                 onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "backgroundColor": "rgba(53, 130, 63, 0.35)",
+                    "backgroundColor": "#42803E",
                     "borderRadius": 4,
                     "opacity": 1,
                     "padding": 16,
@@ -910,12 +905,7 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                           "fontWeight": "bold",
                           "textAlign": "center",
                         },
-                        Object {
-                          "color": "#FFFFFF",
-                          "fontSize": 18,
-                          "fontWeight": "bold",
-                          "textAlign": "center",
-                        },
+                        false,
                         false,
                         false,
                       ]

--- a/packages/legacy/core/__tests__/screens/__snapshots__/PINEnter.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/PINEnter.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                   "color": "#FFFFFF",
                   "fontSize": 18,
                   "fontWeight": "bold",
-                  "marginBottom": 20,
+                  "marginBottom": 4,
                 }
               }
             >
@@ -94,6 +94,13 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                 }
               }
             >
+              <View
+                style={
+                  Object {
+                    "minHeight": 36,
+                  }
+                }
+              />
               <View
                 style={
                   Object {
@@ -372,6 +379,13 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                   </Text>
                 </View>
               </View>
+              <View
+                style={
+                  Object {
+                    "minHeight": 36,
+                  }
+                }
+              />
             </View>
           </View>
           <View
@@ -545,7 +559,7 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                   "color": "#FFFFFF",
                   "fontSize": 18,
                   "fontWeight": "bold",
-                  "marginBottom": 20,
+                  "marginBottom": 4,
                 }
               }
             >
@@ -559,6 +573,13 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                 }
               }
             >
+              <View
+                style={
+                  Object {
+                    "minHeight": 36,
+                  }
+                }
+              />
               <View
                 style={
                   Object {
@@ -837,6 +858,13 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                   </Text>
                 </View>
               </View>
+              <View
+                style={
+                  Object {
+                    "minHeight": 36,
+                  }
+                }
+              />
             </View>
           </View>
           <View

--- a/packages/legacy/core/__tests__/screens/__snapshots__/PINEnter.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/PINEnter.test.tsx.snap
@@ -271,7 +271,6 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                       accessibilityLabel="PINEnter.EnterPIN"
                       accessible={true}
                       autoCapitalize="characters"
-                      autoComplete="one-time-code"
                       autoCorrect={false}
                       autoFocus={true}
                       blurOnSubmit={false}
@@ -290,7 +289,7 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                           "bottom": 0,
                           "fontSize": 1,
                           "left": 0,
-                          "opacity": 0.015,
+                          "opacity": 0.01,
                           "position": "absolute",
                           "right": 0,
                           "top": 0,
@@ -391,7 +390,7 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                   Object {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": false,
+                    "disabled": true,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -416,7 +415,7 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                 onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "backgroundColor": "#42803E",
+                    "backgroundColor": "rgba(53, 130, 63, 0.35)",
                     "borderRadius": 4,
                     "opacity": 1,
                     "padding": 16,
@@ -442,7 +441,12 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                           "fontWeight": "bold",
                           "textAlign": "center",
                         },
-                        false,
+                        Object {
+                          "color": "#FFFFFF",
+                          "fontSize": 18,
+                          "fontWeight": "bold",
+                          "textAlign": "center",
+                        },
                         false,
                         false,
                       ]
@@ -736,7 +740,6 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                       accessibilityLabel="PINEnter.EnterPIN"
                       accessible={true}
                       autoCapitalize="characters"
-                      autoComplete="one-time-code"
                       autoCorrect={false}
                       autoFocus={true}
                       blurOnSubmit={false}
@@ -755,7 +758,7 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                           "bottom": 0,
                           "fontSize": 1,
                           "left": 0,
-                          "opacity": 0.015,
+                          "opacity": 0.01,
                           "position": "absolute",
                           "right": 0,
                           "top": 0,
@@ -856,7 +859,7 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                   Object {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": false,
+                    "disabled": true,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -881,7 +884,7 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                 onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "backgroundColor": "#42803E",
+                    "backgroundColor": "rgba(53, 130, 63, 0.35)",
                     "borderRadius": 4,
                     "opacity": 1,
                     "padding": 16,
@@ -907,7 +910,12 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                           "fontWeight": "bold",
                           "textAlign": "center",
                         },
-                        false,
+                        Object {
+                          "color": "#FFFFFF",
+                          "fontSize": 18,
+                          "fontWeight": "bold",
+                          "textAlign": "center",
+                        },
                         false,
                         false,
                       ]


### PR DESCRIPTION
# Summary of Changes

- add inline errors for pin countdown in pin enter screen


## Screen Recording
### Inline error
https://github.com/user-attachments/assets/aea11f02-48ac-4829-9ece-7d911206505d

### Alert modal
https://github.com/user-attachments/assets/756833ff-aa2c-4e65-ad43-7583b7f11500


# Related Issues

Please reference here any issue #'s that are relevant to this PR, or simply enter "N/A" if this PR does not relate to any existing issues.

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
