### PR TITLE
fix: pin explainer ui

### DIFF
--- a/packages/legacy/core/App/components/chat/ChatMessage.tsx
+++ b/packages/legacy/core/App/components/chat/ChatMessage.tsx
@@ -94,6 +94,7 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({ messageProps }) => {
       >
         <Bubble
           {...messageProps}
+          key={messageProps.key}
           renderUsernameOnMessage={false}
           renderMessageText={() => message.renderEvent()}
           containerStyle={{

--- a/packages/legacy/core/App/screens/PINExplainer.tsx
+++ b/packages/legacy/core/App/screens/PINExplainer.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
+import { ScrollView, StyleSheet, Text, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+
 import Button, { ButtonType } from '../components/buttons/Button'
 import BulletPoint from '../components/inputs/BulletPoint'
-import { testIdWithKey } from '../utils/testable'
-import { ScrollView, StyleSheet, Text, View } from 'react-native'
 import { useTheme } from '../contexts/theme'
+import { testIdWithKey } from '../utils/testable'
 
 export interface PINExplainerProps {
   continueCreatePIN: () => void
@@ -15,19 +17,21 @@ const PINExplainer: React.FC<PINExplainerProps> = ({ continueCreatePIN }) => {
   const { ColorPallet, TextTheme, Assets } = useTheme()
 
   const style = StyleSheet.create({
-    screenContainer: {
-      height: '100%',
+    safeAreaView: {
+      flex: 1,
       backgroundColor: ColorPallet.brand.primaryBackground,
-      padding: 20,
-      justifyContent: 'space-between',
     },
-    pageContainer: {
-      height: '100%',
-      justifyContent: 'space-between',
+    scrollViewContentContainer: {
+      padding: 20,
+      flexGrow: 1,
     },
     imageContainer: {
       alignItems: 'center',
       marginBottom: 30,
+    },
+    footer: {
+      paddingHorizontal: 20,
+      paddingVertical: 10,
     },
   })
 
@@ -38,8 +42,8 @@ const PINExplainer: React.FC<PINExplainerProps> = ({ continueCreatePIN }) => {
   }
 
   return (
-    <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
-      <View style={style.screenContainer}>
+    <SafeAreaView style={style.safeAreaView} edges={['bottom', 'left', 'right']}>
+      <ScrollView contentContainerStyle={style.scrollViewContentContainer}>
         <View>
           <Text style={TextTheme.headingTwo}>{t('PINCreate.Explainer.PrimaryHeading')}</Text>
           <Text style={[TextTheme.normal, { marginTop: 30, marginBottom: 30 }]}>
@@ -51,31 +55,29 @@ const PINExplainer: React.FC<PINExplainerProps> = ({ continueCreatePIN }) => {
               t={t}
             />
           </Text>
-          
         </View>
         <View style={style.imageContainer}>
           <Assets.svg.secureCheck {...imageDisplayOptions} />
         </View>
         <View>
           <Text style={TextTheme.headingFour}>{t('PINCreate.Explainer.WhyNeedPin.Header')}</Text>
-          <Text style={[TextTheme.normal, { marginTop: 20, marginBottom: 20 }]}>{t('PINCreate.Explainer.WhyNeedPin.Paragraph')}</Text>
+          <Text style={[TextTheme.normal, { marginTop: 20, marginBottom: 20 }]}>
+            {t('PINCreate.Explainer.WhyNeedPin.Paragraph')}
+          </Text>
           <BulletPoint text={t('PINCreate.Explainer.WhyNeedPin.ParagraphList1')} textStyle={TextTheme.normal} />
           <BulletPoint text={t('PINCreate.Explainer.WhyNeedPin.ParagraphList2')} textStyle={TextTheme.normal} />
         </View>
-
-        <View>
-          <View style={{ paddingTop: 10 }}>
-            <Button
-              title={t('Global.Continue')}
-              accessibilityLabel={t('Global.Continue')}
-              testID={testIdWithKey('ContinueCreatePIN')}
-              onPress={continueCreatePIN}
-              buttonType={ButtonType.Primary}
-            />
-          </View>
-        </View>
+      </ScrollView>
+      <View style={style.footer}>
+        <Button
+          title={t('Global.Continue')}
+          accessibilityLabel={t('Global.Continue')}
+          testID={testIdWithKey('ContinueCreatePIN')}
+          onPress={continueCreatePIN}
+          buttonType={ButtonType.Primary}
+        />
       </View>
-    </ScrollView>
+    </SafeAreaView>
   )
 }
 

--- a/packages/legacy/core/__mocks__/react-i18next.ts
+++ b/packages/legacy/core/__mocks__/react-i18next.ts
@@ -1,4 +1,4 @@
-const reactI18Next: any = jest.createMockFromModule('react-i18next');
+const reactI18Next: any = jest.createMockFromModule('react-i18next')
 
 const t = (str: string) => str
 
@@ -10,14 +10,16 @@ reactI18Next.useTranslation = () => {
       language: 'en',
       t,
     },
-  };
-};
+  }
+}
 
 reactI18Next.initReactI18next = {
-  type: "3rdParty",
+  type: '3rdParty',
   init: jest.fn(),
 }
 
-module.exports = reactI18Next;
+reactI18Next.Trans = ({ i18nKey }: { i18nKey: string }) => i18nKey
 
-export default {};
+module.exports = reactI18Next
+
+export default {}

--- a/packages/legacy/core/__tests__/screens/PINExplainer.test.tsx
+++ b/packages/legacy/core/__tests__/screens/PINExplainer.test.tsx
@@ -1,0 +1,23 @@
+import { fireEvent, render, screen } from '@testing-library/react-native'
+import React from 'react'
+
+import PINExplainer from '../../App/screens/PINExplainer'
+import { testIdWithKey } from '../../App/utils/testable'
+
+describe('PINExplainer Screen', () => {
+  const continueCreatePIN = jest.fn()
+
+  test('Renders correctly', async () => {
+    const tree = render(<PINExplainer continueCreatePIN={continueCreatePIN} />)
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('Button exists and works', async () => {
+    render(<PINExplainer continueCreatePIN={continueCreatePIN} />)
+
+    const continueButton = await screen.findByTestId(testIdWithKey('ContinueCreatePIN'))
+    fireEvent(continueButton, 'press')
+
+    expect(continueCreatePIN).toHaveBeenCalled()
+  })
+})

--- a/packages/legacy/core/__tests__/screens/__snapshots__/PINExplainer.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/PINExplainer.test.tsx.snap
@@ -1,0 +1,294 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PINExplainer Screen Renders correctly 1`] = `
+<RNCSafeAreaView
+  edges={
+    Array [
+      "bottom",
+      "left",
+      "right",
+    ]
+  }
+  style={
+    Object {
+      "backgroundColor": "#000000",
+      "flex": 1,
+    }
+  }
+>
+  <RCTScrollView
+    contentContainerStyle={
+      Object {
+        "flexGrow": 1,
+        "padding": 20,
+      }
+    }
+  >
+    <View>
+      <View>
+        <Text
+          style={
+            Object {
+              "color": "#FFFFFF",
+              "fontSize": 32,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          PINCreate.Explainer.PrimaryHeading
+        </Text>
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 18,
+                "fontWeight": "normal",
+              },
+              Object {
+                "marginBottom": 30,
+                "marginTop": 30,
+              },
+            ]
+          }
+        >
+          PINCreate.Explainer.PINReminder
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "marginBottom": 30,
+          }
+        }
+      >
+        <
+          fill="#FFFFFF"
+          height={150}
+          width={150}
+        />
+      </View>
+      <View>
+        <Text
+          style={
+            Object {
+              "color": "#FFFFFF",
+              "fontSize": 21,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          PINCreate.Explainer.WhyNeedPin.Header
+        </Text>
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 18,
+                "fontWeight": "normal",
+              },
+              Object {
+                "marginBottom": 20,
+                "marginTop": 20,
+              },
+            ]
+          }
+        >
+          PINCreate.Explainer.WhyNeedPin.Paragraph
+        </Text>
+        <View
+          style={
+            Object {
+              "alignItems": "flex-start",
+              "flexDirection": "row",
+              "marginVertical": 10,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "marginRight": 10,
+                "marginVertical": 6,
+              }
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                Array [
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 9,
+                  },
+                  undefined,
+                  Object {
+                    "fontFamily": "Material Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  Object {},
+                ]
+              }
+            >
+              
+            </Text>
+          </View>
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                },
+                Object {
+                  "flexShrink": 1,
+                },
+              ]
+            }
+          >
+            PINCreate.Explainer.WhyNeedPin.ParagraphList1
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "alignItems": "flex-start",
+              "flexDirection": "row",
+              "marginVertical": 10,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "marginRight": 10,
+                "marginVertical": 6,
+              }
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                Array [
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 9,
+                  },
+                  undefined,
+                  Object {
+                    "fontFamily": "Material Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  Object {},
+                ]
+              }
+            >
+              
+            </Text>
+          </View>
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#FFFFFF",
+                  "fontSize": 18,
+                  "fontWeight": "normal",
+                },
+                Object {
+                  "flexShrink": 1,
+                },
+              ]
+            }
+          >
+            PINCreate.Explainer.WhyNeedPin.ParagraphList2
+          </Text>
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+  <View
+    style={
+      Object {
+        "paddingHorizontal": 20,
+        "paddingVertical": 10,
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Global.Continue"
+      accessibilityRole="button"
+      accessibilityState={
+        Object {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        Object {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "backgroundColor": "#42803E",
+          "borderRadius": 4,
+          "opacity": 1,
+          "padding": 16,
+        }
+      }
+      testID="com.ariesbifold:id/ContinueCreatePIN"
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#FFFFFF",
+                "fontSize": 18,
+                "fontWeight": "bold",
+                "textAlign": "center",
+              },
+              false,
+              false,
+              false,
+            ]
+          }
+        >
+          Global.Continue
+        </Text>
+      </View>
+    </View>
+  </View>
+</RNCSafeAreaView>
+`;


### PR DESCRIPTION
# Summary of Changes

This PR makes the button on the PINExplainer screen always visible, while the content is still scrollable. I also added to the reacti18n mock so that we can test screens and components that makes use of its `Trans` component. I also fixed a jest error that was popping up when running tests, caused by the `ChatMessage` component.

# Screenshots, videos, or gifs

![pin_explainer](https://github.com/user-attachments/assets/8e709de3-e704-4f52-81d8-3ee558ac5a6c)

# Breaking change guide

N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] Updated documentation as needed for changed code and new or modified features
- [x] Added sufficient [tests](../packages/legacy/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed

