### PR TITLE
fix: remove blank error msg spacing

### DIFF
--- a/packages/legacy/core/App/components/inputs/PINInput.tsx
+++ b/packages/legacy/core/App/components/inputs/PINInput.tsx
@@ -23,7 +23,6 @@ const PINInputComponent = (
   { label, onPINChanged, testID, accessibilityLabel, autoFocus = false, inlineMessage }: PINInputProps,
   ref: Ref<TextInput>
 ) => {
-  // const accessible = accessibilityLabel && accessibilityLabel !== '' ? true : false
   const [PIN, setPIN] = useState('')
   const [showPIN, setShowPIN] = useState(false)
   const { t } = useTranslation()
@@ -60,10 +59,8 @@ const PINInputComponent = (
     hideIcon: {
       paddingHorizontal: 10,
     },
-    inlineMessageContainer: {
-      minHeight: 36,
-    },
   })
+
   const content = () => (
     <View style={PINInputTheme.labelAndFieldContainer}>
       <View style={style.codeFieldContainer}>
@@ -110,32 +107,24 @@ const PINInputComponent = (
     </View>
   )
 
-  const inlineMessageView = ({ message, inlineType, config }: InlineMessageProps) => (
-    <InlineErrorText message={message} inlineType={inlineType} config={config} />
-  )
-  const inlineMessagePlaceholder = (placement: InlineErrorPosition) => {
-    // Check if inlineMessage exists and if its position matches the placement or falls back to Above
-    if (!inlineMessage) {
-      return <View style={style.inlineMessageContainer} />
-    }
-  
-    const messagePosition = inlineMessage.config.position || InlineErrorPosition.Above // Default to Above
-    if (messagePosition !== placement) {
-      return <View style={style.inlineMessageContainer} />
-    }
-  
-    return (
-      <View style={style.inlineMessageContainer}>
-        {inlineMessageView(inlineMessage)}
-      </View>
-    )
-  }
   return (
     <View style={style.container}>
       {label && <Text style={[TextTheme.label, { marginBottom: 8 }]}>{label}</Text>}
-      {inlineMessagePlaceholder(InlineErrorPosition.Above)}
+      {inlineMessage?.config.position === InlineErrorPosition.Above ? (
+        <InlineErrorText
+          message={inlineMessage.message}
+          inlineType={inlineMessage.inlineType}
+          config={inlineMessage.config}
+        />
+      ) : null}
       {content()}
-      {inlineMessagePlaceholder(InlineErrorPosition.Below)}
+      {inlineMessage?.config.position === InlineErrorPosition.Below ? (
+        <InlineErrorText
+          message={inlineMessage.message}
+          inlineType={inlineMessage.inlineType}
+          config={inlineMessage.config}
+        />
+      ) : null}
     </View>
   )
 }

--- a/packages/legacy/core/App/index.ts
+++ b/packages/legacy/core/App/index.ts
@@ -123,7 +123,7 @@ export type {
 
 export type { InlineMessageProps } from './components/inputs/InlineErrorText'
 
-export type { InlineErrorPosition } from './types/error'
+export { InlineErrorPosition } from './types/error'
 
 export type { CredentialListFooterProps }
 export * from './container-api'

--- a/packages/legacy/core/__tests__/screens/__snapshots__/PINEnter.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/PINEnter.test.tsx.snap
@@ -97,13 +97,6 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
               <View
                 style={
                   Object {
-                    "minHeight": 36,
-                  }
-                }
-              />
-              <View
-                style={
-                  Object {
                     "alignItems": "center",
                     "backgroundColor": "#313132",
                     "borderColor": "#FFFFFFFF",
@@ -379,13 +372,6 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
                   </Text>
                 </View>
               </View>
-              <View
-                style={
-                  Object {
-                    "minHeight": 36,
-                  }
-                }
-              />
             </View>
           </View>
           <View
@@ -576,13 +562,6 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
               <View
                 style={
                   Object {
-                    "minHeight": 36,
-                  }
-                }
-              />
-              <View
-                style={
-                  Object {
                     "alignItems": "center",
                     "backgroundColor": "#313132",
                     "borderColor": "#FFFFFFFF",
@@ -858,13 +837,6 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
                   </Text>
                 </View>
               </View>
-              <View
-                style={
-                  Object {
-                    "minHeight": 36,
-                  }
-                }
-              />
             </View>
           </View>
           <View


### PR DESCRIPTION
# Summary of Changes

Removed unnecessary space above and below inputs even when no error message is present. Also exported the position enum as an enum rather than a type, allowing other Bifold users to make use of it in config. 

# Screenshots, videos, or gifs

### Before:
![space_before](https://github.com/user-attachments/assets/d1377c73-638e-4247-a937-d9d3128958f9)

### After:
![space_after](https://github.com/user-attachments/assets/fc14b844-aaf1-49fb-b717-c3db0f5d282e)

### After with error:
![space_after_with_error](https://github.com/user-attachments/assets/60b881c1-de3b-4919-8934-3df8d981b2cd)

Note for BC Wallet devs: The error message in the image above is in the "Above" configuration to show the default in Bifold. It will remain in the Below configuration in BC Wallet. 

# Breaking change guide

N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] Updated documentation as needed for changed code and new or modified features
- [x] Added sufficient [tests](../packages/legacy/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed

