### PR TITLE
ui: make inline error message icon optional

### DIFF
--- a/packages/legacy/core/App/components/inputs/InlineErrorText.tsx
+++ b/packages/legacy/core/App/components/inputs/InlineErrorText.tsx
@@ -36,13 +36,19 @@ const InlineErrorText: React.FC<InlineMessageProps> = ({ message, inlineType, co
 
   const props: SvgProps = { height: 24, width: 24, color: color, style: style.icon }
 
+  const getInlineErrorIcon = () => {
+    if (!config.hasErrorIcon) return null
+
+    if (inlineType === InlineErrorType.warning) {
+      return <InputInlineMessage.InlineWarningIcon {...props} />
+    } else {
+      return <InputInlineMessage.InlineErrorIcon {...props} />
+    }
+  }
+
   return (
     <View style={[style.container, config.style]}>
-      {inlineType === InlineErrorType.warning ? (
-        <InputInlineMessage.InlineWarningIcon {...props} />
-      ) : (
-        <InputInlineMessage.InlineErrorIcon {...props} />
-      )}
+      {getInlineErrorIcon()}
       <Text style={[InputInlineMessage.inlineErrorText]} testID={testIdWithKey('InlineErrorText')}>
         {message}
       </Text>

--- a/packages/legacy/core/App/container-impl.ts
+++ b/packages/legacy/core/App/container-impl.ts
@@ -70,7 +70,7 @@ export const defaultConfig: Config = {
     enableCredentialList: false,
   },
 }
-export const defaultHistoryEventsLogger: HistoryEventsLoggerConfig  = {
+export const defaultHistoryEventsLogger: HistoryEventsLoggerConfig = {
   logAttestationAccepted: true,
   logAttestationRefused: true,
   logAttestationRemoved: true,
@@ -98,7 +98,7 @@ export class MainContainer implements Container {
   public get container(): DependencyContainer {
     return this._container
   }
-  
+
   public init(): Container {
     this.log?.info(`Initializing Bifold container`)
 
@@ -143,7 +143,11 @@ export class MainContainer implements Container {
     this._container.registerInstance(TOKENS.COMPONENT_CONTACT_DETAILS_CRED_LIST_ITEM, ContactCredentialListItem)
     this._container.registerInstance(TOKENS.CACHE_CRED_DEFS, [])
     this._container.registerInstance(TOKENS.CACHE_SCHEMAS, [])
-    this._container.registerInstance(TOKENS.INLINE_ERRORS, { enabled: true, position: InlineErrorPosition.Above })
+    this._container.registerInstance(TOKENS.INLINE_ERRORS, {
+      enabled: true,
+      hasErrorIcon: true,
+      position: InlineErrorPosition.Above,
+    })
     this._container.registerInstance(
       TOKENS.FN_ONBOARDING_DONE,
       (dispatch: React.Dispatch<ReducerAction<unknown>>, navigation: StackNavigationProp<AuthenticateStackParams>) => {

--- a/packages/legacy/core/App/types/error.ts
+++ b/packages/legacy/core/App/types/error.ts
@@ -29,6 +29,7 @@ export class BifoldError extends Error {
 
 export type InlineErrorConfig = {
   enabled: boolean
+  hasErrorIcon?: boolean
   position?: InlineErrorPosition
   style?: ViewStyle
 }


### PR DESCRIPTION
# Summary of Changes

This PR makes the inline error message icon optional in the create pin/change pin flow.
 
# Screenshots, videos, or gifs

N/A

# Breaking change guide

N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] Updated documentation as needed for changed code and new or modified features
- [x] Added sufficient [tests](../packages/legacy/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed

