### PR TITLE
fix: change cast from boolean to LockoutState on LOCKOUT_UPDATED action

### DIFF
--- a/packages/legacy/core/App/contexts/reducers/store.ts
+++ b/packages/legacy/core/App/contexts/reducers/store.ts
@@ -472,7 +472,7 @@ export const reducer = <S extends State>(state: S, action: ReducerAction<Dispatc
       return newState
     }
     case LockoutDispatchAction.LOCKOUT_UPDATED: {
-      const displayNotification: boolean = (action?.payload ?? []).pop() ?? false
+      const { displayNotification }: LockoutState = (action?.payload ?? []).pop() ?? { displayNotification: false }
       const lockout: LockoutState = {
         ...state.lockout,
         displayNotification,


### PR DESCRIPTION
# Summary of Changes

This PR fixes a bug where the LOCKOUT_UPDATED state is not being properly updated in the store. The bug occurs after the user is locked out of the app after 5 minutes. When changing the biometry settings, the pin page displays the wrong message.

# Screenshots, videos, or gifs

Here is the bug:

https://github.com/user-attachments/assets/11db3961-611e-4b62-bbc3-74e9e1c428ad

# Breaking change guide

N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] Updated documentation as needed for changed code and new or modified features
- [x] Added sufficient [tests](../packages/legacy/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed

