### PR TITLE
fix: disable back action by gesture after accepting terms and conditions

### DIFF
--- a/packages/legacy/core/App/navigators/defaultStackOptions.tsx
+++ b/packages/legacy/core/App/navigators/defaultStackOptions.tsx
@@ -27,6 +27,7 @@ export const DefaultScreenOptionsDictionary: ScreenOptionsType = {
   },
   [Screens.CreatePIN]: {
     headerLeft: () => false,
+    gestureEnabled: false,
   },
   [Screens.NameWallet]: {
     headerTintColor: OnboardingTheme.headerTintColor,

--- a/packages/legacy/core/App/navigators/defaultStackOptions.tsx
+++ b/packages/legacy/core/App/navigators/defaultStackOptions.tsx
@@ -26,7 +26,7 @@ export const DefaultScreenOptionsDictionary: ScreenOptionsType = {
     headerLeft: () => false,
   },
   [Screens.CreatePIN]: {
-    headerLeft: () => false,
+    //headerLeft: () => false,
     gestureEnabled: false,
   },
   [Screens.NameWallet]: {

--- a/packages/legacy/core/App/screens/PINCreate.tsx
+++ b/packages/legacy/core/App/screens/PINCreate.tsx
@@ -1,4 +1,4 @@
-import { CommonActions, ParamListBase, useNavigation } from '@react-navigation/native'
+import { CommonActions, ParamListBase, useFocusEffect, useNavigation } from '@react-navigation/native'
 import { StackNavigationProp, StackScreenProps } from '@react-navigation/stack'
 import React, { useState, useRef, useEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -12,6 +12,7 @@ import {
   TouchableOpacity,
   findNodeHandle,
   DeviceEventEmitter,
+  BackHandler,
 } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
@@ -95,6 +96,16 @@ const PINCreate: React.FC<PINCreateProps> = ({ setAuthenticated, explainedStatus
     TOKENS.HISTORY_ENABLED,
     TOKENS.HISTORY_EVENTS_LOGGER,
   ])
+
+  useFocusEffect(
+    useCallback(() => {
+      const onBackPress = () => true
+
+      BackHandler.addEventListener('hardwareBackPress', onBackPress)
+
+      return () => BackHandler.removeEventListener('hardwareBackPress', onBackPress)
+    }, [])
+  )
 
   const [explained, setExplained] = useState(explainedStatus || showPINExplainer === false)
 

--- a/packages/legacy/core/App/screens/PINCreate.tsx
+++ b/packages/legacy/core/App/screens/PINCreate.tsx
@@ -110,14 +110,13 @@ const PINCreate: React.FC<PINCreateProps> = ({ setAuthenticated, explainedStatus
 
   useEffect(() => {
     navigation.setOptions({
-      headerLeft: (props) =>
+      headerLeft: () =>
         updatePin ? (
           <IconButton
             icon={'arrow-left'}
             accessibilityLabel={t('Global.Back')}
-            testID={testIdWithKey('Back')}
+            testID={testIdWithKey('BackButton')}
             buttonLocation={ButtonLocation.Left}
-            {...props}
             onPress={() => navigation.goBack()}
           />
         ) : (

--- a/packages/legacy/core/App/screens/PINCreate.tsx
+++ b/packages/legacy/core/App/screens/PINCreate.tsx
@@ -35,7 +35,6 @@ import { testIdWithKey } from '../utils/testable'
 import { InlineErrorType, InlineMessageProps } from '../components/inputs/InlineErrorText'
 import { HistoryCardType, HistoryRecord } from '../modules/history/types'
 import { useAppAgent } from '../utils/agent'
-import IconButton, { ButtonLocation } from '../components/buttons/IconButton'
 
 interface PINCreateProps extends StackScreenProps<ParamListBase, Screens.CreatePIN> {
   setAuthenticated: (status: boolean) => void
@@ -109,21 +108,12 @@ const PINCreate: React.FC<PINCreateProps> = ({ setAuthenticated, explainedStatus
   )
 
   useEffect(() => {
-    navigation.setOptions({
-      headerLeft: () =>
-        updatePin ? (
-          <IconButton
-            icon={'arrow-left'}
-            accessibilityLabel={t('Global.Back')}
-            testID={testIdWithKey('BackButton')}
-            buttonLocation={ButtonLocation.Left}
-            onPress={() => navigation.goBack()}
-          />
-        ) : (
-          false
-        ),
-    })
-  }, [updatePin, navigation, t])
+    if (!updatePin) {
+      navigation.setOptions({
+        headerLeft: () => false,
+      })
+    }
+  }, [updatePin, navigation])
 
   const [explained, setExplained] = useState(explainedStatus || showPINExplainer === false)
 

--- a/packages/legacy/core/App/screens/PINCreate.tsx
+++ b/packages/legacy/core/App/screens/PINCreate.tsx
@@ -35,6 +35,7 @@ import { testIdWithKey } from '../utils/testable'
 import { InlineErrorType, InlineMessageProps } from '../components/inputs/InlineErrorText'
 import { HistoryCardType, HistoryRecord } from '../modules/history/types'
 import { useAppAgent } from '../utils/agent'
+import IconButton, { ButtonLocation } from '../components/buttons/IconButton'
 
 interface PINCreateProps extends StackScreenProps<ParamListBase, Screens.CreatePIN> {
   setAuthenticated: (status: boolean) => void
@@ -99,13 +100,31 @@ const PINCreate: React.FC<PINCreateProps> = ({ setAuthenticated, explainedStatus
 
   useFocusEffect(
     useCallback(() => {
-      const onBackPress = () => true
+      const onBackPress = () => !updatePin
 
       BackHandler.addEventListener('hardwareBackPress', onBackPress)
 
       return () => BackHandler.removeEventListener('hardwareBackPress', onBackPress)
-    }, [])
+    }, [updatePin])
   )
+
+  useEffect(() => {
+    navigation.setOptions({
+      headerLeft: (props) =>
+        updatePin ? (
+          <IconButton
+            icon={'arrow-left'}
+            accessibilityLabel={t('Global.Back')}
+            testID={testIdWithKey('Back')}
+            buttonLocation={ButtonLocation.Left}
+            {...props}
+            onPress={() => navigation.goBack()}
+          />
+        ) : (
+          false
+        ),
+    })
+  }, [updatePin, navigation, t])
 
   const [explained, setExplained] = useState(explainedStatus || showPINExplainer === false)
 

--- a/packages/legacy/core/App/types/proof-items.ts
+++ b/packages/legacy/core/App/types/proof-items.ts
@@ -1,10 +1,10 @@
 import { AnonCredsCredentialsForProofRequest } from '@credo-ts/anoncreds'
 import { CredentialExchangeRecord } from '@credo-ts/core'
 import { Attribute, Predicate } from '@hyperledger/aries-oca/build/legacy'
-import { DescriptorMetadata } from 'utils/anonCredsProofRequestMapper'
+import { DescriptorMetadata } from '../utils/anonCredsProofRequestMapper'
 
 export type CredentialDataForProof = {
-  groupedProof: (ProofCredentialPredicates & ProofCredentialAttributes)[],
+  groupedProof: (ProofCredentialPredicates & ProofCredentialAttributes)[]
   retrievedCredentials: AnonCredsCredentialsForProofRequest | undefined
   fullCredentials: CredentialExchangeRecord[]
   descriptorMetadata?: DescriptorMetadata
@@ -29,4 +29,4 @@ export interface ProofCredentialPredicates {
   predicates?: Predicate[]
 }
 
-export interface ProofCredentialItems extends ProofCredentialAttributes, ProofCredentialPredicates { }
+export interface ProofCredentialItems extends ProofCredentialAttributes, ProofCredentialPredicates {}


### PR DESCRIPTION
# Summary of Changes

This PR fixes a bug where after accepting the Terms & Conditions the user is able to go back from the PINCreate Screen and then is stuck on Terms & Conditions Screen. Only killing app gets the user back on the PINCreate screen.

# Screenshots, videos, or gifs

N/A

# Breaking change guide

N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] Updated documentation as needed for changed code and new or modified features
- [x] Added sufficient [tests](../packages/legacy/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed

