### PR TITLE
fix: fixed logic for credential proof headers

### DIFF
--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -834,7 +834,7 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, proofId }) => {
           {!hasAvailableCredentials && (
             <CredentialList
               header={
-                missingCredentials.length > 1 && userCredentials.length > 1
+                missingCredentials.length > 0 && userCredentials.length > 0
                   ? credentialListHeader(t('ProofRequest.MissingCredentials'))
                   : undefined
               }
@@ -856,7 +856,7 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, proofId }) => {
           )}
           <CredentialList
             header={
-              missingCredentials.length > 1 && userCredentials.length > 1
+              missingCredentials.length > 0 && userCredentials.length > 0
                 ? credentialListHeader(t('ProofRequest.FromYourWallet'))
                 : undefined
             }

--- a/packages/legacy/core/__tests__/screens/__snapshots__/W3cProofRequest.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/W3cProofRequest.test.tsx.snap
@@ -163,6 +163,29 @@ exports[`displays a proof request screen ProofRequest Screen, W3C displays a pro
               }
             />
           }
+          ListHeaderComponent={
+            <View
+              style={
+                Object {
+                  "marginHorizontal": 20,
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 20,
+                    "fontWeight": "bold",
+                    "marginTop": 10,
+                  }
+                }
+                testID="com.ariesbifold:id/ProofRequestHeaderText"
+              >
+                ProofRequest.MissingCredentials
+              </Text>
+            </View>
+          }
           data={
             Array [
               Object {
@@ -213,6 +236,32 @@ exports[`displays a proof request screen ProofRequest Screen, W3C displays a pro
           viewabilityConfigCallbackPairs={Array []}
         >
           <View>
+            <View
+              collapsable={false}
+              onLayout={[Function]}
+            >
+              <View
+                style={
+                  Object {
+                    "marginHorizontal": 20,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Object {
+                      "color": "#FFFFFF",
+                      "fontSize": 20,
+                      "fontWeight": "bold",
+                      "marginTop": 10,
+                    }
+                  }
+                  testID="com.ariesbifold:id/ProofRequestHeaderText"
+                >
+                  ProofRequest.MissingCredentials
+                </Text>
+              </View>
+            </View>
             <View
               onFocusCapture={[Function]}
               onLayout={[Function]}
@@ -604,6 +653,29 @@ exports[`displays a proof request screen ProofRequest Screen, W3C displays a pro
           </View>
         </RCTScrollView>
         <RCTScrollView
+          ListHeaderComponent={
+            <View
+              style={
+                Object {
+                  "marginHorizontal": 20,
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 20,
+                    "fontWeight": "bold",
+                    "marginTop": 10,
+                  }
+                }
+                testID="com.ariesbifold:id/ProofRequestHeaderText"
+              >
+                ProofRequest.FromYourWallet
+              </Text>
+            </View>
+          }
           data={
             Array [
               Object {
@@ -699,6 +771,32 @@ exports[`displays a proof request screen ProofRequest Screen, W3C displays a pro
           viewabilityConfigCallbackPairs={Array []}
         >
           <View>
+            <View
+              collapsable={false}
+              onLayout={[Function]}
+            >
+              <View
+                style={
+                  Object {
+                    "marginHorizontal": 20,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Object {
+                      "color": "#FFFFFF",
+                      "fontSize": 20,
+                      "fontWeight": "bold",
+                      "marginTop": 10,
+                    }
+                  }
+                  testID="com.ariesbifold:id/ProofRequestHeaderText"
+                >
+                  ProofRequest.FromYourWallet
+                </Text>
+              </View>
+            </View>
             <View
               onFocusCapture={[Function]}
               onLayout={[Function]}


### PR DESCRIPTION
# Summary of Changes

- Updated header logic on proof request lists to display properly
- Updated test snapshot


# Screenshots, videos, or gifs
Proof request screen breaks down into 2 section:
- "Missing Credentials"
- "From your wallet"

Missing credentials do not exist in the users wallet, we only want the headers to appear when there are credentials in the proof that appear in both sections

Credentials in both sections:
![dummy](https://github.com/user-attachments/assets/216bac75-05ce-4a4b-a20a-cd5c9f2002da)

No section headers required when credentials are in one of these sections:
![dummy](https://github.com/user-attachments/assets/6a31885f-8bbf-4e43-816e-14eab4f38622)


# Breaking change guide

n/a

# Related Issues
[BC-Wallet: 2303](https://github.com/bcgov/bc-wallet-mobile/issues/2302)


# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] Updated documentation as needed for changed code and new or modified features
- [x] Added sufficient [tests](../packages/legacy/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed

