### PR TITLE
feat: fix template file cache

### DIFF
--- a/packages/legacy/core/App/constants.ts
+++ b/packages/legacy/core/App/constants.ts
@@ -86,6 +86,6 @@ export const hitSlop = { top: 44, bottom: 44, left: 44, right: 44 }
 
 export const templateBundleStorageDirectory = 'templates'
 
-export const templateCacheDataFileName = 'proof-templates.json'
+export const templateCacheDataFileName = 'index.json'
 
 export const templateBundleIndexFileName = 'proof-templates.json'

--- a/packages/legacy/core/App/utils/fileCache.ts
+++ b/packages/legacy/core/App/utils/fileCache.ts
@@ -43,6 +43,21 @@ export class FileCache {
     return this._fileEtag || ''
   }
 
+  protected loadCacheData = async (): Promise<CacheDataFile | undefined> => {
+    const cacheFileExists = await this.checkFileExists(this.cacheFileName)
+    if (!cacheFileExists) {
+      return
+    }
+
+    const data = await this.loadFileFromLocalStorage(this.cacheFileName)
+    if (!data) {
+      return
+    }
+
+    const cacheData: CacheDataFile = JSON.parse(data)
+    return cacheData
+  }
+
   protected saveCacheData = async (cacheData: CacheDataFile): Promise<boolean> => {
     const cacheDataAsString = JSON.stringify(cacheData)
 
@@ -118,5 +133,20 @@ export class FileCache {
     }
 
     return false
+  }
+
+  protected stripWeakEtag = (etag: string): string => {
+    if (etag.startsWith('W/')) {
+      return etag.slice(2).replace(/"/g, '')
+    }
+
+    return etag.replace(/"/g, '')
+  }
+
+  protected compareWeakEtags = (etag1: string, etag2: string): boolean => {
+    const cleanEtag1 = this.stripWeakEtag(etag1)
+    const cleanEtag2 = this.stripWeakEtag(etag2)
+
+    return cleanEtag1 === cleanEtag2
   }
 }

--- a/packages/legacy/core/App/utils/proofBundle.ts
+++ b/packages/legacy/core/App/utils/proofBundle.ts
@@ -99,7 +99,7 @@ export class RemoteProofBundleResolver extends FileCache implements IProofBundle
   private cacheDataFileName = templateCacheDataFileName
 
   public constructor(indexFileBaseUrl: string, log?: BifoldLogger) {
-    super(indexFileBaseUrl, templateBundleStorageDirectory, templateBundleIndexFileName, log)
+    super(indexFileBaseUrl, templateBundleStorageDirectory, templateCacheDataFileName, log)
   }
 
   public async resolve(acceptDevRestrictions: boolean): Promise<ProofRequestTemplate[] | undefined> {
@@ -154,10 +154,11 @@ export class RemoteProofBundleResolver extends FileCache implements IProofBundle
     }
 
     this.log?.info('Loading index now')
-    await this.loadBundleIndex(this.cacheDataFileName)
+    await this.loadBundleIndex(templateBundleIndexFileName)
   }
 
   private loadBundleIndex = async (filePath: string) => {
+    let remoteFetchSucceeded = false
     try {
       const response = await this.axiosInstance.get(filePath)
       const { status } = response
@@ -165,18 +166,11 @@ export class RemoteProofBundleResolver extends FileCache implements IProofBundle
 
       if (status !== 200) {
         this.log?.error(`Failed to fetch remote resource at ${filePath}`)
-        // failed to fetch, use the cached index file
-        // if available
-        const data = await this.loadFileFromLocalStorage(filePath)
-        if (data) {
-          this.log?.info(`Using index file ${filePath} from cache`)
-          this.templateData = JSON.parse(data)
-        }
 
-        return
+        throw new Error('Failed to fetch remote resource')
       }
 
-      if (etag && etag === this.fileEtag) {
+      if (etag && this.compareWeakEtags(this.fileEtag, etag)) {
         this.log?.info(`Index file ${filePath} has not changed, etag ${etag}`)
         // etag is the same, no need to refresh
         this.templateData = response.data
@@ -186,28 +180,25 @@ export class RemoteProofBundleResolver extends FileCache implements IProofBundle
 
       this.fileEtag = etag
       this.templateData = response.data
+      remoteFetchSucceeded = true
 
-      this.log?.info(`Saving file ${filePath}, etag ${etag}`)
       await this.saveFileToLocalStorage(filePath, JSON.stringify(this.templateData))
     } catch (error) {
-      this.log?.error(`Failed to fetch file index ${filePath}`)
+      this.log?.error(`Failed to fetch remote file index ${filePath}`)
+    } finally {
+      if (remoteFetchSucceeded) {
+        return
+      }
+
+      const data = await this.loadFileFromLocalStorage(filePath)
+      if (!data) {
+        this.log?.error(`Failed to load index file ${filePath} from cache`)
+        return
+      }
+
+      this.log?.info(`Using index file ${filePath} from cache`)
+      this.templateData = JSON.parse(data)
     }
-  }
-
-  private loadCacheData = async (): Promise<CacheDataFile | undefined> => {
-    const cacheFileExists = await this.checkFileExists(this.cacheDataFileName)
-    if (!cacheFileExists) {
-      return
-    }
-
-    const data = await this.loadFileFromLocalStorage(this.cacheDataFileName)
-    if (!data) {
-      return
-    }
-
-    const cacheData: CacheDataFile = JSON.parse(data)
-
-    return cacheData
   }
 }
 

--- a/packages/legacy/core/App/utils/proofBundle.ts
+++ b/packages/legacy/core/App/utils/proofBundle.ts
@@ -8,7 +8,7 @@ import { useState, useEffect } from 'react'
 import { TOKENS, useServices } from '../container-api'
 import { templateBundleStorageDirectory, templateCacheDataFileName, templateBundleIndexFileName } from '../constants'
 import { BifoldLogger } from '../services/logger'
-import { FileCache, CacheDataFile } from './fileCache'
+import { FileCache } from './fileCache'
 
 type ProofRequestTemplateFn = (useDevTemplates: boolean) => Array<ProofRequestTemplate>
 

--- a/packages/legacy/core/App/utils/proofBundle.ts
+++ b/packages/legacy/core/App/utils/proofBundle.ts
@@ -185,20 +185,20 @@ export class RemoteProofBundleResolver extends FileCache implements IProofBundle
       await this.saveFileToLocalStorage(filePath, JSON.stringify(this.templateData))
     } catch (error) {
       this.log?.error(`Failed to fetch remote file index ${filePath}`)
-    } finally {
-      if (remoteFetchSucceeded) {
-        return
-      }
-
-      const data = await this.loadFileFromLocalStorage(filePath)
-      if (!data) {
-        this.log?.error(`Failed to load index file ${filePath} from cache`)
-        return
-      }
-
-      this.log?.info(`Using index file ${filePath} from cache`)
-      this.templateData = JSON.parse(data)
     }
+
+    if (remoteFetchSucceeded) {
+      return
+    }
+
+    const data = await this.loadFileFromLocalStorage(filePath)
+    if (!data) {
+      this.log?.error(`Failed to load index file ${filePath} from cache`)
+      return
+    }
+
+    this.log?.info(`Using index file ${filePath} from cache`)
+    this.templateData = JSON.parse(data)
   }
 }
 


### PR DESCRIPTION
# Summary of Changes

**Improved Handling of Remote Proof Template Files and Weak ETags**

This pull request addresses an issue where the remote proof template file cache was not functioning correctly. The problem stemmed from the template file and the cache data file sharing the same name, leading to accidental overwriting.

This PR includes the following improvements:

* **Unique filenames for template and cache files:** Prevents conflicts and ensures correct caching.
* **Enhanced weak ETag validation:** Introduces a more robust method for handling weak ETags, improving cache accuracy.

These changes enhance the reliability and efficiency of the remote proof template caching mechanism.


# Screenshots, videos, or gifs

<img width="938" alt="Screenshot 2024-12-20 at 1 39 41 PM" src="https://github.com/user-attachments/assets/420d13a7-a5b6-4798-b5c4-46f37d49145d" />

# Breaking change guide

N/A

# Related Issues

Replace this text with issue #'s that are relevant to this PR. If there are none, simply enter N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] Updated documentation as needed for changed code and new or modified features
- [x] Added sufficient [tests](../packages/legacy/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed

