### PR TITLE
fix: incorrect proof chat role

### DIFF
--- a/packages/legacy/core/App/localization/en/index.ts
+++ b/packages/legacy/core/App/localization/en/index.ts
@@ -837,7 +837,7 @@ const translation = {
     "CredentialReceived": "received a credential",
     "ProofRequestSent": "sent a proof request",
     "ProofPresentationReceived": "has sent you information",
-    "ProofRequestReceived": "received a proof request",
+    "ProofRequestReceived": "has sent you a proof request",
     "ProofRequestRejected": "rejected a proof request",
     "ProofRequestRejectReceived": "rejected a proof request",
     "ProofRequestSatisfied": "shared information",

--- a/packages/legacy/core/App/localization/fr/index.ts
+++ b/packages/legacy/core/App/localization/fr/index.ts
@@ -814,7 +814,7 @@ const translation = {
         "CredentialReceived": "reçu une attestation",
         "ProofRequestSent": "envoyé une demande d'attestation",
         "ProofPresentationReceived": "vous a envoyé des informations",
-        "ProofRequestReceived": "reçu une demande d'attestation",
+        "ProofRequestReceived": "has sent you a proof request (FR)",
         "ProofRequestRejected": "rejeté une demande d'attestation",
         "ProofRequestRejectReceived": "a rejeté une demande d'attestation",
         "ProofRequestSatisfied": "informations partagées",

--- a/packages/legacy/core/App/localization/pt-br/index.ts
+++ b/packages/legacy/core/App/localization/pt-br/index.ts
@@ -789,7 +789,7 @@ const translation = {
     "CredentialReceived": "recebeu uma credencial",
     "ProofRequestSent": "enviou uma solicitação de prova",
     "ProofPresentationReceived": "te enviou informações",
-    "ProofRequestReceived": "recebeu uma solicitação de prova",
+    "ProofRequestReceived": "has sent you a proof request (PT-BR)",
     "ProofRequestRejected": "rejeitou uma solicitação de prova",
     "ProofRequestRejectReceived": "rejeitou um pedido de prova",
     "ProofRequestSatisfied": "informações compartilhadas",

--- a/packages/legacy/core/App/utils/helpers.ts
+++ b/packages/legacy/core/App/utils/helpers.ts
@@ -1200,7 +1200,7 @@ export function getProofEventRole(record: ProofExchangeRecord) {
     case ProofState.PresentationReceived:
       return Role.them
     case ProofState.RequestReceived:
-      return Role.me
+      return Role.them
     case ProofState.ProposalSent:
     case ProofState.PresentationSent:
       return Role.me


### PR DESCRIPTION
# Summary of Changes

This PR fixes a bug where the chat role for a proof request that has not been responded to was incorrectly on the users side, rather than the contact's. See screenshots below for before and after
 
# Screenshots, videos, or gifs
Before:
![before](https://github.com/user-attachments/assets/e3a51ad6-e182-4765-9a3e-6ab6baae6575)
After:
![after](https://github.com/user-attachments/assets/e6a73dbf-3fb8-4dcb-a27a-c01089fef4ba)

# Breaking change guide

N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] Updated documentation as needed for changed code and new or modified features
- [x] Added sufficient [tests](../packages/legacy/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed

