### PR TITLE
feat: add opt-in hidden dev mode trigger to pin enter scrn

### DIFF
--- a/packages/legacy/core/App/types/config.ts
+++ b/packages/legacy/core/App/types/config.ts
@@ -23,6 +23,7 @@ export interface Config {
   enableTours?: boolean
   enableImplicitInvitations?: boolean
   enableReuseConnections?: boolean
+  enableHiddenDevModeTrigger?: boolean
   showPreface?: boolean
   showPINExplainer?: boolean
   disableOnboardingSkip?: boolean


### PR DESCRIPTION
# Summary of Changes

This PR adds an optional config setting to enable triggering developer mode from the enter PIN screen. It is by default not enabled. The trigger is tapping the help text 10 times

# Screenshots, videos, or gifs
![extra_dev_mode_trigger](https://github.com/user-attachments/assets/eecc2457-8213-40e6-9462-d4b1b87f2d61)

# Breaking change guide
N/A

# Related Issues
N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] Updated documentation as needed for changed code and new or modified features
- [x] Added sufficient [tests](../packages/legacy/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed

