### PR TITLE
fix: show attribute value button in credentials details being cropped

### DIFF
--- a/packages/legacy/core/App/components/record/RecordField.tsx
+++ b/packages/legacy/core/App/components/record/RecordField.tsx
@@ -86,6 +86,14 @@ const RecordField: React.FC<RecordFieldProps> = ({
       justifyContent: 'space-between',
       paddingTop: 5,
     },
+    fieldLabel: {
+      flex: 3,
+    },
+    fieldValue: {
+      flex: 1,
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
+    },
     valueText: {
       ...ListItems.recordAttributeText,
       paddingVertical: 4,
@@ -95,27 +103,31 @@ const RecordField: React.FC<RecordFieldProps> = ({
   return (
     <View style={styles.container}>
       <View style={styles.valueContainer}>
-        {fieldLabel ? (
-          fieldLabel(field)
-        ) : (
-          <Text style={ListItems.recordAttributeLabel} testID={testIdWithKey('AttributeName')}>
-            {field.label ?? startCase(field.name || '')}
-          </Text>
-        )}
+        <View style={styles.fieldLabel}>
+          {fieldLabel ? (
+            fieldLabel(field)
+          ) : (
+            <Text style={ListItems.recordAttributeLabel} testID={testIdWithKey('AttributeName')}>
+              {field.label ?? startCase(field.name || '')}
+            </Text>
+          )}
+        </View>
 
-        {hideFieldValue ? (
-          <TouchableOpacity
-            accessible={true}
-            accessibilityLabel={shown ? t('Record.Hide') : t('Record.Show')}
-            accessibilityRole="button"
-            testID={testIdWithKey('ShowHide')}
-            activeOpacity={1}
-            onPress={onToggleViewPressed}
-            style={styles.link}
-          >
-            <Text style={ListItems.recordLink}>{shown ? t('Record.Hide') : t('Record.Show')}</Text>
-          </TouchableOpacity>
-        ) : null}
+        <View style={styles.fieldValue}>
+          {hideFieldValue ? (
+            <TouchableOpacity
+              accessible={true}
+              accessibilityLabel={shown ? t('Record.Hide') : t('Record.Show')}
+              accessibilityRole="button"
+              testID={testIdWithKey('ShowHide')}
+              activeOpacity={1}
+              onPress={onToggleViewPressed}
+              style={styles.link}
+            >
+              <Text style={ListItems.recordLink}>{shown ? t('Record.Hide') : t('Record.Show')}</Text>
+            </TouchableOpacity>
+          ) : null}
+        </View>
       </View>
 
       <View style={styles.valueContainer}>

--- a/packages/legacy/core/__tests__/components/__snapshots__/RecordField.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/RecordField.test.tsx.snap
@@ -19,18 +19,35 @@ exports[`RecordField Component Shown binary field should render a binary field 1
       }
     }
   >
-    <Text
+    <View
       style={
         Object {
-          "color": "#FFFFFF",
-          "fontSize": 18,
-          "fontWeight": "bold",
+          "flex": 3,
         }
       }
-      testID="com.ariesbifold:id/AttributeName"
     >
-      Test
-    </Text>
+      <Text
+        style={
+          Object {
+            "color": "#FFFFFF",
+            "fontSize": 18,
+            "fontWeight": "bold",
+          }
+        }
+        testID="com.ariesbifold:id/AttributeName"
+      >
+        Test
+      </Text>
+    </View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+        }
+      }
+    />
   </View>
   <View
     style={
@@ -142,18 +159,35 @@ exports[`RecordField Component Shown date field should render a date field 1`] =
       }
     }
   >
-    <Text
+    <View
       style={
         Object {
-          "color": "#FFFFFF",
-          "fontSize": 18,
-          "fontWeight": "bold",
+          "flex": 3,
         }
       }
-      testID="com.ariesbifold:id/AttributeName"
     >
-      Test
-    </Text>
+      <Text
+        style={
+          Object {
+            "color": "#FFFFFF",
+            "fontSize": 18,
+            "fontWeight": "bold",
+          }
+        }
+        testID="com.ariesbifold:id/AttributeName"
+      >
+        Test
+      </Text>
+    </View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+        }
+      }
+    />
   </View>
   <View
     style={

--- a/packages/legacy/core/__tests__/screens/__snapshots__/Connection.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/Connection.test.tsx.snap
@@ -1143,18 +1143,35 @@ exports[`Connection Screen Valid goal code aries.vc.issue extracted, show to off
                 }
               }
             >
-              <Text
+              <View
                 style={
                   Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
+                    "flex": 3,
                   }
                 }
-                testID="com.ariesbifold:id/AttributeName"
               >
-                Student First Name
-              </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#FFFFFF",
+                      "fontSize": 18,
+                      "fontWeight": "bold",
+                    }
+                  }
+                  testID="com.ariesbifold:id/AttributeName"
+                >
+                  Student First Name
+                </Text>
+              </View>
+              <View
+                style={
+                  Object {
+                    "flex": 1,
+                    "flexDirection": "row",
+                    "justifyContent": "flex-end",
+                  }
+                }
+              />
             </View>
             <View
               style={
@@ -1226,18 +1243,35 @@ exports[`Connection Screen Valid goal code aries.vc.issue extracted, show to off
                 }
               }
             >
-              <Text
+              <View
                 style={
                   Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
+                    "flex": 3,
                   }
                 }
-                testID="com.ariesbifold:id/AttributeName"
               >
-                Student Last Name
-              </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#FFFFFF",
+                      "fontSize": 18,
+                      "fontWeight": "bold",
+                    }
+                  }
+                  testID="com.ariesbifold:id/AttributeName"
+                >
+                  Student Last Name
+                </Text>
+              </View>
+              <View
+                style={
+                  Object {
+                    "flex": 1,
+                    "flexDirection": "row",
+                    "justifyContent": "flex-end",
+                  }
+                }
+              />
             </View>
             <View
               style={
@@ -1309,18 +1343,35 @@ exports[`Connection Screen Valid goal code aries.vc.issue extracted, show to off
                 }
               }
             >
-              <Text
+              <View
                 style={
                   Object {
-                    "color": "#FFFFFF",
-                    "fontSize": 18,
-                    "fontWeight": "bold",
+                    "flex": 3,
                   }
                 }
-                testID="com.ariesbifold:id/AttributeName"
               >
-                Expiry Date
-              </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#FFFFFF",
+                      "fontSize": 18,
+                      "fontWeight": "bold",
+                    }
+                  }
+                  testID="com.ariesbifold:id/AttributeName"
+                >
+                  Expiry Date
+                </Text>
+              </View>
+              <View
+                style={
+                  Object {
+                    "flex": 1,
+                    "flexDirection": "row",
+                    "justifyContent": "flex-end",
+                  }
+                }
+              />
             </View>
             <View
               style={

--- a/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/CredentialOffer.test.tsx.snap
@@ -619,18 +619,35 @@ exports[`CredentialOffer Screen accepting a credential 1`] = `
               }
             }
           >
-            <Text
+            <View
               style={
                 Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
+                  "flex": 3,
                 }
               }
-              testID="com.ariesbifold:id/AttributeName"
             >
-              Name
-            </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  }
+                }
+                testID="com.ariesbifold:id/AttributeName"
+              >
+                Name
+              </Text>
+            </View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                }
+              }
+            />
           </View>
           <View
             style={
@@ -702,18 +719,35 @@ exports[`CredentialOffer Screen accepting a credential 1`] = `
               }
             }
           >
-            <Text
+            <View
               style={
                 Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
+                  "flex": 3,
                 }
               }
-              testID="com.ariesbifold:id/AttributeName"
             >
-              Date
-            </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  }
+                }
+                testID="com.ariesbifold:id/AttributeName"
+              >
+                Date
+              </Text>
+            </View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                }
+              }
+            />
           </View>
           <View
             style={
@@ -785,18 +819,35 @@ exports[`CredentialOffer Screen accepting a credential 1`] = `
               }
             }
           >
-            <Text
+            <View
               style={
                 Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
+                  "flex": 3,
                 }
               }
-              testID="com.ariesbifold:id/AttributeName"
             >
-              Degree
-            </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  }
+                }
+                testID="com.ariesbifold:id/AttributeName"
+              >
+                Degree
+              </Text>
+            </View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                }
+              }
+            />
           </View>
           <View
             style={
@@ -868,18 +919,35 @@ exports[`CredentialOffer Screen accepting a credential 1`] = `
               }
             }
           >
-            <Text
+            <View
               style={
                 Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
+                  "flex": 3,
                 }
               }
-              testID="com.ariesbifold:id/AttributeName"
             >
-              Birthdate Dateint
-            </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  }
+                }
+                testID="com.ariesbifold:id/AttributeName"
+              >
+                Birthdate Dateint
+              </Text>
+            </View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                }
+              }
+            />
           </View>
           <View
             style={
@@ -951,18 +1019,35 @@ exports[`CredentialOffer Screen accepting a credential 1`] = `
               }
             }
           >
-            <Text
+            <View
               style={
                 Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
+                  "flex": 3,
                 }
               }
-              testID="com.ariesbifold:id/AttributeName"
             >
-              Timestamp
-            </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  }
+                }
+                testID="com.ariesbifold:id/AttributeName"
+              >
+                Timestamp
+              </Text>
+            </View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                }
+              }
+            />
           </View>
           <View
             style={
@@ -2021,18 +2106,35 @@ exports[`CredentialOffer Screen declining a credential 1`] = `
               }
             }
           >
-            <Text
+            <View
               style={
                 Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
+                  "flex": 3,
                 }
               }
-              testID="com.ariesbifold:id/AttributeName"
             >
-              Name
-            </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  }
+                }
+                testID="com.ariesbifold:id/AttributeName"
+              >
+                Name
+              </Text>
+            </View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                }
+              }
+            />
           </View>
           <View
             style={
@@ -2104,18 +2206,35 @@ exports[`CredentialOffer Screen declining a credential 1`] = `
               }
             }
           >
-            <Text
+            <View
               style={
                 Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
+                  "flex": 3,
                 }
               }
-              testID="com.ariesbifold:id/AttributeName"
             >
-              Date
-            </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  }
+                }
+                testID="com.ariesbifold:id/AttributeName"
+              >
+                Date
+              </Text>
+            </View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                }
+              }
+            />
           </View>
           <View
             style={
@@ -2187,18 +2306,35 @@ exports[`CredentialOffer Screen declining a credential 1`] = `
               }
             }
           >
-            <Text
+            <View
               style={
                 Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
+                  "flex": 3,
                 }
               }
-              testID="com.ariesbifold:id/AttributeName"
             >
-              Degree
-            </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  }
+                }
+                testID="com.ariesbifold:id/AttributeName"
+              >
+                Degree
+              </Text>
+            </View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                }
+              }
+            />
           </View>
           <View
             style={
@@ -2270,18 +2406,35 @@ exports[`CredentialOffer Screen declining a credential 1`] = `
               }
             }
           >
-            <Text
+            <View
               style={
                 Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
+                  "flex": 3,
                 }
               }
-              testID="com.ariesbifold:id/AttributeName"
             >
-              Birthdate Dateint
-            </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  }
+                }
+                testID="com.ariesbifold:id/AttributeName"
+              >
+                Birthdate Dateint
+              </Text>
+            </View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                }
+              }
+            />
           </View>
           <View
             style={
@@ -2353,18 +2506,35 @@ exports[`CredentialOffer Screen declining a credential 1`] = `
               }
             }
           >
-            <Text
+            <View
               style={
                 Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
+                  "flex": 3,
                 }
               }
-              testID="com.ariesbifold:id/AttributeName"
             >
-              Timestamp
-            </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  }
+                }
+                testID="com.ariesbifold:id/AttributeName"
+              >
+                Timestamp
+              </Text>
+            </View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                }
+              }
+            />
           </View>
           <View
             style={
@@ -3648,18 +3818,35 @@ exports[`CredentialOffer Screen renders correctly 1`] = `
               }
             }
           >
-            <Text
+            <View
               style={
                 Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
+                  "flex": 3,
                 }
               }
-              testID="com.ariesbifold:id/AttributeName"
             >
-              Name
-            </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  }
+                }
+                testID="com.ariesbifold:id/AttributeName"
+              >
+                Name
+              </Text>
+            </View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                }
+              }
+            />
           </View>
           <View
             style={
@@ -3731,18 +3918,35 @@ exports[`CredentialOffer Screen renders correctly 1`] = `
               }
             }
           >
-            <Text
+            <View
               style={
                 Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
+                  "flex": 3,
                 }
               }
-              testID="com.ariesbifold:id/AttributeName"
             >
-              Date
-            </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  }
+                }
+                testID="com.ariesbifold:id/AttributeName"
+              >
+                Date
+              </Text>
+            </View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                }
+              }
+            />
           </View>
           <View
             style={
@@ -3814,18 +4018,35 @@ exports[`CredentialOffer Screen renders correctly 1`] = `
               }
             }
           >
-            <Text
+            <View
               style={
                 Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
+                  "flex": 3,
                 }
               }
-              testID="com.ariesbifold:id/AttributeName"
             >
-              Degree
-            </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  }
+                }
+                testID="com.ariesbifold:id/AttributeName"
+              >
+                Degree
+              </Text>
+            </View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                }
+              }
+            />
           </View>
           <View
             style={
@@ -3897,18 +4118,35 @@ exports[`CredentialOffer Screen renders correctly 1`] = `
               }
             }
           >
-            <Text
+            <View
               style={
                 Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
+                  "flex": 3,
                 }
               }
-              testID="com.ariesbifold:id/AttributeName"
             >
-              Birthdate Dateint
-            </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  }
+                }
+                testID="com.ariesbifold:id/AttributeName"
+              >
+                Birthdate Dateint
+              </Text>
+            </View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                }
+              }
+            />
           </View>
           <View
             style={
@@ -3980,18 +4218,35 @@ exports[`CredentialOffer Screen renders correctly 1`] = `
               }
             }
           >
-            <Text
+            <View
               style={
                 Object {
-                  "color": "#FFFFFF",
-                  "fontSize": 18,
-                  "fontWeight": "bold",
+                  "flex": 3,
                 }
               }
-              testID="com.ariesbifold:id/AttributeName"
             >
-              Timestamp
-            </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontSize": 18,
+                    "fontWeight": "bold",
+                  }
+                }
+                testID="com.ariesbifold:id/AttributeName"
+              >
+                Timestamp
+              </Text>
+            </View>
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                }
+              }
+            />
           </View>
           <View
             style={


### PR DESCRIPTION
# Summary of Changes

This PR fixes a visual bug where the button for displaying the value of an attribute in the Credential Details Screen is being cropped:

<img width="423" alt="image" src="https://github.com/user-attachments/assets/c32bb2d8-6715-4db0-a7a7-8a06fefa3778" />

# Screenshots, videos, or gifs

N/A

# Breaking change guide

N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] Updated documentation as needed for changed code and new or modified features
- [x] Added sufficient [tests](../packages/legacy/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed

