### PR TITLE
feat: display revoked text and icon in ProofChangeCredential screen

### DIFF
--- a/packages/legacy/core/App/screens/ProofChangeCredential.tsx
+++ b/packages/legacy/core/App/screens/ProofChangeCredential.tsx
@@ -149,6 +149,7 @@ const ProofChangeCredential: React.FC<ProofChangeProps> = ({ route, navigation }
         ListHeaderComponent={listHeader}
         renderItem={({ item }) => {
           const errors: CredentialErrors[] = []
+          item.credExchangeRecord?.revocationNotification?.revocationDate && errors.push(CredentialErrors.Revoked)
           !hasSatisfiedPredicates(getCredentialsFields(), item.credId) && errors.push(CredentialErrors.PredicateError)
           return (
             <View style={styles.pageMargin}>


### PR DESCRIPTION
# Summary of Changes

Display revoked text and icon in ProofChangeCredential screen if card is revoked.

# Screenshots, videos, or gifs

Before:
<img src="https://github.com/user-attachments/assets/9ebe19c8-eefe-49e3-873a-a08f6908588f" width="400" />

After:
<img src="https://github.com/user-attachments/assets/a70b8388-0985-4fa4-9a0a-b64a6bd6c165" width="400" />

# Breaking change guide

N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] Updated documentation as needed for changed code and new or modified features
- [x] Added sufficient [tests](../packages/legacy/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed

