### PR TITLE
feat: make attemptLockout rules injectable in the Config interface

### DIFF
--- a/packages/legacy/core/App/constants.ts
+++ b/packages/legacy/core/App/constants.ts
@@ -63,9 +63,11 @@ export const attemptLockoutConfig: AttemptLockoutConfig = {
     10: 10 * minute,
     15: hour,
   },
-  baseRulesIncrement: 5,
-  threshold: 20,
-  thresholdPenaltyDuration: 24 * hour,
+  thresholdRules: {
+    threshold: 20,
+    increment: 5,
+    thresholdPenaltyDuration: 24 * hour,
+  },
 }
 
 export const defaultAutoLockTime = 5

--- a/packages/legacy/core/App/constants.ts
+++ b/packages/legacy/core/App/constants.ts
@@ -4,6 +4,7 @@ import { homeTourSteps } from './components/tour/HomeTourSteps'
 import { credentialsTourSteps } from './components/tour/CredentialsTourSteps'
 import { credentialOfferTourSteps } from './components/tour/CredentialOfferTourSteps'
 import { proofRequestTourSteps } from './components/tour/ProofRequestTourSteps'
+import { AttemptLockoutConfig } from './types/attempt-lockout-config'
 
 const lengthOfHiddenAttributes = 10
 const unicodeForBulletCharacter = '\u2022'
@@ -50,21 +51,21 @@ export const walletTimeout = minute * 5
 /* lockout attempt rules: The base rules apply the lockout at a specified number of incorrect attempts,
  and the threshold rules apply the lockout penalty to each attempt after the threshold that falls on the attemptIncrement.
  (In this case the threshold rule applies to every 5th incorrect login after 20).
- Keys need to be multiples of the attemptIncrement in the attemptLockoutThresholdRules.
+ Keys need to be multiples of the baseRulesIncrement.
 5 incorrect => 1 minute lockout
 10 incorrect => 10 minute lockout
 15 incorrect => 1 hour lockout
 20, 25, 30, etc incorrect => 1 day lockout
 */
-export const attemptLockoutBaseRules: Record<number, number | undefined> = {
-  5: minute,
-  10: 10 * minute,
-  15: hour,
-}
-export const attemptLockoutThresholdRules = {
-  attemptThreshold: 20,
-  attemptIncrement: 5,
-  attemptThresholdPenalty: 24 * hour,
+export const attemptLockoutConfig: AttemptLockoutConfig = {
+  baseRules: {
+    5: minute,
+    10: 10 * minute,
+    15: hour,
+  },
+  baseRulesIncrement: 5,
+  threshold: 20,
+  thresholdPenaltyDuration: 24 * hour,
 }
 
 export const defaultAutoLockTime = 5

--- a/packages/legacy/core/App/constants.ts
+++ b/packages/legacy/core/App/constants.ts
@@ -44,7 +44,8 @@ export const walletTimeout = minute * 5
 
 /* lockout attempt rules: The base rules apply the lockout at a specified number of incorrect attempts,
  and the threshold rules apply the lockout penalty to each attempt after the threshold that falls on the attemptIncrement.
- (In this case the threshold rule applies to every 5th incorrect login after 20)
+ (In this case the threshold rule applies to every 5th incorrect login after 20).
+ Keys need to be multiples of the attemptIncrement in the attemptLockoutThresholdRules.
 5 incorrect => 1 minute lockout
 10 incorrect => 10 minute lockout
 15 incorrect => 1 hour lockout
@@ -58,7 +59,7 @@ export const attemptLockoutBaseRules: Record<number, number | undefined> = {
 export const attemptLockoutThresholdRules = {
   attemptThreshold: 20,
   attemptIncrement: 5,
-  attemptPenalty: 24 * hour,
+  attemptThresholdPenalty: 24 * hour,
 }
 
 export const defaultAutoLockTime = 5

--- a/packages/legacy/core/App/index.ts
+++ b/packages/legacy/core/App/index.ts
@@ -50,7 +50,7 @@ import * as types from './types'
 import Scan from './screens/Scan'
 import Onboarding from './screens/Onboarding'
 import { DefaultScreenOptionsDictionary, useDefaultStackOptions } from './navigators/defaultStackOptions'
-import { PINRules, walletTimeout } from './constants'
+import { PINRules, walletTimeout, attemptLockoutBaseRules, attemptLockoutThresholdRules } from './constants'
 import { CredentialListFooterProps } from './types/credential-list-footer'
 import { OpenIDCredentialRecordProvider } from './modules/openid/context/OpenIDCredentialRecordProvider'
 import { defaultConfig, defaultHistoryEventsLogger } from './container-impl'
@@ -83,7 +83,13 @@ export { BifoldError } from './types/error'
 export { EventTypes } from './constants'
 export { migrateToAskar } from './utils/migration'
 export { createLinkSecretIfRequired, getAgentModules } from './utils/agent'
-export { removeExistingInvitationIfRequired, connectFromScanOrDeepLink, formatTime, useCredentialConnectionLabel, getConnectionName } from './utils/helpers'
+export {
+  removeExistingInvitationIfRequired,
+  connectFromScanOrDeepLink,
+  formatTime,
+  useCredentialConnectionLabel,
+  getConnectionName,
+} from './utils/helpers'
 export { isValidAnonCredsCredential, getCredentialIdentifiers } from './utils/credential'
 export { buildFieldsFromAnonCredsCredential } from './utils/oca'
 
@@ -195,6 +201,8 @@ export {
   BulletPoint,
   PINRules,
   walletTimeout,
+  attemptLockoutBaseRules,
+  attemptLockoutThresholdRules,
   DefaultScreenOptionsDictionary,
   DefaultScreenLayoutOptions,
 }

--- a/packages/legacy/core/App/index.ts
+++ b/packages/legacy/core/App/index.ts
@@ -50,7 +50,7 @@ import * as types from './types'
 import Scan from './screens/Scan'
 import Onboarding from './screens/Onboarding'
 import { DefaultScreenOptionsDictionary, useDefaultStackOptions } from './navigators/defaultStackOptions'
-import { PINRules, walletTimeout, tours, attemptLockoutBaseRules, attemptLockoutThresholdRules } from './constants'
+import { PINRules, walletTimeout, tours, attemptLockoutConfig } from './constants'
 import { CredentialListFooterProps } from './types/credential-list-footer'
 import { OpenIDCredentialRecordProvider } from './modules/openid/context/OpenIDCredentialRecordProvider'
 import { defaultConfig, defaultHistoryEventsLogger } from './container-impl'
@@ -203,8 +203,7 @@ export {
   BulletPoint,
   PINRules,
   walletTimeout,
-  attemptLockoutBaseRules,
-  attemptLockoutThresholdRules,
+  attemptLockoutConfig as attemptLockoutConfig,
   tours,
   DefaultScreenOptionsDictionary,
   DefaultScreenLayoutOptions,

--- a/packages/legacy/core/App/index.ts
+++ b/packages/legacy/core/App/index.ts
@@ -203,7 +203,7 @@ export {
   BulletPoint,
   PINRules,
   walletTimeout,
-  attemptLockoutConfig as attemptLockoutConfig,
+  attemptLockoutConfig,
   tours,
   DefaultScreenOptionsDictionary,
   DefaultScreenLayoutOptions,

--- a/packages/legacy/core/App/screens/PINEnter.tsx
+++ b/packages/legacy/core/App/screens/PINEnter.tsx
@@ -47,15 +47,7 @@ const PINEnter: React.FC<PINEnterProps> = ({ setAuthenticated, usage = PINEntryU
   const { ButtonLoading } = useAnimatedComponents()
   const [
     logger,
-    {
-      enableHiddenDevModeTrigger,
-      attemptLockoutConfig: {
-        baseRules,
-        baseRulesIncrement,
-        threshold,
-        thresholdPenaltyDuration,
-      } = attemptLockoutConfig,
-    },
+    { enableHiddenDevModeTrigger, attemptLockoutConfig: { baseRules, thresholdRules } = attemptLockoutConfig },
   ] = useServices([TOKENS.UTIL_LOGGER, TOKENS.CONFIG])
   const developerOptionCount = useRef(0)
   const touchCountToEnableBiometrics = 9
@@ -193,12 +185,12 @@ const PINEnter: React.FC<PINEnterProps> = ({ setAuthenticated, usage = PINEntryU
   const getLockoutPenalty = useCallback(
     (attempts: number): number | undefined => {
       let penalty = baseRules[attempts]
-      if (!penalty && attempts >= threshold && !(attempts % baseRulesIncrement)) {
-        penalty = thresholdPenaltyDuration
+      if (!penalty && attempts >= thresholdRules.threshold && !(attempts % thresholdRules.increment)) {
+        penalty = thresholdRules.thresholdPenaltyDuration
       }
       return penalty
     },
-    [baseRules, baseRulesIncrement, threshold, thresholdPenaltyDuration]
+    [baseRules, thresholdRules]
   )
 
   const loadWalletCredentials = useCallback(async () => {
@@ -277,7 +269,8 @@ const PINEnter: React.FC<PINEnterProps> = ({ setAuthenticated, usage = PINEntryU
         if (!result) {
           const newAttempt = store.loginAttempt.loginAttempts + 1
 
-          const attemptsLeft = (baseRulesIncrement - (newAttempt % baseRulesIncrement)) % baseRulesIncrement
+          const attemptsLeft =
+            (thresholdRules.increment - (newAttempt % thresholdRules.increment)) % thresholdRules.increment
 
           if (!inlineMessages.enabled && !getLockoutPenalty(newAttempt)) {
             // skip displaying modals if we are going to lockout
@@ -357,7 +350,7 @@ const PINEnter: React.FC<PINEnterProps> = ({ setAuthenticated, usage = PINEntryU
       t,
       attemptLockout,
       inlineMessages,
-      baseRulesIncrement,
+      thresholdRules.increment,
     ]
   )
 

--- a/packages/legacy/core/App/screens/PINEnter.tsx
+++ b/packages/legacy/core/App/screens/PINEnter.tsx
@@ -10,10 +10,10 @@ import PopupModal from '../components/modals/PopupModal'
 import KeyboardView from '../components/views/KeyboardView'
 import {
   minPINLength,
-  attemptLockoutBaseRules,
-  attemptLockoutThresholdRules,
   EventTypes,
   defaultAutoLockTime,
+  attemptLockoutBaseRules as defaultAttemptLockoutBaseRules,
+  attemptLockoutThresholdRules as defaultAttemptLockoutThresholdRules,
 } from '../constants'
 import { TOKENS, useServices } from '../container-api'
 import { useAnimatedComponents } from '../contexts/animated-components'
@@ -51,7 +51,16 @@ const PINEnter: React.FC<PINEnterProps> = ({ setAuthenticated, usage = PINEntryU
   const [biometricsEnrollmentChange, setBiometricsEnrollmentChange] = useState<boolean>(false)
   const { ColorPallet, TextTheme, Assets, PINEnterTheme } = useTheme()
   const { ButtonLoading } = useAnimatedComponents()
-  const [logger, { enableHiddenDevModeTrigger }] = useServices([TOKENS.UTIL_LOGGER, TOKENS.CONFIG])
+  const [
+    logger,
+    {
+      enableHiddenDevModeTrigger,
+      attemptLockoutConfig: { attemptLockoutBaseRules, attemptLockoutThresholdRules } = {
+        attemptLockoutBaseRules: defaultAttemptLockoutBaseRules,
+        attemptLockoutThresholdRules: defaultAttemptLockoutThresholdRules,
+      },
+    },
+  ] = useServices([TOKENS.UTIL_LOGGER, TOKENS.CONFIG])
   const developerOptionCount = useRef(0)
   const touchCountToEnableBiometrics = 9
   const [inlineMessageField, setInlineMessageField] = useState<InlineMessageProps>()
@@ -168,7 +177,11 @@ const PINEnter: React.FC<PINEnterProps> = ({ setAuthenticated, usage = PINEntryU
       dispatch({
         type: DispatchAction.ATTEMPT_UPDATED,
         payload: [
-          { loginAttempts: store.loginAttempt.loginAttempts, lockoutDate: Date.now() + penalty, servedPenalty: false },
+          {
+            loginAttempts: store.loginAttempt.loginAttempts + 1,
+            lockoutDate: Date.now() + penalty,
+            servedPenalty: false,
+          },
         ],
       })
       navigation.dispatch(
@@ -178,20 +191,23 @@ const PINEnter: React.FC<PINEnterProps> = ({ setAuthenticated, usage = PINEntryU
         })
       )
     },
-    [dispatch, store.loginAttempt.loginAttempts, navigation]
+    [dispatch, navigation, store.loginAttempt.loginAttempts]
   )
 
-  const getLockoutPenalty = useCallback((attempts: number): number | undefined => {
-    let penalty = attemptLockoutBaseRules[attempts]
-    if (
-      !penalty &&
-      attempts >= attemptLockoutThresholdRules.attemptThreshold &&
-      !(attempts % attemptLockoutThresholdRules.attemptIncrement)
-    ) {
-      penalty = attemptLockoutThresholdRules.attemptPenalty
-    }
-    return penalty
-  }, [])
+  const getLockoutPenalty = useCallback(
+    (attempts: number): number | undefined => {
+      let penalty = attemptLockoutBaseRules[attempts]
+      if (
+        !penalty &&
+        attempts >= attemptLockoutThresholdRules.attemptThreshold &&
+        !(attempts % attemptLockoutThresholdRules.attemptIncrement)
+      ) {
+        penalty = attemptLockoutThresholdRules.attemptThresholdPenalty
+      }
+      return penalty
+    },
+    [attemptLockoutBaseRules, attemptLockoutThresholdRules]
+  )
 
   const loadWalletCredentials = useCallback(async () => {
     if (usage === PINEntryUsage.PINCheck) {
@@ -246,16 +262,10 @@ const PINEnter: React.FC<PINEnterProps> = ({ setAuthenticated, usage = PINEntryU
   useEffect(() => {
     // check number of login attempts and determine if app should apply lockout
     const attempts = store.loginAttempt.loginAttempts
-    const penalty = getLockoutPenalty(attempts)
-    if (penalty && !store.loginAttempt.servedPenalty) {
-      // only apply lockout if user has not served their penalty
-      attemptLockout(penalty)
-    }
-
     // display warning if we are one away from a lockout
     const displayWarning = !!getLockoutPenalty(attempts + 1)
     setDisplayLockoutWarning(displayWarning)
-  }, [store.loginAttempt.loginAttempts, getLockoutPenalty, store.loginAttempt.servedPenalty, attemptLockout])
+  }, [store.loginAttempt.loginAttempts, getLockoutPenalty])
 
   useEffect(() => {
     setInlineMessageField(undefined)
@@ -274,7 +284,12 @@ const PINEnter: React.FC<PINEnterProps> = ({ setAuthenticated, usage = PINEntryU
 
         if (!result) {
           const newAttempt = store.loginAttempt.loginAttempts + 1
-          const attemptsLeft = attemptLockoutThresholdRules.attemptIncrement - newAttempt
+
+          const attemptsLeft =
+            (attemptLockoutThresholdRules.attemptIncrement -
+              (newAttempt % attemptLockoutThresholdRules.attemptIncrement)) %
+            attemptLockoutThresholdRules.attemptIncrement
+
           if (!inlineMessages.enabled && !getLockoutPenalty(newAttempt)) {
             // skip displaying modals if we are going to lockout
             setAlertModalVisible(true)
@@ -353,6 +368,7 @@ const PINEnter: React.FC<PINEnterProps> = ({ setAuthenticated, usage = PINEntryU
       t,
       attemptLockout,
       inlineMessages,
+      attemptLockoutThresholdRules.attemptIncrement,
     ]
   )
 

--- a/packages/legacy/core/App/types/attempt-lockout-config.ts
+++ b/packages/legacy/core/App/types/attempt-lockout-config.ts
@@ -1,6 +1,8 @@
 export type AttemptLockoutConfig = {
   baseRules: Record<number, number | undefined>
-  baseRulesIncrement: number
-  threshold: number
-  thresholdPenaltyDuration: number
+  thresholdRules: {
+    threshold: number
+    increment: number
+    thresholdPenaltyDuration: number
+  }
 }

--- a/packages/legacy/core/App/types/attempt-lockout-config.ts
+++ b/packages/legacy/core/App/types/attempt-lockout-config.ts
@@ -1,0 +1,6 @@
+export type AttemptLockoutConfig = {
+  baseRules: Record<number, number | undefined>
+  baseRulesIncrement: number
+  threshold: number
+  thresholdPenaltyDuration: number
+}

--- a/packages/legacy/core/App/types/config.ts
+++ b/packages/legacy/core/App/types/config.ts
@@ -1,4 +1,5 @@
 import { Locales } from '../localization'
+import { AttemptLockoutConfig } from './attempt-lockout-config'
 import { ContactDetailsOptionsParams } from './contact-details'
 import { PINSecurityParams } from './security'
 import { SettingSection } from './settings'
@@ -40,14 +41,7 @@ export interface Config {
   disableContactsInSettings?: boolean
   disableMediatorCheck?: boolean
   internetReachabilityUrls: string[]
-  attemptLockoutConfig?: {
-    attemptLockoutBaseRules: Record<number, number | undefined>
-    attemptLockoutThresholdRules: {
-      attemptThreshold: number
-      attemptIncrement: number
-      attemptThresholdPenalty: number
-    }
-  }
+  attemptLockoutConfig?: AttemptLockoutConfig
 }
 
 export interface HistoryEventsLoggerConfig {

--- a/packages/legacy/core/App/types/config.ts
+++ b/packages/legacy/core/App/types/config.ts
@@ -40,6 +40,14 @@ export interface Config {
   disableContactsInSettings?: boolean
   disableMediatorCheck?: boolean
   internetReachabilityUrls: string[]
+  attemptLockoutConfig?: {
+    attemptLockoutBaseRules: Record<number, number | undefined>
+    attemptLockoutThresholdRules: {
+      attemptThreshold: number
+      attemptIncrement: number
+      attemptThresholdPenalty: number
+    }
+  }
 }
 
 export interface HistoryEventsLoggerConfig {


### PR DESCRIPTION
# Summary of Changes

This PR makes the attempt lockout rules injectable in the Config interface. The default values are as seen in the `constants.ts` file. If a wallet decides to make their own rules, the attemptLockoutBaseRules keys need to be multiples of the attemptLockoutThresholdRules.attemptIncrement.

# Screenshots, videos, or gifs

N/A

# Breaking change guide

N/A

# Related Issues

This also fixes an issue where after the first 5 tries, the user gets locked out for 1 minute. After the user has served the 1 minute penalty, they can try again. But then if they make the wrong PIN, they get locked out right away and the penalty doesn't increase (it stays locked for 1 minute).

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [ ] If applicable, screenshots, gifs, or video are included for UI changes
- [ ] If applicable, breaking changes are described above along with how to address them
- [ ] Updated documentation as needed for changed code and new or modified features
- [ ] Added sufficient [tests](../packages/legacy/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed

