### PR TITLE
fix: credential details metadata

### DIFF
--- a/packages/legacy/core/App/screens/CredentialDetails.tsx
+++ b/packages/legacy/core/App/screens/CredentialDetails.tsx
@@ -218,6 +218,7 @@ const CredentialDetails: React.FC<CredentialDetailsProps> = ({ navigation, route
   }, [])
 
   const callDismissRevokedMessage = useCallback(() => {
+    setIsRevokedMessageHidden(true)
     if (credential) {
       const meta = credential.metadata.get(CredentialMetadata.customMetadata)
       credential.metadata.set(CredentialMetadata.customMetadata, { ...meta, revoked_detail_dismissed: true })

--- a/packages/legacy/core/App/screens/CredentialDetails.tsx
+++ b/packages/legacy/core/App/screens/CredentialDetails.tsx
@@ -65,6 +65,11 @@ const CredentialDetails: React.FC<CredentialDetailsProps> = ({ navigation, route
   )
 
   useEffect(() => {
+    setIsRevokedMessageHidden((credential?.metadata.get(CredentialMetadata.customMetadata) as credentialCustomMetadata)
+    ?.revoked_detail_dismissed ?? false)
+  }, [credential?.metadata])
+
+  useEffect(() => {
     // fetch credential for ID
     const fetchCredential = async () => {
       try {
@@ -213,7 +218,6 @@ const CredentialDetails: React.FC<CredentialDetailsProps> = ({ navigation, route
   }, [])
 
   const callDismissRevokedMessage = useCallback(() => {
-    setIsRevokedMessageHidden(true)
     if (credential) {
       const meta = credential.metadata.get(CredentialMetadata.customMetadata)
       credential.metadata.set(CredentialMetadata.customMetadata, { ...meta, revoked_detail_dismissed: true })


### PR DESCRIPTION
# Summary of Changes

The "RevokedMessage" is hidden when dismissed, but it reappears when returning to the credentialDetails page. This fix ensures the message remains properly hidden after dismissal, even upon page navigation.

# Screenshots, videos, or gifs

N/A

# Breaking change guide

N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [ ] If applicable, screenshots, gifs, or video are included for UI changes
- [ ] If applicable, breaking changes are described above along with how to address them
- [ ] Updated documentation as needed for changed code and new or modified features
- [ ] Added sufficient [tests](../packages/legacy/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed

