### PR TITLE
fix: decline proof

### DIFF
--- a/packages/legacy/core/App/components/listItems/NotificationListItem.tsx
+++ b/packages/legacy/core/App/components/listItems/NotificationListItem.tsx
@@ -163,6 +163,11 @@ const NotificationListItem: React.FC<NotificationListItemProps> = ({
     try {
       const proofId = (notification as ProofExchangeRecord).id
       if (agent) {
+        const connection = await agent.connections.findById(proofId)
+        if (connection) {
+          await agent.proofs.sendProblemReport({ proofRecordId: proofId, description: t('ProofRequest.Declined') })
+        }
+
         await agent.proofs.declineRequest({ proofRecordId: proofId })
       }
     } catch (err: unknown) {
@@ -268,11 +273,11 @@ const NotificationListItem: React.FC<NotificationListItemProps> = ({
 
           // message.comment is the common fallback title for both v1 and v2 proof requests
           let body: string = message?.comment ?? ''
-          
+
           if (message instanceof V1RequestPresentationMessage) {
             body = message.indyProofRequest?.name ?? body
           }
-          
+
           if (message instanceof V2RequestPresentationMessage) {
             // workaround for getting proof request name in v2 proof request
             // https://github.com/openwallet-foundation/credo-ts/blob/5f08bc67e3d1cc0ab98e7cce7747fedd2bf71ec1/packages/core/src/modules/proofs/protocol/v2/messages/V2RequestPresentationMessage.ts#L78

--- a/packages/legacy/core/App/components/listItems/NotificationListItem.tsx
+++ b/packages/legacy/core/App/components/listItems/NotificationListItem.tsx
@@ -161,14 +161,20 @@ const NotificationListItem: React.FC<NotificationListItemProps> = ({
 
   const declineProofRequest = useCallback(async () => {
     try {
-      const proofId = (notification as ProofExchangeRecord).id
-      if (agent) {
-        const connection = await agent.connections.findById(proofId)
+      const proofRecord = notification as ProofExchangeRecord
+
+      if (agent && proofRecord) {
+        const connectionId = proofRecord.connectionId ?? ''
+        const connection = await agent.connections.findById(connectionId)
+
         if (connection) {
-          await agent.proofs.sendProblemReport({ proofRecordId: proofId, description: t('ProofRequest.Declined') })
+          await agent.proofs.sendProblemReport({
+            proofRecordId: proofRecord.id,
+            description: t('ProofRequest.Declined'),
+          })
         }
 
-        await agent.proofs.declineRequest({ proofRecordId: proofId })
+        await agent.proofs.declineRequest({ proofRecordId: proofRecord.id })
       }
     } catch (err: unknown) {
       const error = new BifoldError(t('Error.Title1028'), t('Error.Message1028'), (err as Error)?.message ?? err, 1028)

--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -561,10 +561,15 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, proofId }) => {
   const handleDeclineTouched = useCallback(async () => {
     try {
       if (agent && proof) {
-        await agent.proofs.sendProblemReport({ proofRecordId: proof.id, description: t('ProofRequest.Declined') })
+        const connection = await agent.connections.findById(proof.id)
+        if (connection) {
+          await agent.proofs.sendProblemReport({ proofRecordId: proof.id, description: t('ProofRequest.Declined') })
+        }
+
         await agent.proofs.declineRequest({ proofRecordId: proof.id })
 
         if (proof.connectionId && goalCode && goalCode.endsWith('verify.once')) {
+          console.log('******* REM C3', proofId, proof.id)
           agent.connections.deleteById(proof.connectionId)
         }
       }
@@ -714,7 +719,7 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, proofId }) => {
             {t('ProofRequest.SensitiveInformation')}
           </InfoTextBox>
         )}
-        {(!loading && proofConnectionLabel && goalCode === 'aries.vc.verify') && (
+        {!loading && proofConnectionLabel && goalCode === 'aries.vc.verify' && (
           <ConnectionAlert connectionID={proofConnectionLabel} />
         )}
         {!loading && isShareDisabled() ? (

--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -569,7 +569,6 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, proofId }) => {
         await agent.proofs.declineRequest({ proofRecordId: proof.id })
 
         if (proof.connectionId && goalCode && goalCode.endsWith('verify.once')) {
-          console.log('******* REM C3', proofId, proof.id)
           agent.connections.deleteById(proof.connectionId)
         }
       }

--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -561,15 +561,17 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, proofId }) => {
   const handleDeclineTouched = useCallback(async () => {
     try {
       if (agent && proof) {
-        const connection = await agent.connections.findById(proof.id)
+        const connectionId = proof.connectionId ?? ''
+        const connection = await agent.connections.findById(connectionId)
+
         if (connection) {
           await agent.proofs.sendProblemReport({ proofRecordId: proof.id, description: t('ProofRequest.Declined') })
         }
 
         await agent.proofs.declineRequest({ proofRecordId: proof.id })
 
-        if (proof.connectionId && goalCode && goalCode.endsWith('verify.once')) {
-          agent.connections.deleteById(proof.connectionId)
+        if (connectionId && goalCode && goalCode.endsWith('verify.once')) {
+          agent.connections.deleteById(connectionId)
         }
       }
     } catch (err: unknown) {


### PR DESCRIPTION
# Summary of Changes

This pull request fixes a bug that occurred when declining a proof request from a notification. If the contact associated with that proof request had their connection deleted, the app would throw a visible error.  This happened because the app tried to send a problem report related to the declined proof, but sending a problem report requires an active connection, which no longer existed.  This change prevents that error from occurring.

# Screenshots, videos, or gifs

n/a

# Breaking change guide

n/a

# Related Issues

n/a

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] Updated documentation as needed for changed code and new or modified features
- [x] Added sufficient [tests](../packages/legacy/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed

