### PR TITLE
fix: disable header elements and bottom nav for TalkBack during tours

### DIFF
--- a/packages/legacy/core/App/components/buttons/HeaderHome.tsx
+++ b/packages/legacy/core/App/components/buttons/HeaderHome.tsx
@@ -1,20 +1,29 @@
 import { useNavigation } from '@react-navigation/native'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Screens, TabStacks } from '../../types/navigators'
 import { testIdWithKey } from '../../utils/testable'
 
 import IconButton, { ButtonLocation } from './IconButton'
+import { useTour } from '../../contexts/tour/tour-context'
+import { ImportantForAccessibility } from '../../types/accessibility'
 
 const HeaderRightHome: React.FC = () => {
   const { t } = useTranslation()
   const navigation = useNavigation()
+  const { currentStep } = useTour()
+  const [hideElements, setHideElements] = useState<ImportantForAccessibility>('auto')
+
+  useEffect(() => {
+    setHideElements(currentStep === undefined ? 'auto' : 'no-hide-descendants')
+  }, [currentStep])
 
   return (
     <IconButton
       buttonLocation={ButtonLocation.Right}
       accessibilityLabel={t('Global.Home')}
+      importantForAccessibility={hideElements}
       testID={testIdWithKey('HomeButton')}
       onPress={() => navigation.getParent()?.navigate(TabStacks.HomeStack, { screen: Screens.Home })}
       icon="home"

--- a/packages/legacy/core/App/components/buttons/IconButton.tsx
+++ b/packages/legacy/core/App/components/buttons/IconButton.tsx
@@ -4,6 +4,7 @@ import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
 import { hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
+import { ImportantForAccessibility } from '../../types/accessibility'
 
 const defaultIconSize = 26
 
@@ -15,6 +16,7 @@ export enum ButtonLocation {
 interface IconButtonProps {
   buttonLocation: ButtonLocation
   accessibilityLabel: string
+  importantForAccessibility: ImportantForAccessibility
   testID: string
   onPress: () => void
   icon: string
@@ -27,6 +29,7 @@ const IconButton: React.FC<IconButtonProps> = ({
   icon,
   text,
   accessibilityLabel,
+  importantForAccessibility,
   testID,
   onPress,
   iconTintColor,
@@ -74,6 +77,7 @@ const IconButton: React.FC<IconButtonProps> = ({
     <Pressable
       accessibilityLabel={accessibilityLabel}
       accessibilityRole={'button'}
+      importantForAccessibility={importantForAccessibility}
       testID={testID}
       onPress={onPress}
       hitSlop={hitSlop}

--- a/packages/legacy/core/App/components/buttons/InfoIcon.tsx
+++ b/packages/legacy/core/App/components/buttons/InfoIcon.tsx
@@ -20,6 +20,7 @@ const InfoIcon: React.FC<InfoIconProps> = ({ connectionId }) => {
     <IconButton
       buttonLocation={ButtonLocation.Right}
       accessibilityLabel={t('Screens.Settings')}
+      importantForAccessibility="auto"
       testID={testIdWithKey('Settings')}
       onPress={() =>
         navigation.navigate(Stacks.ContactStack, {

--- a/packages/legacy/core/App/components/buttons/SettingsMenu.tsx
+++ b/packages/legacy/core/App/components/buttons/SettingsMenu.tsx
@@ -1,21 +1,31 @@
 import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { RootStackParams, Screens, Stacks } from '../../types/navigators'
 import { testIdWithKey } from '../../utils/testable'
 
 import IconButton, { ButtonLocation } from './IconButton'
+import { useTour } from '../../contexts/tour/tour-context'
+import { ImportantForAccessibility } from '../../types/accessibility'
 
 const SettingsMenu: React.FC = () => {
   const navigation = useNavigation<StackNavigationProp<RootStackParams>>()
   const { t } = useTranslation()
 
+  const { currentStep } = useTour()
+  const [hideElements, setHideElements] = useState<ImportantForAccessibility>('auto')
+
+  useEffect(() => {
+    setHideElements(currentStep === undefined ? 'auto' : 'no-hide-descendants')
+  }, [currentStep])
+
   return (
     <IconButton
       buttonLocation={ButtonLocation.Left}
       accessibilityLabel={t('Screens.Settings')}
+      importantForAccessibility={hideElements}
       testID={testIdWithKey('Settings')}
       onPress={() => navigation.navigate(Stacks.SettingStack, { screen: Screens.Settings })}
       icon="menu"

--- a/packages/legacy/core/App/components/misc/NewQRView.tsx
+++ b/packages/legacy/core/App/components/misc/NewQRView.tsx
@@ -141,6 +141,7 @@ const NewQRView: React.FC<Props> = ({ defaultToConnect, handleCodeScan, error, e
       <IconButton
         buttonLocation={ButtonLocation.Right}
         accessibilityLabel={t('Global.Share')}
+        importantForAccessibility="auto"
         testID={testIdWithKey('ShareButton')}
         onPress={() => {
           Share.share({ message: invitation ?? '' })
@@ -155,6 +156,7 @@ const NewQRView: React.FC<Props> = ({ defaultToConnect, handleCodeScan, error, e
         <IconButton
           buttonLocation={ButtonLocation.Right}
           accessibilityLabel={t('Global.Share')}
+          importantForAccessibility="auto"
           testID={testIdWithKey('ShareButton')}
           onPress={() => {
             navigation.navigate(Screens.PasteUrl)
@@ -315,6 +317,7 @@ const NewQRView: React.FC<Props> = ({ defaultToConnect, handleCodeScan, error, e
                   <IconButton
                     buttonLocation={ButtonLocation.Right}
                     accessibilityLabel={t('NameWallet.EditWalletName')}
+                    importantForAccessibility="auto"
                     testID={testIdWithKey('EditWalletName')}
                     onPress={handleEdit}
                     icon={'pencil'}

--- a/packages/legacy/core/App/components/texts/HeaderTitle.tsx
+++ b/packages/legacy/core/App/components/texts/HeaderTitle.tsx
@@ -1,7 +1,9 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Text, StyleSheet } from 'react-native'
 
 import { useTheme } from '../../contexts/theme'
+import { ImportantForAccessibility } from '../../types/accessibility'
+import { useTour } from '../../contexts/tour/tour-context'
 
 interface Props {
   children: React.ReactNode
@@ -11,15 +13,25 @@ interface Props {
 // https://reactnavigation.org/docs/native-stack-navigator#headertitle
 const HeaderTitle: React.FC<Props> = ({ children }) => {
   const { TextTheme } = useTheme()
+  const { currentStep } = useTour()
+  const [hideElements, setHideElements] = useState<ImportantForAccessibility>('auto')
   const styles = StyleSheet.create({
     title: {
       ...TextTheme.headerTitle,
       textAlign: 'center',
     },
   })
-
+  useEffect(() => {
+    setHideElements(currentStep === undefined ? 'auto' : 'no-hide-descendants')
+  }, [currentStep])
   return (
-    <Text accessibilityRole="header" numberOfLines={1} ellipsizeMode="tail" style={styles.title}>
+    <Text
+      accessibilityRole="header"
+      numberOfLines={1}
+      ellipsizeMode="tail"
+      style={styles.title}
+      importantForAccessibility={hideElements}
+    >
       {children}
     </Text>
   )

--- a/packages/legacy/core/App/modules/history/ui/components/HistoryMenu.tsx
+++ b/packages/legacy/core/App/modules/history/ui/components/HistoryMenu.tsx
@@ -15,6 +15,7 @@ const HistoryMenu: React.FC = () => {
     <IconButton
       buttonLocation={ButtonLocation.Right}
       accessibilityLabel={t('Screens.Settings')}
+      importantForAccessibility="auto"
       testID={testIdWithKey('Settings')}
       onPress={() => navigation.navigate(Stacks.HistoryStack, { screen: Screens.HistoryPage })}
       icon="history"

--- a/packages/legacy/core/App/navigators/MainStack.tsx
+++ b/packages/legacy/core/App/navigators/MainStack.tsx
@@ -72,6 +72,7 @@ const MainStack: React.FC = () => {
             <IconButton
               buttonLocation={ButtonLocation.Left}
               accessibilityLabel={t('Global.Back')}
+              importantForAccessibility="auto"
               testID={testIdWithKey('BackButton')}
               onPress={() => {
                 navigation.navigate(TabStacks.HomeStack, { screen: Screens.Home })

--- a/packages/legacy/core/App/navigators/ProofRequestStack.tsx
+++ b/packages/legacy/core/App/navigators/ProofRequestStack.tsx
@@ -32,7 +32,7 @@ const ProofRequestStack: React.FC = () => {
         component={ListProofRequests}
         options={{
           title: t('Screens.ChooseProofRequest'),
-          ...ScreenOptionsDictionary[Screens.ProofRequest]
+          ...ScreenOptionsDictionary[Screens.ProofRequest],
         }}
       />
       <Stack.Screen
@@ -40,7 +40,7 @@ const ProofRequestStack: React.FC = () => {
         component={ProofRequestDetails}
         options={() => ({
           title: '',
-          ...ScreenOptionsDictionary[Screens.ProofRequestDetails]
+          ...ScreenOptionsDictionary[Screens.ProofRequestDetails],
         })}
       />
       <Stack.Screen
@@ -53,7 +53,7 @@ const ProofRequestStack: React.FC = () => {
         component={ProofChangeCredential}
         options={{
           title: t('Screens.ProofChangeCredential'),
-          ...ScreenOptionsDictionary[Screens.ProofChangeCredential]
+          ...ScreenOptionsDictionary[Screens.ProofChangeCredential],
         }}
       ></Stack.Screen>
       <Stack.Screen
@@ -65,12 +65,13 @@ const ProofRequestStack: React.FC = () => {
             <IconButton
               buttonLocation={ButtonLocation.Left}
               accessibilityLabel={t('Global.Back')}
+              importantForAccessibility="auto"
               testID={testIdWithKey('BackButton')}
               onPress={() => navigation.navigate(Screens.ProofRequests, {})}
               icon="arrow-left"
             />
           ),
-          ...ScreenOptionsDictionary[Screens.ProofRequesting]
+          ...ScreenOptionsDictionary[Screens.ProofRequesting],
         })}
       />
       <Stack.Screen
@@ -82,6 +83,7 @@ const ProofRequestStack: React.FC = () => {
             <IconButton
               buttonLocation={ButtonLocation.Left}
               accessibilityLabel={t('Global.Back')}
+              importantForAccessibility="auto"
               testID={testIdWithKey('BackButton')}
               onPress={() => {
                 if (route.params.isHistory) {
@@ -94,7 +96,7 @@ const ProofRequestStack: React.FC = () => {
             />
           ),
           headerRight: () => <HeaderRightHome />,
-          ...ScreenOptionsDictionary[Screens.ProofDetails]
+          ...ScreenOptionsDictionary[Screens.ProofDetails],
         })}
       />
       <Stack.Screen
@@ -103,7 +105,7 @@ const ProofRequestStack: React.FC = () => {
         options={() => ({
           title: t('Screens.ProofRequestUsageHistory'),
           headerRight: () => <HeaderRightHome />,
-          ...ScreenOptionsDictionary[Screens.ProofRequestUsageHistory]
+          ...ScreenOptionsDictionary[Screens.ProofRequestUsageHistory],
         })}
       />
     </Stack.Navigator>

--- a/packages/legacy/core/App/navigators/TabStack.tsx
+++ b/packages/legacy/core/App/navigators/TabStack.tsx
@@ -21,10 +21,12 @@ import { BifoldError } from '../types/error'
 import { Screens, Stacks, TabStackParams, TabStacks } from '../types/navigators'
 import { connectFromScanOrDeepLink } from '../utils/helpers'
 import { testIdWithKey } from '../utils/testable'
+import { ImportantForAccessibility } from '../types/accessibility'
 
 import CredentialStack from './CredentialStack'
 import HomeStack from './HomeStack'
 import { BaseTourID } from '../types/tour'
+import { useTour } from '../contexts/tour/tour-context'
 
 const TabStack: React.FC = () => {
   const { fontScale } = useWindowDimensions()
@@ -40,7 +42,9 @@ const TabStack: React.FC = () => {
   const { ColorPallet, TabTheme, TextTheme } = useTheme()
   const [orientation, setOrientation] = useState(OrientationType.PORTRAIT)
   const [store, dispatch] = useStore()
+  const { currentStep } = useTour()
   const { agent } = useAgent()
+  const [hideElements, setHideElements] = useState<ImportantForAccessibility>('auto')
   const navigation = useNavigation<StackNavigationProp<TabStackParams>>()
   const showLabels = fontScale * TabTheme.tabBarTextStyle.fontSize < 18
   const styles = StyleSheet.create({
@@ -103,13 +107,20 @@ const TabStack: React.FC = () => {
   )
 
   useEffect(() => {
+    setHideElements(currentStep === undefined ? 'auto' : 'no-hide-descendants')
+  }, [currentStep])
+
+  useEffect(() => {
     if (store.deepLink && agent && store.authentication.didAuthenticate) {
       handleDeepLink(store.deepLink)
     }
   }, [store.deepLink, agent, store.authentication.didAuthenticate, handleDeepLink])
 
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: ColorPallet.brand.primary }}>
+    <SafeAreaView
+      style={{ flex: 1, backgroundColor: ColorPallet.brand.primary }}
+      importantForAccessibility={hideElements}
+    >
       <Tab.Navigator
         initialRouteName={TabStacks.HomeStack}
         screenOptions={{

--- a/packages/legacy/core/App/screens/ListContacts.tsx
+++ b/packages/legacy/core/App/screens/ListContacts.tsx
@@ -26,7 +26,7 @@ const ListContacts: React.FC<ListContactsProps> = ({ navigation }) => {
   const { t } = useTranslation()
   const { agent } = useAgent()
   const [connections, setConnections] = useState<ConnectionRecord[]>([])
-  const {records: connectionRecords} = useConnections()
+  const { records: connectionRecords } = useConnections()
   const [store] = useStore()
   const [{ contactHideList }, ContactListItem] = useServices([TOKENS.CONFIG, TOKENS.COMPONENT_CONTACT_LIST_ITEM])
   const style = StyleSheet.create({
@@ -77,6 +77,7 @@ const ListContacts: React.FC<ListContactsProps> = ({ navigation }) => {
           <IconButton
             buttonLocation={ButtonLocation.Right}
             accessibilityLabel={t('Contacts.AddContact')}
+            importantForAccessibility="auto"
             testID={testIdWithKey('AddContact')}
             onPress={onPressAddContact}
             icon="plus-circle-outline"

--- a/packages/legacy/core/App/screens/Onboarding.tsx
+++ b/packages/legacy/core/App/screens/Onboarding.tsx
@@ -104,6 +104,7 @@ const Onboarding: React.FC<OnboardingProps> = ({
           <IconButton
             buttonLocation={ButtonLocation.Right}
             accessibilityLabel={t('Onboarding.SkipA11y')}
+            importantForAccessibility="auto"
             testID={testIdWithKey('Skip')}
             onPress={onSkipTouched}
             icon="chevron-right"

--- a/packages/legacy/core/App/screens/ProofRequesting.tsx
+++ b/packages/legacy/core/App/screens/ProofRequesting.tsx
@@ -164,6 +164,7 @@ const ProofRequesting: React.FC<ProofRequestingProps> = ({ route, navigation }) 
         <IconButton
           buttonLocation={ButtonLocation.Right}
           accessibilityLabel={t('Global.Share')}
+          importantForAccessibility="auto"
           testID={testIdWithKey('ShareButton')}
           onPress={() => {
             Share.share({ message })

--- a/packages/legacy/core/App/screens/Settings.tsx
+++ b/packages/legacy/core/App/screens/Settings.tsx
@@ -167,10 +167,10 @@ const Settings: React.FC<SettingsProps> = ({ navigation }) => {
     },
     ...(settings || []),
   ]
-  
+
   // Remove the Contact section from Setting per TOKENS.CONFIG
   if (disableContactsInSettings) {
-    settingsSections.shift();
+    settingsSections.shift()
   }
 
   // add optional push notifications menu to settings
@@ -311,6 +311,7 @@ const Settings: React.FC<SettingsProps> = ({ navigation }) => {
           <IconButton
             buttonLocation={ButtonLocation.Right}
             accessibilityLabel={iconRight.accessibilityLabel!}
+            importantForAccessibility="auto"
             testID={iconRight.testID!}
             onPress={iconRight.action!}
             icon={'pencil'}

--- a/packages/legacy/core/App/types/accessibility.ts
+++ b/packages/legacy/core/App/types/accessibility.ts
@@ -1,0 +1,3 @@
+import { AccessibilityProps } from 'react-native'
+
+export type ImportantForAccessibility = AccessibilityProps['importantForAccessibility']

--- a/packages/legacy/core/__tests__/components/IconButton.test.tsx
+++ b/packages/legacy/core/__tests__/components/IconButton.test.tsx
@@ -10,6 +10,7 @@ describe('IconButton Component', () => {
       <IconButton
         buttonLocation={ButtonLocation.Left}
         accessibilityLabel={'LeftButton'}
+        importantForAccessibility="auto"
         testID={testIdWithKey('LeftButton')}
         onPress={jest.fn()}
         icon="information"
@@ -24,6 +25,7 @@ describe('IconButton Component', () => {
       <IconButton
         buttonLocation={ButtonLocation.Right}
         accessibilityLabel={'RightButton'}
+        importantForAccessibility="auto"
         testID={testIdWithKey('RightButton')}
         onPress={jest.fn()}
         icon="information"
@@ -38,6 +40,7 @@ describe('IconButton Component', () => {
       <IconButton
         buttonLocation={ButtonLocation.Right}
         accessibilityLabel={'RightButton'}
+        importantForAccessibility="auto"
         testID={testIdWithKey('RightButton')}
         onPress={jest.fn()}
         text="RightButton"
@@ -54,6 +57,7 @@ describe('IconButton Component', () => {
       <IconButton
         buttonLocation={ButtonLocation.Left}
         accessibilityLabel={'LeftButton'}
+        importantForAccessibility="auto"
         testID={testIdWithKey('LeftButton')}
         onPress={callback}
         icon="information"

--- a/packages/legacy/core/__tests__/components/__snapshots__/HeaderRightHome.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/HeaderRightHome.test.tsx.snap
@@ -32,6 +32,7 @@ exports[`HeaderRightHome Component Renders correctly 1`] = `
       "top": 44,
     }
   }
+  importantForAccessibility="auto"
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}

--- a/packages/legacy/core/__tests__/components/__snapshots__/IconButton.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/IconButton.test.tsx.snap
@@ -32,6 +32,7 @@ exports[`IconButton Component Left alignment renders correctly 1`] = `
       "top": 44,
     }
   }
+  importantForAccessibility="auto"
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -112,6 +113,7 @@ exports[`IconButton Component Right alignment renders correctly 1`] = `
       "top": 44,
     }
   }
+  importantForAccessibility="auto"
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -192,6 +194,7 @@ exports[`IconButton Component Right alignment with text renders correctly 1`] = 
       "top": 44,
     }
   }
+  importantForAccessibility="auto"
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}

--- a/packages/legacy/core/__tests__/components/__snapshots__/NewQRView.test.tsx.snap
+++ b/packages/legacy/core/__tests__/components/__snapshots__/NewQRView.test.tsx.snap
@@ -683,6 +683,7 @@ Array [
                     "top": 44,
                   }
                 }
+                importantForAccessibility="auto"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}


### PR DESCRIPTION
# Summary of Changes

Disabled header elements and bottomNav for talkBack in ModalTour

# Screenshots, videos, or gifs

N/A

# Breaking change guide
N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] Updated documentation as needed for changed code and new or modified features
- [x] Added sufficient [tests](../packages/legacy/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed

