### PR TITLE
fix: extra overlay text color

### DIFF
--- a/packages/legacy/core/App/components/misc/CredentialCard11.tsx
+++ b/packages/legacy/core/App/components/misc/CredentialCard11.tsx
@@ -425,9 +425,18 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
             </Text>
           </View>
         </View>
-        {extraOverlayParameter && (
+        {extraOverlayParameter && !displayItems && (
           <View style={{ flex: 1, justifyContent: 'flex-end' }}>
-            <Text style={TextTheme.caption}>{extraOverlayParameter}</Text>
+            <Text
+              style={[
+                TextTheme.caption,
+                {
+                  color: styles.textContainer.color,
+                },
+              ]}
+            >
+              {extraOverlayParameter}
+            </Text>
           </View>
         )}
 


### PR DESCRIPTION
# Summary of Changes

Fix extra overlay text color in credentialCard11, this will apply only to W3C credentials where `primary_overlay_attribute` exists in the metadata 

Before
![IMG_AEEA47F91724-1](https://github.com/user-attachments/assets/d858f556-ce25-4af1-afa4-e5de8fdac61f)


After
![IMG_EFE7613AD456-1](https://github.com/user-attachments/assets/fb0cda9e-99aa-46e6-b961-ace81526180e)



Replace this text with issue #'s that are relevant to this PR. If there are none, simply enter N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [ ] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [ ] If applicable, screenshots, gifs, or video are included for UI changes
- [ ] If applicable, breaking changes are described above along with how to address them
- [ ] Updated documentation as needed for changed code and new or modified features
- [ ] Added sufficient [tests](../packages/legacy/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed

