### PR TITLE
hotfix: pinEnter bug in main

### DIFF
--- a/packages/legacy/core/App/screens/PINEnter.tsx
+++ b/packages/legacy/core/App/screens/PINEnter.tsx
@@ -223,7 +223,7 @@ const PINEnter: React.FC<PINEnterProps> = ({ setAuthenticated, usage = PINEntryU
   )
 
   const loadWalletCredentials = useCallback(async () => {
-    if (usage === PINEntryUsage.PINCheck || PINEntryUsage.ChangeBiometrics) {
+    if (usage === PINEntryUsage.PINCheck || usage === PINEntryUsage.ChangeBiometrics) {
       return
     }
 
@@ -447,7 +447,7 @@ const PINEnter: React.FC<PINEnterProps> = ({ setAuthenticated, usage = PINEntryU
 
       setContinueEnabled(false)
 
-      if (usage === PINEntryUsage.PINCheck || PINEntryUsage.ChangeBiometrics) {
+      if (usage === PINEntryUsage.PINCheck || usage === PINEntryUsage.ChangeBiometrics) {
         await verifyPIN(PIN)
       }
 


### PR DESCRIPTION
# Summary of Changes

Fix bug in PinEnter

- The "Unlock with Biometry" button does not work.
- If biometry is not provided, an error occurs (see screenshot below).

# Screenshots, videos, or gifs

Currently, PinEnter prompts for both PIN and Biometry. If only the PIN is provided, you receive this error before proceeding:

<img width="358" alt="image" src="https://github.com/user-attachments/assets/c763ac89-c36d-43eb-a890-e42d4a2e7e23" />



# Breaking change guide

N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [ ] If applicable, screenshots, gifs, or video are included for UI changes
- [ ] If applicable, breaking changes are described above along with how to address them
- [ ] Updated documentation as needed for changed code and new or modified features
- [ ] Added sufficient [tests](../packages/legacy/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed

