### PR TITLE
fix: enable cleaning up multiple received invitations

### DIFF
--- a/packages/legacy/core/App/index.ts
+++ b/packages/legacy/core/App/index.ts
@@ -84,7 +84,7 @@ export { EventTypes } from './constants'
 export { migrateToAskar } from './utils/migration'
 export { createLinkSecretIfRequired, getAgentModules } from './utils/agent'
 export {
-  removeExistingInvitationIfRequired,
+  removeExistingInvitationsById,
   connectFromScanOrDeepLink,
   formatTime,
   useCredentialConnectionLabel,

--- a/packages/legacy/core/__mocks__/@credo-ts/react-hooks.ts
+++ b/packages/legacy/core/__mocks__/@credo-ts/react-hooks.ts
@@ -452,6 +452,7 @@ const mockOobModule = {
   createInvitation: jest.fn(),
   toUrl: jest.fn(),
   findByReceivedInvitationId: jest.fn().mockReturnValue(Promise.resolve(null)),
+  findAllByQuery: jest.fn().mockReturnValue(Promise.resolve([])),
   parseInvitation: jest.fn().mockReturnValue(Promise.resolve(null)),
 }
 const mockBasicMessageRepository = {
@@ -472,7 +473,7 @@ const agent = {
     oob: mockOobModule,
     context: mockAgentContext,
     receiveMessage: jest.fn(),
-    config: { logger: { error: jest.fn() } },
+    config: { logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() } },
   },
 }
 


### PR DESCRIPTION
# Summary of Changes

This PR enables the cleanup of multiple existing received invitations if they exist. Previously, this function could only remove one existing invitation and threw a silent error if there were more than one or none. 

It no longer throws if no received invitations with the given `invitationId` exist, and now can remove 0, 1, or multiple received invitations properly. If for whatever reason one of the Credo methods throw, it will no longer happen silently and will bubble up.

I also did a bit of refactoring and added more testing

# Screenshots, videos, or gifs

N/A

# Breaking change guide

Wherever you were using `removeExistingInvitationIfExists`, please use `removeExistingInvitationsById` from now on. Same signature.

# Related Issues

bcgov/bc-wallet-mobile#2331

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] Updated documentation as needed for changed code and new or modified features
- [x] Added sufficient [tests](../packages/legacy/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed

