### PR TITLE
fix: broken safe areas within modals

### DIFF
--- a/packages/legacy/core/App/components/chat/ActionSlider.tsx
+++ b/packages/legacy/core/App/components/chat/ActionSlider.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Modal, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
 import { hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 import { testIdWithKey } from '../../utils/testable'
+import SafeAreaModal from '../modals/SafeAreaModal'
 
 interface Action {
   text: string
@@ -64,7 +65,7 @@ const ActionSlider: React.FC<Props> = ({ actions, onDismiss }) => {
   })
 
   return (
-    <Modal animationType="slide" transparent={true} onRequestClose={onDismiss}>
+    <SafeAreaModal animationType="slide" transparent={true} onRequestClose={onDismiss}>
       <TouchableOpacity style={styles.outsideListener} onPress={onDismiss} />
       <View style={styles.centeredView}>
         <View style={styles.modalView}>
@@ -96,7 +97,7 @@ const ActionSlider: React.FC<Props> = ({ actions, onDismiss }) => {
             })}
         </View>
       </View>
-    </Modal>
+    </SafeAreaModal>
   )
 }
 

--- a/packages/legacy/core/App/components/misc/QRScanner.tsx
+++ b/packages/legacy/core/App/components/misc/QRScanner.tsx
@@ -3,7 +3,7 @@ import { useAgent } from '@credo-ts/react-hooks'
 import { StackScreenProps } from '@react-navigation/stack'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { View, Modal, Pressable, StyleSheet, Text, useWindowDimensions, Share, ScrollView, ColorValue } from 'react-native'
+import { View, Pressable, StyleSheet, Text, useWindowDimensions, Share, ScrollView, ColorValue } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
@@ -20,6 +20,7 @@ import LoadingIndicator from '../animated/LoadingIndicator'
 import IconButton, { ButtonLocation } from '../buttons/IconButton'
 import InfoBox, { InfoBoxType } from '../misc/InfoBox'
 import DismissiblePopupModal from '../modals/DismissiblePopupModal'
+import SafeAreaModal from '../modals/SafeAreaModal'
 
 import QRRenderer from './QRRenderer'
 import QRScannerTorch from './QRScannerTorch'
@@ -303,7 +304,7 @@ const QRScanner: React.FC<Props> = ({ showTabs = false, defaultToConnect, handle
                 </View>
               </View>
             </View>
-            <Modal visible={showInfoBox} animationType="fade" transparent>
+            <SafeAreaModal visible={showInfoBox} animationType="fade" transparent>
               <View
                 style={{
                   flex: 1,
@@ -320,7 +321,7 @@ const QRScanner: React.FC<Props> = ({ showTabs = false, defaultToConnect, handle
                   onCallToActionPressed={toggleShowInfoBox}
                 />
               </View>
-            </Modal>
+            </SafeAreaModal>
             {showErrorDetailsModal && (
               <DismissiblePopupModal
                 title={t('Scan.ErrorDetails')}

--- a/packages/legacy/core/App/components/modals/AppGuideModal.tsx
+++ b/packages/legacy/core/App/components/modals/AppGuideModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Modal, StyleSheet, View, Text, TouchableOpacity, useWindowDimensions } from 'react-native'
+import { StyleSheet, View, Text, TouchableOpacity, useWindowDimensions } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
 import { hitSlop } from '../../constants'
@@ -8,6 +8,7 @@ import { useTheme } from '../../contexts/theme'
 import { GenericFn } from '../../types/fn'
 import { testIdWithKey } from '../../utils/testable'
 import Button, { ButtonType } from '../buttons/Button'
+import SafeAreaModal from './SafeAreaModal'
 
 interface AppGuideModalProps {
   title: string
@@ -79,7 +80,7 @@ const AppGuideModal: React.FC<AppGuideModalProps> = ({
   })
 
   return (
-    <Modal transparent accessibilityViewIsModal>
+    <SafeAreaModal transparent accessibilityViewIsModal>
       <View style={styles.modalCenter}>
         <View style={styles.container}>
           <View style={styles.headerContainer}>
@@ -127,7 +128,7 @@ const AppGuideModal: React.FC<AppGuideModalProps> = ({
           </View>
         </View>
       </View>
-    </Modal>
+    </SafeAreaModal>
   )
 }
 

--- a/packages/legacy/core/App/components/modals/CameraDisclosureModal.tsx
+++ b/packages/legacy/core/App/components/modals/CameraDisclosureModal.tsx
@@ -2,7 +2,7 @@ import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Modal, ScrollView, StyleSheet, Text, View, Linking } from 'react-native'
+import { ScrollView, StyleSheet, Text, View, Linking } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import { useTheme } from '../../contexts/theme'
@@ -11,6 +11,7 @@ import { testIdWithKey } from '../../utils/testable'
 import Button, { ButtonType } from '../buttons/Button'
 
 import DismissiblePopupModal from './DismissiblePopupModal'
+import SafeAreaModal from './SafeAreaModal'
 
 interface CameraDisclosureModalProps {
   requestCameraUse: () => Promise<boolean>
@@ -68,7 +69,7 @@ const CameraDisclosureModal: React.FC<CameraDisclosureModalProps> = ({ requestCa
   }
 
   return (
-    <Modal visible={modalVisible} animationType={'slide'} supportedOrientations={['portrait', 'landscape']} transparent>
+    <SafeAreaModal visible={modalVisible} animationType={'slide'} supportedOrientations={['portrait', 'landscape']} transparent>
       {showSettingsPopup && (
         <DismissiblePopupModal
           title={t('CameraDisclosure.AllowCameraUse')}
@@ -108,7 +109,7 @@ const CameraDisclosureModal: React.FC<CameraDisclosureModalProps> = ({ requestCa
           </View>
         </View>
       </SafeAreaView>
-    </Modal>
+    </SafeAreaModal>
   )
 }
 

--- a/packages/legacy/core/App/components/modals/CommonRemoveModal.tsx
+++ b/packages/legacy/core/App/components/modals/CommonRemoveModal.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Modal, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import Collapsible from 'react-native-collapsible'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialIcons'
@@ -15,6 +15,7 @@ import Button, { ButtonType } from '../buttons/Button'
 import BulletPoint from '../inputs/BulletPoint'
 import ContentGradient from '../misc/ContentGradient'
 import UnorderedList from '../misc/UnorderedList'
+import SafeAreaModal from './SafeAreaModal'
 
 interface CommonRemoveModalProps {
   usage: ModalUsage
@@ -268,7 +269,7 @@ const CommonRemoveModal: React.FC<CommonRemoveModalProps> = ({ usage, visible, o
   }
 
   return (
-    <Modal transparent={true} visible={visible} animationType="slide">
+    <SafeAreaModal transparent={true} visible={visible} animationType="slide">
       <View style={styles.overlay}>
         <SafeAreaView edges={['left', 'right', 'bottom']} style={styles.safeAreaView}>
           <View style={styles.headerView}>
@@ -313,7 +314,7 @@ const CommonRemoveModal: React.FC<CommonRemoveModalProps> = ({ usage, visible, o
           </View>
         </SafeAreaView>
       </View>
-    </Modal>
+    </SafeAreaModal>
   )
 }
 

--- a/packages/legacy/core/App/components/modals/DismissiblePopupModal.tsx
+++ b/packages/legacy/core/App/components/modals/DismissiblePopupModal.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import {
-  Modal,
   StyleSheet,
   View,
   Text,
@@ -17,6 +16,7 @@ import { useTheme } from '../../contexts/theme'
 import { GenericFn } from '../../types/fn'
 import { testIdWithKey } from '../../utils/testable'
 import Button, { ButtonType } from '../buttons/Button'
+import SafeAreaModal from './SafeAreaModal'
 
 interface DismissiblePopupModalProps {
   title: string
@@ -107,7 +107,7 @@ const DismissiblePopupModal: React.FC<DismissiblePopupModalProps> = ({
   const iconColor = ColorPallet.notification.infoIcon
 
   return (
-    <Modal transparent>
+    <SafeAreaModal transparent>
       <TouchableOpacity onPress={onDismissPressed} accessible={false}>
         <View style={styles.modalCenter}>
           <TouchableWithoutFeedback accessible={false}>
@@ -161,7 +161,7 @@ const DismissiblePopupModal: React.FC<DismissiblePopupModalProps> = ({
           </TouchableWithoutFeedback>
         </View>
       </TouchableOpacity>
-    </Modal>
+    </SafeAreaModal>
   )
 }
 

--- a/packages/legacy/core/App/components/modals/ErrorModal.tsx
+++ b/packages/legacy/core/App/components/modals/ErrorModal.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Modal, StyleSheet, StatusBar, DeviceEventEmitter, useWindowDimensions } from 'react-native'
+import { StyleSheet, StatusBar, DeviceEventEmitter, useWindowDimensions } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
@@ -9,6 +9,7 @@ import { TOKENS, useServices } from '../../container-api'
 import { useTheme } from '../../contexts/theme'
 import { BifoldError } from '../../types/error'
 import InfoBox, { InfoBoxType } from '../misc/InfoBox'
+import SafeAreaModal from './SafeAreaModal'
 
 interface ErrorModalProps {
   enableReport?: boolean
@@ -83,7 +84,7 @@ const ErrorModal: React.FC<ErrorModalProps> = ({ enableReport }) => {
   )
 
   return (
-    <Modal visible={modalVisible} transparent={true}>
+    <SafeAreaModal visible={modalVisible} transparent={true}>
       <StatusBar hidden={true} />
       <SafeAreaView style={styles.container}>
         <InfoBox
@@ -99,7 +100,7 @@ const ErrorModal: React.FC<ErrorModalProps> = ({ enableReport }) => {
           showVersionFooter
         />
       </SafeAreaView>
-    </Modal>
+    </SafeAreaModal>
   )
 }
 

--- a/packages/legacy/core/App/components/modals/ImageModal.tsx
+++ b/packages/legacy/core/App/components/modals/ImageModal.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import {
-  Modal,
   StyleSheet,
   View,
   useWindowDimensions,
@@ -15,6 +14,7 @@ import { hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 import { GenericFn } from '../../types/fn'
 import { testIdWithKey } from '../../utils/testable'
+import SafeAreaModal from './SafeAreaModal'
 
 interface ImageModalProps {
   uri: string
@@ -59,7 +59,7 @@ const ImageModal: React.FC<ImageModalProps> = ({ uri, onDismissPressed }) => {
   const iconColor = ColorPallet.brand.primary
 
   return (
-    <Modal transparent>
+    <SafeAreaModal transparent>
       <TouchableOpacity onPress={onDismissPressed} accessible={false}>
         <View style={styles.modalCenter}>
           <TouchableWithoutFeedback accessible={false}>
@@ -80,7 +80,7 @@ const ImageModal: React.FC<ImageModalProps> = ({ uri, onDismissPressed }) => {
           </TouchableWithoutFeedback>
         </View>
       </TouchableOpacity>
-    </Modal>
+    </SafeAreaModal>
   )
 }
 

--- a/packages/legacy/core/App/components/modals/NotificationModal.tsx
+++ b/packages/legacy/core/App/components/modals/NotificationModal.tsx
@@ -2,7 +2,7 @@ import { useNavigation } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Modal, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
@@ -11,6 +11,7 @@ import { useTheme } from '../../contexts/theme'
 import { HomeStackParams, Screens } from '../../types/navigators'
 import { testIdWithKey } from '../../utils/testable'
 import Button, { ButtonType } from '../buttons/Button'
+import SafeAreaModal from './SafeAreaModal'
 
 interface NotificationModalProps extends React.PropsWithChildren {
   title: string
@@ -83,7 +84,7 @@ const NotificationModal: React.FC<NotificationModalProps> = ({
   }
 
   return (
-    <Modal testID={testID} visible={modalVisible} transparent={true}>
+    <SafeAreaModal testID={testID} visible={modalVisible} transparent={true}>
       <SafeAreaView style={styles.container}>
         {homeVisible ? (
           <View style={styles.iconContainer}>
@@ -118,7 +119,7 @@ const NotificationModal: React.FC<NotificationModalProps> = ({
           </View>
         ) : null}
       </SafeAreaView>
-    </Modal>
+    </SafeAreaModal>
   )
 }
 

--- a/packages/legacy/core/App/components/modals/PopupModal.tsx
+++ b/packages/legacy/core/App/components/modals/PopupModal.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
-import { Modal, StyleSheet, View } from 'react-native'
+import { StyleSheet, View } from 'react-native'
 
 import { useTheme } from '../../contexts/theme'
 import { GenericFn } from '../../types/fn'
 import InfoBox, { InfoBoxType } from '../misc/InfoBox'
+import SafeAreaModal from './SafeAreaModal'
 
 interface PopupModalProps {
   notificationType: InfoBoxType
@@ -36,7 +37,7 @@ const PopupModal: React.FC<PopupModalProps> = ({
   })
 
   return (
-    <Modal transparent>
+    <SafeAreaModal transparent>
       <View style={styles.modalCenter}>
         <InfoBox
           notificationType={notificationType}
@@ -48,7 +49,7 @@ const PopupModal: React.FC<PopupModalProps> = ({
           onCallToActionPressed={onCallToActionPressed}
         />
       </View>
-    </Modal>
+    </SafeAreaModal>
   )
 }
 

--- a/packages/legacy/core/App/components/modals/ProofCancelModal.tsx
+++ b/packages/legacy/core/App/components/modals/ProofCancelModal.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Modal, ScrollView, StyleSheet, View, Text } from 'react-native'
+import { ScrollView, StyleSheet, View, Text } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import { useTheme } from '../../contexts/theme'
 import { GenericFn } from '../../types/fn'
 import { testIdWithKey } from '../../utils/testable'
 import Button, { ButtonType } from '../buttons/Button'
+import SafeAreaModal from './SafeAreaModal'
 
 interface ProofCancelModalProps {
   visible?: boolean
@@ -50,7 +51,7 @@ const ProofCancelModal: React.FC<ProofCancelModalProps> = ({ visible, onDone }) 
   })
 
   return (
-    <Modal visible={visible} animationType="slide">
+    <SafeAreaModal visible={visible} animationType="slide">
       <SafeAreaView style={styles.safeAreaView}>
         <ScrollView style={styles.container}>
           <View style={styles.content}>
@@ -71,7 +72,7 @@ const ProofCancelModal: React.FC<ProofCancelModalProps> = ({ visible, onDone }) 
           </View>
         </View>
       </SafeAreaView>
-    </Modal>
+    </SafeAreaModal>
   )
 }
 

--- a/packages/legacy/core/App/components/modals/SafeAreaModal.tsx
+++ b/packages/legacy/core/App/components/modals/SafeAreaModal.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { Modal, ModalProps } from 'react-native'
+import { SafeAreaProvider } from 'react-native-safe-area-context'
+
+interface SafeAreaModalProps extends ModalProps {
+  children: React.ReactNode
+}
+
+const SafeAreaModal: React.FC<SafeAreaModalProps> = ({ children, ...modalProps }) => {
+  return (
+    <Modal {...modalProps}>
+      <SafeAreaProvider>
+        {children}
+      </SafeAreaProvider>
+    </Modal>
+  )
+}
+
+export default SafeAreaModal

--- a/packages/legacy/core/App/index.ts
+++ b/packages/legacy/core/App/index.ts
@@ -14,6 +14,7 @@ import ContentGradient from './components/misc/ContentGradient'
 import CredentialCard from './components/misc/CredentialCard'
 import InfoBox, { InfoBoxType } from './components/misc/InfoBox'
 import ErrorModal from './components/modals/ErrorModal'
+import SafeAreaModal from './components/modals/SafeAreaModal'
 import NetInfo from './components/network/NetInfo'
 import Record from './components/record/Record'
 import InfoTextBox from './components/texts/InfoTextBox'
@@ -165,6 +166,7 @@ export {
   CredentialCard,
   ContentGradient,
   ErrorModal,
+  SafeAreaModal,
   IconButton,
   ActivityProvider,
   useActivity,

--- a/packages/legacy/core/App/screens/CredentialOfferAccept.tsx
+++ b/packages/legacy/core/App/screens/CredentialOfferAccept.tsx
@@ -3,10 +3,11 @@ import { useCredentialById } from '@credo-ts/react-hooks'
 import { useNavigation } from '@react-navigation/native'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { AccessibilityInfo, Modal, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { AccessibilityInfo, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import Button, { ButtonType } from '../components/buttons/Button'
+import SafeAreaModal from '../components/modals/SafeAreaModal'
 import { useAnimatedComponents } from '../contexts/animated-components'
 import { useTheme } from '../contexts/theme'
 import { Screens, TabStacks } from '../types/navigators'
@@ -116,7 +117,7 @@ const CredentialOfferAccept: React.FC<CredentialOfferAcceptProps> = ({ visible, 
   }, [shouldShowDelayMessage, credentialDeliveryStatus, t])
 
   return (
-    <Modal visible={visible} transparent={true} animationType={'none'}>
+    <SafeAreaModal visible={visible} transparent={true} animationType={'none'}>
       <SafeAreaView style={{ ...ListItems.credentialOfferBackground }}>
         <ScrollView style={styles.container}>
           <View style={styles.messageContainer}>
@@ -180,7 +181,7 @@ const CredentialOfferAccept: React.FC<CredentialOfferAcceptProps> = ({ visible, 
           )}
         </View>
       </SafeAreaView>
-    </Modal>
+    </SafeAreaModal>
   )
 }
 

--- a/packages/legacy/core/App/screens/MobileVerifierLoading.tsx
+++ b/packages/legacy/core/App/screens/MobileVerifierLoading.tsx
@@ -3,10 +3,11 @@ import { isPresentationFailed, isPresentationReceived } from '@hyperledger/aries
 import { StackScreenProps } from '@react-navigation/stack'
 import React, { useCallback, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Modal, SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native'
 
 import PresentationLoading from '../components/animated/PresentationLoading'
 import Button, { ButtonType } from '../components/buttons/Button'
+import SafeAreaModal from '../components/modals/SafeAreaModal'
 import { useTheme } from '../contexts/theme'
 import { useOutOfBandByConnectionId } from '../hooks/connections'
 import { DeliveryStackParams, Screens } from '../types/navigators'
@@ -70,7 +71,7 @@ const MobileVerifierLoading: React.FC<MobileVerifierLoadingProps> = ({ navigatio
   }, [proofRecord, goalCode, agent, connectionId, navigation])
 
   return (
-    <Modal transparent animationType={'slide'}>
+    <SafeAreaModal transparent animationType={'slide'}>
       <SafeAreaView style={{ backgroundColor: ColorPallet.brand.modalPrimaryBackground }}>
         <ScrollView style={styles.container}>
           <View style={styles.messageContainer}>
@@ -93,7 +94,7 @@ const MobileVerifierLoading: React.FC<MobileVerifierLoadingProps> = ({ navigatio
           />
         </View>
       </SafeAreaView>
-    </Modal>
+    </SafeAreaModal>
   )
 }
 

--- a/packages/legacy/core/App/screens/PasteUrl.tsx
+++ b/packages/legacy/core/App/screens/PasteUrl.tsx
@@ -2,11 +2,12 @@ import { useAgent } from '@credo-ts/react-hooks'
 import { StackScreenProps } from '@react-navigation/stack'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, Text, View, TextInput, ScrollView, TouchableOpacity, Modal } from 'react-native'
+import { StyleSheet, Text, View, TextInput, ScrollView, TouchableOpacity } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import Button, { ButtonType } from '../components/buttons/Button'
 import InfoBox, { InfoBoxType } from '../components/misc/InfoBox'
+import SafeAreaModal from '../components/modals/SafeAreaModal'
 import { TOKENS, useServices } from '../container-api'
 import { useTheme } from '../contexts/theme'
 import { ConnectStackParams } from '../types/navigators'
@@ -66,7 +67,7 @@ const PasteUrl: React.FC<PasteProps> = ({ navigation }) => {
   return (
     <SafeAreaView style={styles.container}>
       <ScrollView>
-        <Modal visible={!!errorMessage} testID={testIdWithKey('ErrorModal')} animationType="fade" transparent>
+        <SafeAreaModal visible={!!errorMessage} testID={testIdWithKey('ErrorModal')} animationType="fade" transparent>
           <View
             style={{
               flex: 1,
@@ -84,7 +85,7 @@ const PasteUrl: React.FC<PasteProps> = ({ navigation }) => {
               onCallToActionLabel={t('Global.TryAgain')}
             />
           </View>
-        </Modal>
+        </SafeAreaModal>
         <View style={styles.content}>
           <Text style={styles.description}>{t('PasteUrl.PasteUrlDescription')}</Text>
           <TextInput

--- a/packages/legacy/core/App/screens/ProofRequestAccept.tsx
+++ b/packages/legacy/core/App/screens/ProofRequestAccept.tsx
@@ -3,10 +3,11 @@ import { useProofById } from '@credo-ts/react-hooks'
 import { useNavigation } from '@react-navigation/native'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Modal, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import Button, { ButtonType } from '../components/buttons/Button'
+import SafeAreaModal from '../components/modals/SafeAreaModal'
 import { useAnimatedComponents } from '../contexts/animated-components'
 import { useTheme } from '../contexts/theme'
 import { Screens, TabStacks } from '../types/navigators'
@@ -79,7 +80,7 @@ const ProofRequestAccept: React.FC<ProofRequestAcceptProps> = ({ visible, proofI
   }, [proof, proofDeliveryStatus, confirmationOnly])
 
   return (
-    <Modal visible={visible} transparent={true} animationType={'none'}>
+    <SafeAreaModal visible={visible} transparent={true} animationType={'none'}>
       <SafeAreaView style={{ backgroundColor: ColorPallet.brand.modalPrimaryBackground }}>
         <ScrollView style={styles.container}>
           <View style={styles.messageContainer}>
@@ -122,7 +123,7 @@ const ProofRequestAccept: React.FC<ProofRequestAcceptProps> = ({ visible, proofI
           </View>
         </View>
       </SafeAreaView>
-    </Modal>
+    </SafeAreaModal>
   )
 }
 

--- a/packages/legacy/core/App/screens/UseBiometry.tsx
+++ b/packages/legacy/core/App/screens/UseBiometry.tsx
@@ -3,25 +3,26 @@ import { StackNavigationProp } from '@react-navigation/stack'
 import { Header, useHeaderHeight, HeaderBackButton } from '@react-navigation/elements';
 import React, { useState, useEffect, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, Text, View, Modal, ScrollView, Linking, Platform } from 'react-native'
+import { StyleSheet, Text, View, ScrollView, Linking, Platform } from 'react-native'
 import { PERMISSIONS, RESULTS, request, check, PermissionStatus } from 'react-native-permissions'
-import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
+import { SafeAreaView } from 'react-native-safe-area-context'
 
 import Button, { ButtonType } from '../components/buttons/Button'
 import ToggleButton from '../components/buttons/ToggleButton'
+import DismissiblePopupModal from '../components/modals/DismissiblePopupModal'
+import SafeAreaModal from '../components/modals/SafeAreaModal'
 import { useAnimatedComponents } from '../contexts/animated-components'
 import { useAuth } from '../contexts/auth'
 import { DispatchAction } from '../contexts/reducers/store'
 import { useStore } from '../contexts/store'
 import { useTheme } from '../contexts/theme'
 import { OnboardingStackParams, Screens } from '../types/navigators'
+import { useAppAgent } from '../utils/agent'
 import { testIdWithKey } from '../utils/testable'
-import DismissiblePopupModal from '../components/modals/DismissiblePopupModal'
 
 import PINEnter, { PINEntryUsage } from './PINEnter'
 import { TOKENS, useServices } from '../container-api'
 import { HistoryCardType, HistoryRecord } from '../modules/history/types'
-import { useAppAgent } from '../utils/agent'
 
 enum UseBiometryUsage {
   InitialSetup,
@@ -48,7 +49,6 @@ const UseBiometry: React.FC = () => {
     return store.onboarding.didCompleteOnboarding ? UseBiometryUsage.ToggleOnOff : UseBiometryUsage.InitialSetup
   }, [store.onboarding.didCompleteOnboarding])
   const headerHeight = useHeaderHeight()
-  const insets = useSafeAreaInsets()
 
   const BIOMETRY_PERMISSION = PERMISSIONS.IOS.FACE_ID
 
@@ -328,7 +328,7 @@ const UseBiometry: React.FC = () => {
           </Button>
         )}
       </View>
-      <Modal
+      <SafeAreaModal
         style={{ backgroundColor: ColorPallet.brand.primaryBackground }}
         visible={canSeeCheckPIN}
         transparent={false}
@@ -337,16 +337,16 @@ const UseBiometry: React.FC = () => {
       >
         <Header 
           title={t('Screens.EnterPIN')}
-          headerTitleStyle={{ marginTop: insets.top, ...TextTheme.headerTitle }}
+          headerTitleStyle={TextTheme.headerTitle}
           headerStyle={{ height: headerHeight }}
-          headerLeft={() => <HeaderBackButton onPress={() => setCanSeeCheckPIN(false)} tintColor='white' style={{ marginTop: insets.top }} labelVisible={false} />}
+          headerLeft={() => <HeaderBackButton onPress={() => setCanSeeCheckPIN(false)} tintColor='white' labelVisible={false} />}
         />
         <PINEnter
           usage={PINEntryUsage.ChangeBiometrics}
           setAuthenticated={onAuthenticationComplete}
           onCancelAuth={setCanSeeCheckPIN}
         />
-      </Modal>
+      </SafeAreaModal>
     </SafeAreaView>
   )
 }

--- a/packages/legacy/core/__tests__/screens/__snapshots__/UseBiometry.test.tsx.snap
+++ b/packages/legacy/core/__tests__/screens/__snapshots__/UseBiometry.test.tsx.snap
@@ -1,7 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UseBiometry Screen Renders correctly when biometry available 1`] = `
-Array [
+exports[`UseBiometry Screen renders correctly when biometry available 1`] = `
+<RNCSafeAreaView
+  edges={
+    Object {
+      "bottom": "additive",
+      "left": "additive",
+      "right": "additive",
+      "top": "off",
+    }
+  }
+>
   <RCTScrollView
     style={
       Object {
@@ -200,7 +209,7 @@ Array [
         </View>
       </View>
     </View>
-  </RCTScrollView>,
+  </RCTScrollView>
   <View
     style={
       Object {
@@ -277,12 +286,21 @@ Array [
         </Text>
       </View>
     </View>
-  </View>,
-]
+  </View>
+</RNCSafeAreaView>
 `;
 
-exports[`UseBiometry Screen Renders correctly when biometry not available 1`] = `
-Array [
+exports[`UseBiometry Screen renders correctly when biometry unavailable 1`] = `
+<RNCSafeAreaView
+  edges={
+    Object {
+      "bottom": "additive",
+      "left": "additive",
+      "right": "additive",
+      "top": "off",
+    }
+  }
+>
   <RCTScrollView
     style={
       Object {
@@ -469,7 +487,7 @@ Array [
         </View>
       </View>
     </View>
-  </RCTScrollView>,
+  </RCTScrollView>
   <View
     style={
       Object {
@@ -546,328 +564,6 @@ Array [
         </Text>
       </View>
     </View>
-  </View>,
-]
-`;
-
-exports[`UseBiometry Screen Toggles use biometrics ok 1`] = `
-Array [
-  <RCTScrollView
-    style={
-      Object {
-        "backgroundColor": "#000000",
-        "height": "100%",
-        "padding": 20,
-      }
-    }
-  >
-    <View>
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-          }
-        }
-      >
-        <
-          style={
-            Object {
-              "marginBottom": 66,
-              "minHeight": 200,
-              "minWidth": 200,
-            }
-          }
-        />
-      </View>
-      <View
-        style={
-          Object {
-            "rowGap": 20,
-          }
-        }
-      >
-        <Text
-          style={
-            Object {
-              "color": "#FFFFFF",
-              "fontSize": 18,
-              "fontWeight": "normal",
-            }
-          }
-        >
-          Biometry.EnabledText1
-        </Text>
-        <Text
-          style={
-            Object {
-              "color": "#FFFFFF",
-              "fontSize": 18,
-              "fontWeight": "normal",
-            }
-          }
-        >
-          Biometry.EnabledText2
-          <Text
-            style={
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 18,
-                "fontWeight": "bold",
-              }
-            }
-          >
-             
-            Biometry.Warning
-          </Text>
-        </Text>
-      </View>
-      <View
-        style={
-          Object {
-            "flexDirection": "row",
-            "marginVertical": 20,
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "flexShrink": 1,
-              "justifyContent": "center",
-              "marginRight": 10,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 18,
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Biometry.UseToUnlock
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "justifyContent": "center",
-            }
-          }
-        >
-          <View
-            accessibilityLabel="Biometry.Off"
-            accessibilityRole="switch"
-            accessibilityState={
-              Object {
-                "busy": undefined,
-                "checked": false,
-                "disabled": false,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              Object {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
-            accessible={true}
-            collapsable={false}
-            focusable={true}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            testID="com.ariesbifold:id/ToggleBiometrics"
-          >
-            <View
-              collapsable={false}
-              style={
-                Object {
-                  "backgroundColor": "rgba(211, 211, 211, 1)",
-                  "borderRadius": 25,
-                  "height": 30,
-                  "justifyContent": "center",
-                  "opacity": 1,
-                  "padding": 3,
-                  "width": 55,
-                }
-              }
-            >
-              <View
-                collapsable={false}
-                style={
-                  Object {
-                    "alignItems": "center",
-                    "backgroundColor": "#FFFFFF",
-                    "borderRadius": 20,
-                    "height": 25,
-                    "justifyContent": "center",
-                    "transform": Array [
-                      Object {
-                        "translateX": 1,
-                      },
-                    ],
-                    "width": 25,
-                  }
-                }
-              >
-                <Text
-                  allowFontScaling={false}
-                  selectable={false}
-                  style={
-                    Array [
-                      Object {
-                        "color": "#606060",
-                        "fontSize": 15,
-                      },
-                      undefined,
-                      Object {
-                        "fontFamily": "Material Icons",
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
-                      },
-                      Object {},
-                    ]
-                  }
-                >
-                  
-                </Text>
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </RCTScrollView>,
-  <View
-    style={
-      Object {
-        "margin": 20,
-        "marginTop": "auto",
-      }
-    }
-  >
-    <View
-      accessibilityLabel="Continue"
-      accessibilityRole="button"
-      accessibilityState={
-        Object {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        Object {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        Object {
-          "backgroundColor": "rgba(53, 130, 63, 0.35)",
-          "borderRadius": 4,
-          "opacity": 1,
-          "padding": 16,
-        }
-      }
-      testID="com.ariesbifold:id/Continue"
-    >
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "flexDirection": "row",
-            "justifyContent": "center",
-          }
-        }
-      >
-        <View
-          collapsable={false}
-          style={
-            Object {
-              "transform": Array [
-                Object {
-                  "rotate": "0deg",
-                },
-              ],
-            }
-          }
-        >
-          <Text
-            allowFontScaling={false}
-            selectable={false}
-            style={
-              Array [
-                Object {
-                  "color": undefined,
-                  "fontSize": 25,
-                },
-                Object {
-                  "color": "#FFFFFF",
-                },
-                Object {
-                  "fontFamily": "Material Icons",
-                  "fontStyle": "normal",
-                  "fontWeight": "normal",
-                },
-                Object {},
-              ]
-            }
-          >
-            
-          </Text>
-        </View>
-        <Text
-          style={
-            Array [
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 18,
-                "fontWeight": "bold",
-                "textAlign": "center",
-              },
-              Object {
-                "color": "#FFFFFF",
-                "fontSize": 18,
-                "fontWeight": "bold",
-                "textAlign": "center",
-              },
-              false,
-              false,
-            ]
-          }
-        >
-          Global.Continue
-        </Text>
-      </View>
-    </View>
-  </View>,
-]
+  </View>
+</RNCSafeAreaView>
 `;

--- a/packages/legacy/core/jestSetup.js
+++ b/packages/legacy/core/jestSetup.js
@@ -5,10 +5,12 @@ import 'react-native-gesture-handler/jestSetup'
 import mockRNCNetInfo from '@react-native-community/netinfo/jest/netinfo-mock.js'
 import mockRNLocalize from 'react-native-localize/mock'
 import mockRNDeviceInfo from 'react-native-device-info/jest/react-native-device-info-mock'
+import mockSafeAreaContext from 'react-native-safe-area-context/jest/mock';
 
 mockRNDeviceInfo.getVersion = jest.fn(() => '1')
 mockRNDeviceInfo.getBuildNumber = jest.fn(() => '1')
 
+jest.mock('react-native-safe-area-context', () => mockSafeAreaContext);
 jest.mock('react-native-device-info', () => mockRNDeviceInfo)
 jest.mock('@react-native-community/netinfo', () => mockRNCNetInfo)
 jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper')


### PR DESCRIPTION
# Summary of Changes

Due to our recent upgrade from `react-native-safe-area-context` 3.x.x to 4.x.x, this breaking change was introduced:
- https://github.com/AppAndFlow/react-native-safe-area-context/issues/279

This PR fixes the issue and cleans up a particularly difficult and flakey test

# Screenshots, videos, or gifs

Before (you can see the heading text overlapping with the time):
![broken_safe_area](https://github.com/user-attachments/assets/9fa658e5-4b4a-43d1-93dc-59f7bbd16377)

After (back to how it was before):
![fixed_safe_area](https://github.com/user-attachments/assets/16927111-1dc4-4858-b850-1abb62e06ed7)

# Breaking change guide

You will need to use the newly exported `SafeAreaModal` component in place of the RN `Modal` component if you want the correct behaviour

# Related Issues

bcgov/bc-wallet-mobile#2390

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] Updated documentation as needed for changed code and new or modified features
- [x] Added sufficient [tests](../packages/legacy/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed

