### PR TITLE
fix: change maxFontSize for AppGuideModal so it's readable in small phones with large font size settings

### DIFF
--- a/packages/legacy/core/App/components/buttons/Button-api.tsx
+++ b/packages/legacy/core/App/components/buttons/Button-api.tsx
@@ -16,6 +16,7 @@ export interface ButtonProps extends React.PropsWithChildren {
   buttonType: ButtonType
   accessibilityLabel?: string
   accessibilityHint?: string
+  maxfontSizeMultiplier?: number
   testID?: string
   onPress?: () => void
   disabled?: boolean

--- a/packages/legacy/core/App/components/buttons/Button.tsx
+++ b/packages/legacy/core/App/components/buttons/Button.tsx
@@ -15,6 +15,7 @@ const ButtonImplComponent = (
     testID,
     onPress,
     disabled = false,
+    maxfontSizeMultiplier,
     children,
   }: ButtonProps,
   ref: React.LegacyRef<TouchableOpacity>
@@ -68,6 +69,7 @@ const ButtonImplComponent = (
       >
         {children}
         <ThemedText
+          maxFontSizeMultiplier={maxfontSizeMultiplier}
           style={[
             buttonStyles[buttonType].text,
             disabled &&

--- a/packages/legacy/core/App/components/modals/AppGuideModal.tsx
+++ b/packages/legacy/core/App/components/modals/AppGuideModal.tsx
@@ -85,6 +85,7 @@ const AppGuideModal: React.FC<AppGuideModalProps> = ({
           <View style={styles.headerContainer}>
             <View style={styles.headerTextContainer}>
               <ThemedText
+                maxFontSizeMultiplier={1.5}
                 variant="headingThree"
                 style={styles.headerText}
                 testID={testIdWithKey('HeaderText')}
@@ -106,7 +107,7 @@ const AppGuideModal: React.FC<AppGuideModalProps> = ({
             </View>
           </View>
           <View>
-            <ThemedText style={styles.bodyText} testID={testIdWithKey('BodyText')}>
+            <ThemedText maxFontSizeMultiplier={1.5} style={styles.bodyText} testID={testIdWithKey('BodyText')}>
               {description}
             </ThemedText>
             {onCallToActionPressed && (
@@ -117,6 +118,7 @@ const AppGuideModal: React.FC<AppGuideModalProps> = ({
                   testID={testIdWithKey('Primary')}
                   buttonType={ButtonType.Primary}
                   onPress={onCallToActionPressed}
+                  maxfontSizeMultiplier={1.5}
                 />
               </View>
             )}
@@ -127,6 +129,7 @@ const AppGuideModal: React.FC<AppGuideModalProps> = ({
                 testID={testIdWithKey('Secondary')}
                 buttonType={ButtonType.Secondary}
                 onPress={onSecondCallToActionPressed}
+                maxfontSizeMultiplier={1.5}
               />
             )}
           </View>


### PR DESCRIPTION
# Summary of Changes

Fixes AppGuideModal being cropped in the Home Screen in small phones with large font size setting at system level

# Screenshots, videos, or gifs

Before fix:
<img width="411" alt="image" src="https://github.com/user-attachments/assets/7891c468-6535-44ef-b119-f008fb075956" />

After fix:
<img width="411" alt="image" src="https://github.com/user-attachments/assets/940dfdb0-793a-4fd0-858c-544b4fac7d92" />

# Breaking change guide

N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [ ] If applicable, screenshots, gifs, or video are included for UI changes
- [ ] If applicable, breaking changes are described above along with how to address them
- [ ] Updated documentation as needed for changed code and new or modified features
- [ ] Added sufficient [tests](../packages/legacy/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed

