### PR TITLE
fix: prevent extra storage loads

### DIFF
--- a/.changeset/light-plums-rhyme.md
+++ b/.changeset/light-plums-rhyme.md
@@ -2,4 +2,4 @@
 '@bifold/core': patch
 ---
 
-Prevent unwanted duplicate initial storage loads and export lockout function for reuse elsewhere
+Prevent unwanted duplicate initial storage loads and export AuthProvider lockUserOut function for reuse elsewhere if desired

--- a/.changeset/light-plums-rhyme.md
+++ b/.changeset/light-plums-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+Prevent unwanted duplicate initial storage loads and export lockout function for reuse elsewhere

--- a/packages/core/__tests__/contexts/auth.ts
+++ b/packages/core/__tests__/contexts/auth.ts
@@ -7,6 +7,7 @@ const authContext = {
   isBiometricsActive: jest.fn(),
   disableBiometrics: jest.fn(),
   rekeyWallet: jest.fn(),
+  lockOutUser: jest.fn(),
 }
 
 export default authContext

--- a/packages/core/src/contexts/auth.tsx
+++ b/packages/core/src/contexts/auth.tsx
@@ -24,6 +24,7 @@ import { hashPIN } from '../utils/crypto'
 import { migrateToAskar } from '../utils/migration'
 
 export interface AuthContext {
+  lockOutUser: () => void
   checkWalletPIN: (PIN: string) => Promise<boolean>
   getWalletSecret: () => Promise<WalletSecret | undefined>
   walletSecret?: WalletSecret
@@ -128,6 +129,18 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     setWalletSecret(undefined)
   }, [])
 
+  const lockOutUser = useCallback(() => {
+    removeSavedWalletSecret()
+    dispatch({
+      type: DispatchAction.DID_AUTHENTICATE,
+      payload: [false],
+    })
+    dispatch({
+      type: DispatchAction.LOCKOUT_UPDATED,
+      payload: [{ displayNotification: true }],
+    })
+  }, [removeSavedWalletSecret, dispatch])
+
   const disableBiometrics = useCallback(async () => {
     await wipeWalletKey(true)
   }, [])
@@ -169,6 +182,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   return (
     <AuthContext.Provider
       value={{
+        lockOutUser,
         checkWalletPIN,
         getWalletSecret,
         removeSavedWalletSecret,

--- a/packages/core/src/navigators/RootStack.tsx
+++ b/packages/core/src/navigators/RootStack.tsx
@@ -43,12 +43,15 @@ const RootStack: React.FC = () => {
   }, [])
 
   useEffect(() => {
+    // Load state only if it hasn't been loaded yet
+    if (store.stateLoaded) return
+    
     loadState(dispatch).catch((err: unknown) => {
       const error = new BifoldError(t('Error.Title1044'), t('Error.Message1044'), (err as Error).message, 1001)
 
       DeviceEventEmitter.emit(EventTypes.ERROR_ADDED, error)
     })
-  }, [dispatch, loadState, t])
+  }, [dispatch, loadState, t, store.stateLoaded])
 
   if (shouldRenderMainStack && agent) {
     return (


### PR DESCRIPTION
# Summary of Changes

This PR prevents more than one initial state load from storage if the RootStack gets remounted. This prevents state from being overwritten with stale values. The other thing included in this PR is moving the `lockOutUser` function to AuthProvider for reuse if desired.

Note: this also makes it really easy to add a logout button if you so desire 👀

# Screenshots, videos, or gifs

N/A

# Breaking change guide

N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
