### PR TITLE
fix(pin): Screen readers are not able to read the PIN input screen #754

### DIFF
--- a/.changeset/warm-times-fail.md
+++ b/.changeset/warm-times-fail.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+properly readout accessibilitylabel of pin

--- a/packages/core/src/components/inputs/PINInput.tsx
+++ b/packages/core/src/components/inputs/PINInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, forwardRef, Ref } from 'react'
+import React, { useState, forwardRef, Ref, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, TextInput, TouchableOpacity, View } from 'react-native'
 import { CodeField, Cursor, useClearByFocusCell } from 'react-native-confirmation-code-field'
@@ -37,6 +37,9 @@ const PINInputComponent = (
     value: PIN,
     setValue: onChangeText,
   })
+  const allyLabel = useMemo(() => {
+    return showPIN ? PIN.split('').join(' ') : t('PINCreate.Masked')
+  }, [showPIN, PIN, t])
 
   const style = StyleSheet.create({
     container: {
@@ -67,13 +70,14 @@ const PINInputComponent = (
         <CodeField
           {...props}
           testID={testID}
-          accessibilityLabel={accessibilityLabel}
+          accessibilityLabel={PIN.length === 0 ? accessibilityLabel : allyLabel}
+          accessibilityRole={'text'}
           accessible
           value={PIN}
           rootStyle={PINInputTheme.codeFieldRoot}
           onChangeText={onChangeText}
           cellCount={minPINLength}
-          keyboardType="numeric"
+          keyboardType="number-pad"
           textContentType="password"
           renderCell={({ index, symbol, isFocused }) => {
             let child: React.ReactNode | string = ''

--- a/packages/core/src/localization/en/index.ts
+++ b/packages/core/src/localization/en/index.ts
@@ -247,6 +247,7 @@ const translation = {
     "PINDisclaimer": "If you forget it, you may need to set up your wallet again and re-add your cards.",
     "Show": "Show PIN",
     "Hide": "Hide PIN",
+    "Masked": "PIN Masked for privacy",
   },
   "PINChange": {
     "PinChangeSuccessTitle": "Successfully changed your PIN",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8194,9 +8194,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001669":
-  version: 1.0.30001669
-  resolution: "caniuse-lite@npm:1.0.30001669"
-  checksum: 8ed0c69d0c6aa3b1cbc5ba4e5f5330943e7b7165e257f6955b8b73f043d07ad922265261f2b54d9bbaf02886bbdba5e6f5b16662310a13f91f17035af3212de1
+  version: 1.0.30001717
+  resolution: "caniuse-lite@npm:1.0.30001717"
+  checksum: 357fbb230d86d28c0f7005d0c19a2274059ad4f1ed419ebe8754737ec908b567c9745abf0d16eda93417f40913221adc6290eb2f0432bc5bb5364f95bd7eabfa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary of Changes

This PR fixes screen readers ability to read the PIN input as individual digits (1111 now reads as "one" "one" "one" "one" instead of one thousand one hundred eleven), also fixed the PIN being readable while hidden.

# Screenshots, videos, or gifs

N/A

# Breaking change guide

N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [ ] If applicable, screenshots, gifs, or video are included for UI changes
- [ ] If applicable, breaking changes are described above along with how to address them
- [ ] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [ ] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
