### PR TITLE
fix: patch revocation check in credo indy vdr

### DIFF
--- a/.changeset/hot-wasps-argue.md
+++ b/.changeset/hot-wasps-argue.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+patch @credo-ts/indy-vdr to prevent issues with revocation check

--- a/.yarn/patches/@credo-ts-indy-vdr-npm-0.5.13-007d41ad5c.patch
+++ b/.yarn/patches/@credo-ts-indy-vdr-npm-0.5.13-007d41ad5c.patch
@@ -1,3 +1,16 @@
+diff --git a/build/anoncreds/utils/transform.js b/build/anoncreds/utils/transform.js
+index c38801e690b48598ae80df5466f7bffc7e587d04..57ada8e9486023caa04ab274916df52c9b73d85e 100644
+--- a/build/anoncreds/utils/transform.js
++++ b/build/anoncreds/utils/transform.js
+@@ -13,7 +13,7 @@ function anonCredsRevocationStatusListFromIndyVdr(revocationRegistryDefinitionId
+     // Check whether the highest delta index is supported in the `maxCredNum` field of the
+     // revocation registry definition. This will likely also be checked on other levels as well
+     // by the ledger or the indy-vdr library itself
+-    if (Math.max(...delta.issued, ...delta.revoked) >= revocationRegistryDefinition.value.maxCredNum) {
++    if (Math.max(...delta.issued, ...delta.revoked) > revocationRegistryDefinition.value.maxCredNum) {
+         throw new core_1.CredoError(`Highest delta index '${Math.max(...delta.issued, ...delta.revoked)}' is too large for the Revocation registry maxCredNum '${revocationRegistryDefinition.value.maxCredNum}' `);
+     }
+     // 0 means unrevoked, 1 means revoked
 diff --git a/build/pool/IndyVdrPool.js b/build/pool/IndyVdrPool.js
 index eab13b315dede8a2a7f7f56caa850405cf5f2f47..2109fb8eeae12c490b8233403b4445a5f6e0e465 100644
 --- a/build/pool/IndyVdrPool.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -2854,13 +2854,13 @@ __metadata:
 
 "@credo-ts/indy-vdr@patch:@credo-ts/indy-vdr@npm%3A0.5.13#./.yarn/patches/@credo-ts-indy-vdr-npm-0.5.13-007d41ad5c.patch::locator=bifold-wallet-root%40workspace%3A.":
   version: 0.5.13
-  resolution: "@credo-ts/indy-vdr@patch:@credo-ts/indy-vdr@npm%3A0.5.13#./.yarn/patches/@credo-ts-indy-vdr-npm-0.5.13-007d41ad5c.patch::version=0.5.13&hash=c42b94&locator=bifold-wallet-root%40workspace%3A."
+  resolution: "@credo-ts/indy-vdr@patch:@credo-ts/indy-vdr@npm%3A0.5.13#./.yarn/patches/@credo-ts-indy-vdr-npm-0.5.13-007d41ad5c.patch::version=0.5.13&hash=90a927&locator=bifold-wallet-root%40workspace%3A."
   dependencies:
     "@credo-ts/anoncreds": 0.5.13
     "@credo-ts/core": 0.5.13
   peerDependencies:
     "@hyperledger/indy-vdr-shared": ^0.2.2
-  checksum: ff4bc71ff42c36ffd27b7d4959730b4bf1acacf108a37dce2e8946b17e99380ecfe9c955e35f1289d730b839111b3d89ed8eb52092a62f2255b4707a79931f8a
+  checksum: d4d277ae722dc05f508ccfd6d5a770ed8790f53c084c98a39bf24aed15cbb4493f5bb48c40eb92ed7f8316a21b66f136a25e39d7d342a26f2b500d649d16c25b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary of Changes

An issue was discovered today where if your revocation registry size for a given credential was 4, and the fourth credential got revoked, proof requests using that credential would suddenly start failing. A PR to @credo-ts/indy-vdr will be made as well but this patch fixes the issue in the interim

# Screenshots, videos, or gifs

N/A

# Breaking change guide

N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
