### PR TITLE
feat: manual logout #2473

### DIFF
--- a/.changeset/tiny-crabs-cry.md
+++ b/.changeset/tiny-crabs-cry.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+Added logout button when developer mode is active

--- a/packages/core/__tests__/screens/NameWallet.test.tsx
+++ b/packages/core/__tests__/screens/NameWallet.test.tsx
@@ -35,6 +35,5 @@ describe('NameWallet Screen', () => {
     expect(WalletNameInput).not.toBeNull()
     expect(ContinueButton).not.toBeNull()
     expect(tree).toMatchSnapshot()
-
   })
 })

--- a/packages/core/__tests__/screens/RenameWallet.test.tsx
+++ b/packages/core/__tests__/screens/RenameWallet.test.tsx
@@ -24,7 +24,7 @@ describe('RenameWallet Screen', () => {
     const tree = render(
       <StoreProvider initialState={testDefaultState}>
         <BasicAppContext>
-          <RenameWallet/>
+          <RenameWallet />
         </BasicAppContext>
       </StoreProvider>
     )

--- a/packages/core/__tests__/screens/Settings.test.tsx
+++ b/packages/core/__tests__/screens/Settings.test.tsx
@@ -11,6 +11,8 @@ import { BasicAppContext } from '../helpers/app'
 import { CustomBasicAppContext } from '../helpers/app'
 import { TOKENS } from '../../src/container-api'
 import { MainContainer } from '../../src/container-impl'
+import { AuthContext } from '../../src/contexts/auth'
+import authContext from '../contexts/auth'
 
 describe('Settings Screen', () => {
   beforeEach(() => {
@@ -37,7 +39,9 @@ describe('Settings Screen', () => {
         ]}
       >
         <BasicAppContext>
-          <Settings navigation={useNavigation()} route={{} as any} />
+          <AuthContext.Provider value={authContext}>
+            <Settings navigation={useNavigation()} route={{} as any} />
+          </AuthContext.Provider>
         </BasicAppContext>
       </StoreContext.Provider>
     )
@@ -65,7 +69,9 @@ describe('Settings Screen', () => {
         ]}
       >
         <BasicAppContext>
-          <Settings navigation={useNavigation()} route={{} as any} />
+          <AuthContext.Provider value={authContext}>
+            <Settings navigation={useNavigation()} route={{} as any} />
+          </AuthContext.Provider>
         </BasicAppContext>
       </StoreContext.Provider>
     )
@@ -96,7 +102,9 @@ describe('Settings Screen', () => {
         ]}
       >
         <BasicAppContext>
-          <Settings navigation={useNavigation()} route={{} as any} />
+          <AuthContext.Provider value={authContext}>
+            <Settings navigation={useNavigation()} route={{} as any} />
+          </AuthContext.Provider>
         </BasicAppContext>
       </StoreContext.Provider>
     )
@@ -124,7 +132,9 @@ describe('Settings Screen', () => {
         ]}
       >
         <BasicAppContext>
-          <Settings navigation={useNavigation()} route={{} as any} />
+          <AuthContext.Provider value={authContext}>
+            <Settings navigation={useNavigation()} route={{} as any} />
+          </AuthContext.Provider>
         </BasicAppContext>
       </StoreContext.Provider>
     )
@@ -156,7 +166,9 @@ describe('Settings Screen', () => {
         ]}
       >
         <CustomBasicAppContext container={context}>
-          <Settings navigation={useNavigation()} route={{} as any} />
+          <AuthContext.Provider value={authContext}>
+            <Settings navigation={useNavigation()} route={{} as any} />
+          </AuthContext.Provider>
         </CustomBasicAppContext>
       </StoreContext.Provider>
     )

--- a/packages/core/__tests__/screens/__snapshots__/Settings.test.tsx.snap
+++ b/packages/core/__tests__/screens/__snapshots__/Settings.test.tsx.snap
@@ -91,6 +91,12 @@ exports[`Settings Screen Renders correctly 1`] = `
               "testID": "com.ariesbifold:id/DeveloperOptions",
               "title": "Settings.Developer",
             },
+            Object {
+              "accessibilityLabel": "Settings.Logout",
+              "onPress": [Function],
+              "testID": "com.ariesbifold:id/Logout",
+              "title": "Settings.Logout",
+            },
           ],
           "header": Object {
             "icon": Object {
@@ -1184,10 +1190,20 @@ exports[`Settings Screen Renders correctly 1`] = `
           <View
             style={
               Object {
-                "marginBottom": 10,
+                "backgroundColor": "#313132",
               }
             }
-          />
+          >
+            <View
+              style={
+                Object {
+                  "borderBottomColor": "#000000",
+                  "borderBottomWidth": 1,
+                  "marginHorizontal": 25,
+                }
+              }
+            />
+          </View>
         </View>
       </View>
       <View

--- a/packages/core/src/components/modals/CommonRemoveModal.tsx
+++ b/packages/core/src/components/modals/CommonRemoveModal.tsx
@@ -68,7 +68,6 @@ const Dropdown: React.FC<RemoveProps> = ({ title, content }) => {
 }
 
 const CommonRemoveModal: React.FC<CommonRemoveModalProps> = ({ usage, visible, onSubmit, onCancel, extraDetails }) => {
-
   if (!usage) {
     throw new Error('usage cannot be undefined')
   }
@@ -248,12 +247,13 @@ const CommonRemoveModal: React.FC<CommonRemoveModalProps> = ({ usage, visible, o
       case ModalUsage.CredentialOfferDecline:
         return (
           <View style={{ marginBottom: 25 }}>
-            <ThemedText variant="modalTitle" style={{ marginTop: 15 }}>{t('CredentialOffer.DeclineTitle')}</ThemedText>
+            <ThemedText variant="modalTitle" style={{ marginTop: 15 }}>
+              {t('CredentialOffer.DeclineTitle')}
+            </ThemedText>
             <ThemedText variant="modalNormal" style={{ marginVertical: 30 }}>
               {extraDetails
                 ? t('CredentialOffer.DeclineParagraph1WithIssuerName', { issuer: extraDetails })
-                : t('CredentialOffer.DeclineParagraph1')
-              }
+                : t('CredentialOffer.DeclineParagraph1')}
             </ThemedText>
             <ThemedText variant="modalNormal">{t('CredentialOffer.DeclineParagraph2')}</ThemedText>
           </View>

--- a/packages/core/src/contexts/activity.tsx
+++ b/packages/core/src/contexts/activity.tsx
@@ -12,7 +12,7 @@ import React, {
 import { AppState, AppStateStatus, PanResponder, View } from 'react-native'
 import { defaultAutoLockTime } from '../constants'
 import { TOKENS, useServices } from '../container-api'
-import { reasonTimeout, useAuth } from './auth'
+import { LockoutReason, useAuth } from './auth'
 import { useStore } from './store'
 
 // number of minutes before the timeout action is triggered
@@ -60,7 +60,7 @@ export const ActivityProvider: React.FC<PropsWithChildren> = ({ children }) => {
       // do not set timeout if timeout duration is set to 0
       if (milliseconds > 0) {
         // create new timeout
-        inactivityTimeoutRef.current = setTimeout(() => lockOutUser(reasonTimeout), milliseconds)
+        inactivityTimeoutRef.current = setTimeout(() => lockOutUser(LockoutReason.Timeout), milliseconds)
       }
     },
     [clearInactivityTimeoutIfExists, lockOutUser]
@@ -89,7 +89,7 @@ export const ActivityProvider: React.FC<PropsWithChildren> = ({ children }) => {
           Date.now() - lastActiveTimeRef.current >= timeoutInMilliseconds.current &&
           timeoutInMilliseconds.current > 0
         ) {
-          lockOutUser(reasonTimeout)
+          lockOutUser(LockoutReason.Timeout)
         } else {
           // otherwise restart message pickup
           try {

--- a/packages/core/src/contexts/activity.tsx
+++ b/packages/core/src/contexts/activity.tsx
@@ -12,7 +12,7 @@ import React, {
 import { AppState, AppStateStatus, PanResponder, View } from 'react-native'
 import { defaultAutoLockTime } from '../constants'
 import { TOKENS, useServices } from '../container-api'
-import { useAuth } from './auth'
+import { reasonTimeout, useAuth } from './auth'
 import { useStore } from './store'
 
 // number of minutes before the timeout action is triggered
@@ -60,7 +60,7 @@ export const ActivityProvider: React.FC<PropsWithChildren> = ({ children }) => {
       // do not set timeout if timeout duration is set to 0
       if (milliseconds > 0) {
         // create new timeout
-        inactivityTimeoutRef.current = setTimeout(lockOutUser, milliseconds)
+        inactivityTimeoutRef.current = setTimeout(() => lockOutUser(reasonTimeout), milliseconds)
       }
     },
     [clearInactivityTimeoutIfExists, lockOutUser]
@@ -89,7 +89,7 @@ export const ActivityProvider: React.FC<PropsWithChildren> = ({ children }) => {
           Date.now() - lastActiveTimeRef.current >= timeoutInMilliseconds.current &&
           timeoutInMilliseconds.current > 0
         ) {
-          lockOutUser()
+          lockOutUser(reasonTimeout)
         } else {
           // otherwise restart message pickup
           try {

--- a/packages/core/src/contexts/auth.tsx
+++ b/packages/core/src/contexts/auth.tsx
@@ -41,8 +41,8 @@ export interface AuthContext {
 
 export const AuthContext = createContext<AuthContext>(null as unknown as AuthContext)
 export enum LockoutReason {
-  Timeout = "Timeout",
-  Logout = "Logout",
+  Timeout = 'Timeout',
+  Logout = 'Logout',
 }
 
 export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) => {

--- a/packages/core/src/contexts/auth.tsx
+++ b/packages/core/src/contexts/auth.tsx
@@ -144,7 +144,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       })
       dispatch({
         type: DispatchAction.LOCKOUT_UPDATED,
-        payload: [{ displayNotification: reason === reasonTimeout }],
+        payload: [{ displayNotification: reason === LockoutReason.Timeout }],
       })
     },
     [removeSavedWalletSecret, dispatch]

--- a/packages/core/src/contexts/auth.tsx
+++ b/packages/core/src/contexts/auth.tsx
@@ -40,10 +40,10 @@ export interface AuthContext {
 }
 
 export const AuthContext = createContext<AuthContext>(null as unknown as AuthContext)
-export type LockoutReason = 'logout' | 'timeout'
-
-export const reasonLogout: LockoutReason = 'logout'
-export const reasonTimeout: LockoutReason = 'timeout'
+export enum LockoutReason {
+  Timeout = "Timeout",
+  Logout = "Logout",
+}
 
 export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
   const [walletSecret, setWalletSecret] = useState<WalletSecret>()

--- a/packages/core/src/contexts/auth.tsx
+++ b/packages/core/src/contexts/auth.tsx
@@ -26,7 +26,7 @@ import { BifoldError } from '../types/error'
 import { EventTypes } from '../constants'
 
 export interface AuthContext {
-  lockOutUser: () => void
+  lockOutUser: (reason: LockoutReason) => void
   checkWalletPIN: (PIN: string) => Promise<boolean>
   getWalletSecret: () => Promise<WalletSecret | undefined>
   walletSecret?: WalletSecret
@@ -40,6 +40,10 @@ export interface AuthContext {
 }
 
 export const AuthContext = createContext<AuthContext>(null as unknown as AuthContext)
+export type LockoutReason = 'logout' | 'timeout'
+
+export const reasonLogout: LockoutReason = 'logout'
+export const reasonTimeout: LockoutReason = 'timeout'
 
 export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
   const [walletSecret, setWalletSecret] = useState<WalletSecret>()
@@ -131,17 +135,20 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     setWalletSecret(undefined)
   }, [])
 
-  const lockOutUser = useCallback(() => {
-    removeSavedWalletSecret()
-    dispatch({
-      type: DispatchAction.DID_AUTHENTICATE,
-      payload: [false],
-    })
-    dispatch({
-      type: DispatchAction.LOCKOUT_UPDATED,
-      payload: [{ displayNotification: true }],
-    })
-  }, [removeSavedWalletSecret, dispatch])
+  const lockOutUser = useCallback(
+    (reason: LockoutReason) => {
+      removeSavedWalletSecret()
+      dispatch({
+        type: DispatchAction.DID_AUTHENTICATE,
+        payload: [false],
+      })
+      dispatch({
+        type: DispatchAction.LOCKOUT_UPDATED,
+        payload: [{ displayNotification: reason === reasonTimeout }],
+      })
+    },
+    [removeSavedWalletSecret, dispatch]
+  )
 
   const disableBiometrics = useCallback(async () => {
     await wipeWalletKey(true)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -153,8 +153,7 @@ export type { Config, HistoryEventsLoggerConfig } from './types/config'
 export { BaseTourID } from './types/tour'
 export type { SplashProps } from './screens/Splash'
 export type { OnboardingStackProps } from './navigators/OnboardingStack'
-export type { LockoutReason } from './contexts/auth'
-export { reasonLogout, reasonTimeout } from './contexts/auth'
+export { LockoutReason } from './contexts/auth'
 
 export {
   createApp,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -153,6 +153,8 @@ export type { Config, HistoryEventsLoggerConfig } from './types/config'
 export { BaseTourID } from './types/tour'
 export type { SplashProps } from './screens/Splash'
 export type { OnboardingStackProps } from './navigators/OnboardingStack'
+export type { LockoutReason } from './contexts/auth'
+export { reasonLogout, reasonTimeout } from './contexts/auth'
 
 export {
   createApp,

--- a/packages/core/src/localization/en/index.ts
+++ b/packages/core/src/localization/en/index.ts
@@ -743,6 +743,7 @@ const translation = {
     "Developer": "Developer options",
     "Notifications": "Notifications",
     "AutoLockTime": "Auto lock time",
+    "Logout": "Log out",
   },
   "AutoLockTimes": {
     "FiveMinutes": "Five Minutes",

--- a/packages/core/src/localization/fr/index.ts
+++ b/packages/core/src/localization/fr/index.ts
@@ -731,6 +731,7 @@ const translation = {
         "ScanMyQR": "Scanner mon code QR",
         "Developer": "Options de développeur",
         "AutoLockTime": "Auto lock time (FR)",
+        "Logout": "Déconnexion",
     },
     "AutoLockTimes": {
         "FiveMinutes": "Five Minutes (FR)",

--- a/packages/core/src/localization/pt-br/index.ts
+++ b/packages/core/src/localization/pt-br/index.ts
@@ -715,6 +715,7 @@ const translation = {
     "ScanMyQR": "Scanear meu QR code",
     "Developer": "Opções de Desenvolvedor",
     "AutoLockTime": "Auto lock time (PT-BR)",
+    "Logout": "Sair",
   },
   "AutoLockTimes": {
     "FiveMinutes": "Five Minutes (PT-BR)",

--- a/packages/core/src/screens/NameWallet.tsx
+++ b/packages/core/src/screens/NameWallet.tsx
@@ -3,9 +3,7 @@ import React from 'react'
 import WalletNameForm from '../components/forms/WalletNameForm'
 
 const NameWallet: React.FC = () => {
-  return (
-    <WalletNameForm />
-  )
+  return <WalletNameForm />
 }
 
 export default NameWallet

--- a/packages/core/src/screens/RenameWallet.tsx
+++ b/packages/core/src/screens/RenameWallet.tsx
@@ -12,14 +12,15 @@ const RenameWallet: React.FC = () => {
     navigation.goBack()
   }, [navigation])
 
-  const onSubmitSuccess = useCallback((name: string) => {
-    agent.config.label = name
-    navigation.goBack()
-  }, [navigation, agent])
-
-  return (
-    <WalletNameForm isRenaming onCancel={onCancel} onSubmitSuccess={onSubmitSuccess} />
+  const onSubmitSuccess = useCallback(
+    (name: string) => {
+      agent.config.label = name
+      navigation.goBack()
+    },
+    [navigation, agent]
   )
+
+  return <WalletNameForm isRenaming onCancel={onCancel} onSubmitSuccess={onSubmitSuccess} />
 }
 
 export default RenameWallet

--- a/packages/core/src/screens/Settings.tsx
+++ b/packages/core/src/screens/Settings.tsx
@@ -1,6 +1,7 @@
 import { StackScreenProps } from '@react-navigation/stack'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
+import { reasonLogout, useAuth } from '../contexts/auth'
 import {
   ScrollView,
   SectionList,
@@ -33,6 +34,7 @@ type SettingsProps = StackScreenProps<SettingStackParams>
 const Settings: React.FC<SettingsProps> = ({ navigation }) => {
   const { t, i18n } = useTranslation()
   const [store] = useStore()
+  const { lockOutUser } = useAuth()
   const onDevModeTriggered = () => {
     Vibration.vibrate()
     navigation.navigate(Screens.Developer)
@@ -215,6 +217,18 @@ const Settings: React.FC<SettingsProps> = ({ navigation }) => {
           accessibilityLabel: t('Settings.Developer'),
           testID: testIdWithKey('DeveloperOptions'),
           onPress: () => navigation.navigate(Screens.Developer),
+        },
+      ]
+    }
+    const additionalSection = settingsSections.find((item) => item.header.title === t('Settings.AppSettings'))
+    if (additionalSection && !additionalSection.data.some((item) => item.testID === testIdWithKey('Logout'))) {
+      additionalSection.data = [
+        ...additionalSection.data,
+        {
+          title: t('Settings.Logout'),
+          accessibilityLabel: t('Settings.Logout'),
+          testID: testIdWithKey('Logout'),
+          onPress: () => lockOutUser(reasonLogout),
         },
       ]
     }

--- a/packages/core/src/screens/Settings.tsx
+++ b/packages/core/src/screens/Settings.tsx
@@ -1,7 +1,7 @@
 import { StackScreenProps } from '@react-navigation/stack'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { reasonLogout, useAuth } from '../contexts/auth'
+import { LockoutReason, useAuth } from '../contexts/auth'
 import {
   ScrollView,
   SectionList,
@@ -218,17 +218,11 @@ const Settings: React.FC<SettingsProps> = ({ navigation }) => {
           testID: testIdWithKey('DeveloperOptions'),
           onPress: () => navigation.navigate(Screens.Developer),
         },
-      ]
-    }
-    const additionalSection = settingsSections.find((item) => item.header.title === t('Settings.AppSettings'))
-    if (additionalSection && !additionalSection.data.some((item) => item.testID === testIdWithKey('Logout'))) {
-      additionalSection.data = [
-        ...additionalSection.data,
         {
           title: t('Settings.Logout'),
           accessibilityLabel: t('Settings.Logout'),
           testID: testIdWithKey('Logout'),
-          onPress: () => lockOutUser(reasonLogout),
+          onPress: () => lockOutUser(LockoutReason.Logout),
         },
       ]
     }

--- a/packages/core/src/screens/Splash.tsx
+++ b/packages/core/src/screens/Splash.tsx
@@ -47,7 +47,6 @@ const Splash: React.FC<SplashProps> = ({ initializeAgent }) => {
     if (!walletSecret) {
       throw new Error('Wallet secret is missing')
     }
-    
     initializing.current = true
 
     const initAgentAsyncEffect = async (): Promise<void> => {


### PR DESCRIPTION
# Summary of Changes

This PR adds a logout button to the settings screen that is only visible when developer mode is enabled. The logout button will take you to the pin enter screen without the 'logged out due to 5 minutes of inactivity message'.

# Screenshots, videos, or gifs

N/A

# Breaking change guide

N/A

# Related Issues

 N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
