### PR TITLE
fix: change accessibility labels in chat slider

### DIFF
--- a/.changeset/mighty-items-burn.md
+++ b/.changeset/mighty-items-burn.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+changed accessibility labels in the actions slider in the chat screen

--- a/packages/core/src/components/chat/ActionSlider.tsx
+++ b/packages/core/src/components/chat/ActionSlider.tsx
@@ -85,7 +85,7 @@ const ActionSlider: React.FC<Props> = ({ actions, onDismiss }) => {
               <TouchableOpacity
                 key={action.text}
                 testID={testIdWithKey(action.text)}
-                accessibilityLabel={testIdWithKey(action.text)}
+                accessibilityLabel={action.text}
                 accessibilityRole="button"
                 style={styles.drawerRow}
                 onPress={action.onPress}


### PR DESCRIPTION
# Summary of Changes

Changed the accessibility label for items in the action slider in the chat window to use action.text instead of their testID (ex: the 'Send a Proof Request' button used to have the label 'Com.ariesbifold:id/Send a Proof request', now 'Send a Proof request'.) 

# Screenshots, videos, or gifs

![Screenshot_20250603_124508sapr](https://github.com/user-attachments/assets/9a4d3c1e-b0a5-459e-a059-e6cc29c12f98)


# Breaking change guide

N/A

# Related Issues

bcgov/bc-wallet-mobile#1867

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
