### PR TITLE
fix: use different logo when loading qr code

### DIFF
--- a/.changeset/deep-walls-ask.md
+++ b/.changeset/deep-walls-ask.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+swapped logo in qr loading splash

--- a/packages/core/__tests__/components/__snapshots__/LoadingView.test.tsx.snap
+++ b/packages/core/__tests__/components/__snapshots__/LoadingView.test.tsx.snap
@@ -37,9 +37,9 @@ exports[`LoadingView Component renders correctly 1`] = `
       }
       style={
         Object {
-          "height": "33%",
+          "height": 120,
           "objectFit": "contain",
-          "width": "33%",
+          "width": 120,
         }
       }
       testID="com.ariesbifold:id/LoadingActivityIndicatorImage"

--- a/packages/core/__tests__/components/__snapshots__/QRScanner.test.tsx.snap
+++ b/packages/core/__tests__/components/__snapshots__/QRScanner.test.tsx.snap
@@ -650,9 +650,9 @@ exports[`QRScanner Component Renders correctly on second tab 1`] = `
                 }
                 style={
                   Object {
-                    "height": "33%",
+                    "height": 120,
                     "objectFit": "contain",
-                    "width": "33%",
+                    "width": 120,
                   }
                 }
                 testID="com.ariesbifold:id/LoadingActivityIndicatorImage"

--- a/packages/core/__tests__/screens/__snapshots__/ProofRequesting.test.tsx.snap
+++ b/packages/core/__tests__/screens/__snapshots__/ProofRequesting.test.tsx.snap
@@ -47,9 +47,9 @@ exports[`ProofRequesting Component generate new qr works correctly 1`] = `
             }
             style={
               Object {
-                "height": "33%",
+                "height": 120,
                 "objectFit": "contain",
-                "width": "33%",
+                "width": 120,
               }
             }
             testID="com.ariesbifold:id/LoadingActivityIndicatorImage"
@@ -266,9 +266,9 @@ exports[`ProofRequesting Component renders correctly 1`] = `
             }
             style={
               Object {
-                "height": "33%",
+                "height": 120,
                 "objectFit": "contain",
-                "width": "33%",
+                "width": 120,
               }
             }
             testID="com.ariesbifold:id/LoadingActivityIndicatorImage"

--- a/packages/core/__tests__/screens/__snapshots__/Scan.test.tsx.snap
+++ b/packages/core/__tests__/screens/__snapshots__/Scan.test.tsx.snap
@@ -37,9 +37,9 @@ exports[`Scan Screen Renders correctly 1`] = `
       }
       style={
         Object {
-          "height": "33%",
+          "height": 120,
           "objectFit": "contain",
-          "width": "33%",
+          "width": 120,
         }
       }
       testID="com.ariesbifold:id/LoadingActivityIndicatorImage"

--- a/packages/core/__tests__/screens/__snapshots__/Splash.test.tsx.snap
+++ b/packages/core/__tests__/screens/__snapshots__/Splash.test.tsx.snap
@@ -36,9 +36,9 @@ exports[`Splash Screen Renders default correctly 1`] = `
       }
       style={
         Object {
-          "height": "33%",
+          "height": 120,
           "objectFit": "contain",
-          "width": "33%",
+          "width": 120,
         }
       }
       testID="com.ariesbifold:id/LoadingActivityIndicatorImage"

--- a/packages/core/src/components/animated/LoadingIndicator.tsx
+++ b/packages/core/src/components/animated/LoadingIndicator.tsx
@@ -35,8 +35,8 @@ const LoadingIndicator: React.FC = () => {
   return (
     <View style={{ alignItems: 'center', justifyContent: 'center' }} testID={testIdWithKey('LoadingActivityIndicator')}>
       <Image
-        source={Assets.img.logoPrimary.src}
-        style={{ width: Assets.img.logoPrimary.width, height: Assets.img.logoPrimary.height, objectFit: 'contain' }}
+        source={Assets.img.logoSecondary.src}
+        style={{ width: Assets.img.logoSecondary.width, height: Assets.img.logoSecondary.height, objectFit: 'contain' }}
         testID={testIdWithKey('LoadingActivityIndicatorImage')}
       />
       <Animated.View style={[style.animation, { transform: [{ rotate: rotation }] }]}>


### PR DESCRIPTION
# Summary of Changes

Instead of using logoPrimary (light text), use logoSecondary (dark text) on the white background qr code loading splash.

# Screenshots, videos, or gifs

[Screen_recording_20250604_142200.webm](https://github.com/user-attachments/assets/60ef36e2-4ae6-4386-8f20-4b30b88b6656)

![Screenshot 2025-06-04 143948](https://github.com/user-attachments/assets/05a7f6ab-dfe2-4b0f-8254-9846c3a92605)


# Breaking change guide

N/A

# Related Issues

bcgov/bc-wallet-mobile#1201

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
