### PR TITLE
feat: add json button to proof request screen

### DIFF
--- a/.changeset/rich-doors-heal.md
+++ b/.changeset/rich-doors-heal.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+added json details button to proof request screen

--- a/packages/core/src/localization/en/en.json
+++ b/packages/core/src/localization/en/en.json
@@ -471,8 +471,7 @@
     "GoToCredentialDetail": "Go to credential details",
     "CredentialName": "Credential name",
     "Credentials": "My credentials from this contact",
-    "NoCredentials": "You don't have any credentials from this contact.",
-    "JSONDetails": "View JSON details"
+    "NoCredentials": "You don't have any credentials from this contact."
   },
   "WhatAreContacts": {
     "Title": "What are Contacts?",

--- a/packages/core/src/localization/en/en.json
+++ b/packages/core/src/localization/en/en.json
@@ -47,7 +47,8 @@
     "Close": "Close",
     "Remove": "Remove",
     "GotIt": "Got it",
-    "Send": "Send"
+    "Send": "Send",
+    "ViewJSON": "View JSON Details"
   },
   "Date": {
     "ShortFormat": "MMM D",

--- a/packages/core/src/localization/fr/fr.json
+++ b/packages/core/src/localization/fr/fr.json
@@ -47,7 +47,9 @@
     "Remove": "Supprimer",
     "Close": "Fermer",
     "GotIt": "Got it (FR)",
-    "Send": "Envoyer"
+    "Send": "Envoyer",
+    "ViewJSON": "View JSON Details (FR)"
+
   },
   "Date": {
     "ShortFormat": "D MMM",
@@ -474,8 +476,7 @@
     "GoToCredentialDetail": "Aller au détail de l'attestation",
     "CredentialName": "Nom du justificatif",
     "Credentials": "Mes justificatifs avec ce contact",
-    "NoCredentials": "Vous n'avez aucun justificatif de ce contact.",
-    "JSONDetails": "View JSON details (FR)"
+    "NoCredentials": "Vous n'avez aucun justificatif de ce contact."
   },
   "WhatAreContacts": {
     "Title": "Que sont les Contacts?",

--- a/packages/core/src/localization/pt-br/pt-br.json
+++ b/packages/core/src/localization/pt-br/pt-br.json
@@ -46,7 +46,9 @@
     "Close": "Fechar",
     "Remove": "Remover",
     "GotIt": "Got it (PT-BR)",
-    "Send": "Enviar"
+    "Send": "Enviar",
+    "ViewJSON": "View JSON Details (PT-BR)"
+
   },
   "Date": {
     "ShortFormat": "D MMM",
@@ -454,8 +456,7 @@
     "GoToCredentialDetail": "Ir para os detalhes da credencial",
     "CredentialName": "Nome da credencial",
     "Credentials": "Minhas credenciais",
-    "NoCredentials": "Você não tem nenhuma credencial com esse Contato.",
-    "JSONDetails": "View JSON details (PT-BR)"
+    "NoCredentials": "Você não tem nenhuma credencial com esse Contato."
   },
   "WhatAreContacts": {
     "Title": "O que são Contatos?",

--- a/packages/core/src/screens/ContactDetails.tsx
+++ b/packages/core/src/screens/ContactDetails.tsx
@@ -311,13 +311,13 @@ const ContactDetails: React.FC<ContactDetailsProps> = ({ route }) => {
         {store?.preferences.developerModeEnabled && (
           <TouchableOpacity
             onPress={callViewJSONDetails}
-            accessibilityLabel={t('ContactDetails.JSONDetails')}
+            accessibilityLabel={t('Global.ViewJSON')}
             accessibilityRole={'button'}
             testID={testIdWithKey('JSONDetails')}
             style={[styles.contentContainer, styles.actionContainer, { marginTop: 10 }]}
           >
             <Assets.svg.iconCode width={20} height={20} color={ColorPallet.brand.text} />
-            <ThemedText>{t('ContactDetails.JSONDetails')}</ThemedText>
+            <ThemedText>{t('Global.ViewJSON')}</ThemedText>
           </TouchableOpacity>
         )}
         <TouchableOpacity

--- a/packages/core/src/screens/CredentialDetails.tsx
+++ b/packages/core/src/screens/CredentialDetails.tsx
@@ -414,13 +414,13 @@ const CredentialDetails: React.FC<CredentialDetailsProps> = ({ navigation, route
           >
             <TouchableOpacity
               onPress={callViewJSONDetails}
-              accessibilityLabel={t('ContactDetails.JSONDetails')}
+              accessibilityLabel={t('Global.ViewJSON')}
               accessibilityRole={'button'}
               testID={testIdWithKey('JSONDetails')}
               style={{ flexDirection: 'row', gap: 8 }}
             >
               <Assets.svg.iconCode width={20} height={20} color={ColorPallet.brand.secondary} />
-              <ThemedText>{t('ContactDetails.JSONDetails')}</ThemedText>
+              <ThemedText>{t('Global.ViewJSON')}</ThemedText>
             </TouchableOpacity>
           </View>
         )}

--- a/packages/core/src/screens/ProofRequest.tsx
+++ b/packages/core/src/screens/ProofRequest.tsx
@@ -637,6 +637,19 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, proofId }) => {
     navigation.getParent()?.navigate(TabStacks.HomeStack, { screen: Screens.Home })
   }, [navigation])
 
+  const callViewJSONDetails = useCallback(() => {
+    navigation.navigate(Stacks.ContactStack, {
+      screen: Screens.JSONDetails,
+      params: {
+        jsonBlob:
+          '"proof":' +
+          JSON.stringify(proof, null, 2) +
+          '\n"retrievedCredentials":' +
+          JSON.stringify(retrievedCredentials, null, 2),
+      },
+    })
+  }, [navigation, proof, retrievedCredentials])
+
   const shareDisabledErrors = useMemo(() => {
     return {
       hasCredentialError: !hasAvailableCredentials,
@@ -802,6 +815,19 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, proofId }) => {
                     onPress={toggleDeclineModalVisible}
                   />
                 </View>
+                {store.preferences.developerModeEnabled && (
+                  <>
+                    <View style={styles.footerButton}>
+                      <Button
+                        title={t('Global.ViewJSON')}
+                        accessibilityLabel={t('Global.ViewJSON')}
+                        testID={testIdWithKey('JSONDetails')}
+                        buttonType={ButtonType.Secondary}
+                        onPress={callViewJSONDetails}
+                      />
+                    </View>
+                  </>
+                )}
               </>
             )}
           </>


### PR DESCRIPTION
# Summary of Changes

Added the ability to view json details from the proof request screen

# Screenshots, videos, or gifs

[untitled2.webm](https://github.com/user-attachments/assets/91da9005-4c20-4aa8-b6cd-c07cf2b6a8e3)


# Breaking change guide

N/A

# Related Issues

bcgov/bc-wallet-mobile#2515

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
