### PR TITLE
feat: Pin autosubmit

### DIFF
--- a/.changeset/solid-needles-do.md
+++ b/.changeset/solid-needles-do.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+PIN automatically triggers unlock when minPINLength characters are entered

--- a/packages/core/__mocks__/react-native-keychain.ts
+++ b/packages/core/__mocks__/react-native-keychain.ts
@@ -1,6 +1,16 @@
 const ACCESS_CONTROL = jest.fn()
-const ACCESSIBLE = jest.fn()
+const ACCESSIBLE = {
+  ALWAYS: 'Always',
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'WhenUnlockedThisDeviceOnly',
+}
 const SECURITY_LEVEL = jest.fn()
 const STORAGE_TYPE = jest.fn()
+const setGenericPassword = jest.fn().mockResolvedValue(true)
 
-export { ACCESS_CONTROL, ACCESSIBLE, SECURITY_LEVEL, STORAGE_TYPE }
+export default {
+  ACCESS_CONTROL,
+  ACCESSIBLE,
+  SECURITY_LEVEL,
+  STORAGE_TYPE,
+  setGenericPassword,
+}

--- a/packages/core/__tests__/screens/PINEnter.test.tsx
+++ b/packages/core/__tests__/screens/PINEnter.test.tsx
@@ -1,6 +1,7 @@
 import { render, fireEvent } from '@testing-library/react-native'
 import React, { act } from 'react'
 import { container } from 'tsyringe'
+import { Keyboard } from 'react-native'
 
 import { ContainerProvider } from '../../src/container-api'
 import { MainContainer } from '../../src/container-impl'
@@ -156,5 +157,57 @@ describe('PINEnter Screen', () => {
     )
     const versionText = await tree.getByTestId(testIdWithKey('Version'))
     expect(versionText).not.toBeNull()
+  })
+
+  test('keyboard dismiss is called when pin input is filled', async () => {
+    jest.spyOn(Keyboard, 'dismiss').mockImplementation(() => {})
+
+    const main = new MainContainer(container.createChildContainer()).init()
+    const tree = render(
+      <ContainerProvider value={main}>
+        <StoreProvider
+          initialState={{
+            ...defaultState,
+          }}
+        >
+          <AuthContext.Provider value={authContext}>
+            <PINEnter setAuthenticated={jest.fn()} />
+          </AuthContext.Provider>
+        </StoreProvider>
+      </ContainerProvider>
+    )
+    const pinInput = tree.getByTestId(testIdWithKey('EnterPIN'))
+    await act(async () => {
+      fireEvent.changeText(pinInput, '123456') // minpinlength is 6
+    })
+    expect(Keyboard.dismiss).toHaveBeenCalled()
+  })
+
+  test('pin is submitted when pin input is filled', async () => {
+    const setAuthenticatedMock = jest.fn()
+    const mockAuthContext = {
+      ...authContext,
+      checkWalletPIN: jest.fn().mockResolvedValue(true),
+      setAuthenticated: setAuthenticatedMock,
+    }
+    const main = new MainContainer(container.createChildContainer()).init()
+    const tree = render(
+      <ContainerProvider value={main}>
+        <StoreProvider
+          initialState={{
+            ...defaultState,
+          }}
+        >
+          <AuthContext.Provider value={mockAuthContext}>
+            <PINEnter setAuthenticated={mockAuthContext.setAuthenticated} />
+          </AuthContext.Provider>
+        </StoreProvider>
+      </ContainerProvider>
+    )
+    const pinInput = tree.getByTestId(testIdWithKey('EnterPIN'))
+    await act(async () => {
+      fireEvent.changeText(pinInput, '123456') // minpinlength is 6
+    })
+    expect(setAuthenticatedMock).toHaveBeenCalled()
   })
 })

--- a/packages/core/src/screens/PINEnter.tsx
+++ b/packages/core/src/screens/PINEnter.tsx
@@ -333,6 +333,7 @@ const PINEnter: React.FC<PINEnterProps> = ({ setAuthenticated }) => {
               setPIN(p)
               if (p.length === minPINLength) {
                 Keyboard.dismiss()
+                onPINInputCompleted(p)
               }
             }}
             testID={testIdWithKey('EnterPIN')}


### PR DESCRIPTION
# Summary of Changes

Pin screen will now automatically submit the pin as soon minPINLength characters are entered. This solves the issue of the unlock button jumping around when the keyboard is dismissed. 

# Screenshots, videos, or gifs

![untitled480](https://github.com/user-attachments/assets/359b3609-323f-429b-9c66-411fff410628)

# Breaking change guide

N/A

# Related Issues

https://github.com/bcgov/bc-wallet-mobile/issues/2395

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
