### PR TITLE
fix: unneeded safearea

### DIFF
--- a/.changeset/old-nails-sit.md
+++ b/.changeset/old-nails-sit.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+Remove extra safearea from developer modal

--- a/packages/core/src/components/modals/DeveloperModal.tsx
+++ b/packages/core/src/components/modals/DeveloperModal.tsx
@@ -12,7 +12,7 @@ interface DeveloperModalProps {
 }
 
 const DeveloperModal: React.FC<DeveloperModalProps> = ({ onBackPressed }) => {
-  const { NavigationTheme, ColorPallet } = useTheme()
+  const { NavigationTheme } = useTheme()
   const [Developer] = useServices([TOKENS.SCREEN_DEVELOPER])
   const { t } = useTranslation()
 
@@ -25,7 +25,6 @@ const DeveloperModal: React.FC<DeveloperModalProps> = ({ onBackPressed }) => {
         <FauxHeader title={t('Screens.Developer')} onBackPressed={onBackPressed} />
         <Developer />
       </SafeAreaView>
-      <SafeAreaView edges={['bottom']} style={{ backgroundColor: ColorPallet.brand.primaryBackground }} />
     </SafeAreaModal>
   )
 }


### PR DESCRIPTION
# Summary of Changes

There was an extra unnecessary safeareaview edge in the developer modal, this PR removes it

# Screenshots, videos, or gifs

This is being removed
![Screenshot 2025-07-16 at 2 56 56 PM](https://github.com/user-attachments/assets/879dee50-8ace-4c01-88b9-d6d6f5981eaf)

# Breaking change guide

N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
