### PR TITLE
fix: swap credential_help_url for issuer_url in failed proof request 2337

### DIFF
--- a/.changeset/violet-worlds-show.md
+++ b/.changeset/violet-worlds-show.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+Swapped credential_help_url for issuer_url in failed proof request

--- a/packages/core/src/assets/oca-bundles.json
+++ b/packages/core/src/assets/oca-bundles.json
@@ -21,7 +21,7 @@
         "description": "",
         "issuer": "",
         "issuer_description": "",
-        "issuer_url": ""
+        "issuer_url": "http://example.com/issue"
       },
       {
         "capture_base": "EfeQBz5tyC0gett-ETgkg4pkxBwwuQoeYsT-9Nt0cNsc",
@@ -33,7 +33,7 @@
         "description": "",
         "issuer": "",
         "issuer_description": "",
-        "issuer_url": ""
+        "issuer_url": "http://example.com/issue"
       },
       {
         "capture_base": "EfeQBz5tyC0gett-ETgkg4pkxBwwuQoeYsT-9Nt0cNsc",
@@ -88,7 +88,7 @@
         "description": "",
         "issuer": "",
         "issuer_description": "",
-        "issuer_url": ""
+        "issuer_url": "http://example.com/issue"
       },
       {
         "capture_base": "EfeQBz5tyC0gett-ETgkg4pkxBwwuQoeYsT-9Nt0cNsc",
@@ -100,7 +100,7 @@
         "description": "",
         "issuer": "",
         "issuer_description": "",
-        "issuer_url": ""
+        "issuer_url": "http://example.com/issue"
       },
       {
         "capture_base": "EfeQBz5tyC0gett-ETgkg4pkxBwwuQoeYsT-9Nt0cNsc",

--- a/packages/core/src/components/misc/CredentialCard11.tsx
+++ b/packages/core/src/components/misc/CredentialCard11.tsx
@@ -220,9 +220,9 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
     bundleResolver.resolveAllBundles(params).then((bundle: any) => {
       if (proof) {
         setFlaggedAttributes((bundle as any).bundle.bundle.flaggedAttributes.map((attr: any) => attr.name))
-        const credHelpUrl =
-          (bundle as any).bundle.bundle.metadata.credentialSupportUrl[params.language] ??
-          Object.values((bundle as any).bundle.bundle.metadata.credentialSupportUrl)?.[0]
+        const issuerUrl =
+          (bundle as any).bundle.bundle.metadata.issuerUrl[params.language] ??
+          Object.values((bundle as any).bundle.bundle.metadata.issuerUrl)?.[0]
 
         // Check if there is a help action override for this credential
         const override = credHelpActionOverrides?.find(
@@ -234,9 +234,9 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
           setHelpAction(() => () => {
             override.action(navigation)
           })
-        } else if (credHelpUrl) {
+        } else if (issuerUrl) {
           setHelpAction(() => () => {
-            Linking.openURL(credHelpUrl)
+            Linking.openURL(issuerUrl)
           })
         }
       }


### PR DESCRIPTION
# Summary of Changes

This PR swaps the credential_help_url for the issuer_url in the failed proof request view.
Now the 'Get this credential` button will link to the issuer url.

Steps to reproduce:

1. Add a valid credential to your wallet
2. Generate a proof request for a different credential
3. Scan invalid proof request
4. Select "Get this credential"

Note: This is dependent on the credential having the correct `issuer_url` configured. The proof shown in the below image is configured correctly with both values pointing to the correct locations.

<img width="468" height="410" alt="image" src="https://github.com/user-attachments/assets/08c2ae9f-fad5-4f8d-865c-bce937620f7a" />

# Breaking change guide

N/A

# Related Issues

- [2337](https://github.com/orgs/bcgov/projects/108?pane=issue&itemId=93013284&issue=bcgov%7Cbc-wallet-mobile%7C2337)

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
