### PR TITLE
fix: revocation styling 2357

### DIFF
--- a/.changeset/hot-snails-fetch.md
+++ b/.changeset/hot-snails-fetch.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+Updated revoked credential styling

--- a/packages/core/src/components/misc/CredentialCard11.tsx
+++ b/packages/core/src/components/misc/CredentialCard11.tsx
@@ -490,30 +490,55 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
     )
   }
 
-  function getSliceBackgroundColor(): ColorValue | undefined {
-    if (hideSlice) return 'transparent'
-    return brandingOverlayType === BrandingOverlayType.Branding10
-      ? backgroundColorIfRevoked(styles.secondaryBodyContainer.backgroundColor)
-      : overlay.brandingOverlay?.secondaryBackgroundColor
+  /**
+   * Returns the background color for the slice of the card.
+   *
+   * @return {ColorValue} - The background color for the slice.
+   */
+  function getSliceBackgroundColor(): ColorValue {
+    if (overlay.brandingOverlay?.secondaryBackgroundColor) {
+      return overlay.brandingOverlay.secondaryBackgroundColor
+    }
+
+    if (styles.secondaryBodyContainer.backgroundColor) {
+      return styles.secondaryBodyContainer.backgroundColor
+    }
+
+    return 'transparent'
   }
 
   const CredentialCardSecondaryBody: React.FC = () => {
+    // If the slice is hidden, we return an empty view with the same styles
+    if (hideSlice) {
+      return (
+        <View
+          testID={testIdWithKey('CredentialCardSecondaryBody')}
+          style={[
+            styles.secondaryBodyContainer,
+            {
+              backgroundColor: 'transparent',
+              overflow: 'hidden',
+            },
+          ]}
+        />
+      )
+    }
+
     return (
       <View
         testID={testIdWithKey('CredentialCardSecondaryBody')}
         style={[
           styles.secondaryBodyContainer,
           {
-            backgroundColor: getSliceBackgroundColor() ?? ColorPallet.brand.secondaryBackground,
+            backgroundColor: getSliceBackgroundColor(),
             overflow: 'hidden',
           },
         ]}
       >
         {overlay.brandingOverlay?.backgroundImageSlice &&
-        (!displayItems || brandingOverlayType === BrandingOverlayType.Branding11) &&
-        !hideSlice ? (
+        (!displayItems || brandingOverlayType === BrandingOverlayType.Branding11) ? (
           <ImageBackground
-            source={toImageSource(overlay.brandingOverlay?.backgroundImageSlice)}
+            source={toImageSource(overlay.brandingOverlay.backgroundImageSlice)}
             style={{ flexGrow: 1 }}
             imageStyle={{
               borderTopLeftRadius: borderRadius,
@@ -521,8 +546,7 @@ const CredentialCard11: React.FC<CredentialCard11Props> = ({
             }}
           />
         ) : (
-          !(Boolean(credentialErrors.length) || proof || getSecondaryBackgroundColor(overlay, proof)) &&
-          !hideSlice && (
+          !(Boolean(credentialErrors.length) || proof || getSecondaryBackgroundColor(overlay, proof)) && (
             <View
               style={[
                 {


### PR DESCRIPTION
# Summary of Changes

Updated the styling for the revoked credentials. They now render the default image / background colour when then credential is revoked. Previously it would render a pink colour instead.

Slight rework of the `CredentialCardSecondaryBody` component for legibility.

# Screenshots, videos, or gifs

<img width="460" height="820" alt="image" src="https://github.com/user-attachments/assets/3af20846-5cc0-4e1f-8729-fd5700193965" />

# Breaking change guide

N/A

# Related Issues

[Issue 2357](https://github.com/bcgov/bc-wallet-mobile/issues/2357)

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
