### PR TITLE
fix: disable keyboardavoidingview padding on ios

### DIFF
--- a/.changeset/sixty-news-serve.md
+++ b/.changeset/sixty-news-serve.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+react native gifted chat no longer uses redundant keyboard avoiding view padding on ios

--- a/packages/core/__tests__/screens/__snapshots__/Chat.test.tsx.snap
+++ b/packages/core/__tests__/screens/__snapshots__/Chat.test.tsx.snap
@@ -20,14 +20,9 @@ exports[`Chat Screen Renders correctly 1`] = `
   <View
     onLayout={[Function]}
     style={
-      Array [
-        Object {
-          "flex": 1,
-        },
-        Object {
-          "paddingBottom": 0,
-        },
-      ]
+      Object {
+        "flex": 1,
+      }
     }
   >
     <View

--- a/packages/core/src/screens/Chat.tsx
+++ b/packages/core/src/screens/Chat.tsx
@@ -21,7 +21,7 @@ import { Role } from '../types/chat'
 import { BasicMessageMetadata, basicMessageCustomMetadata } from '../types/metadata'
 import { RootStackParams, ContactStackParams, Screens, Stacks } from '../types/navigators'
 import { getConnectionName } from '../utils/helpers'
-import { KeyboardAvoidingView } from 'react-native'
+import { KeyboardAvoidingView, Platform } from 'react-native'
 
 type ChatProps = StackScreenProps<ContactStackParams, Screens.Chat> | StackScreenProps<RootStackParams, Screens.Chat>
 
@@ -108,7 +108,11 @@ const Chat: React.FC<ChatProps> = ({ route }) => {
 
   return (
     <SafeAreaView edges={['bottom', 'left', 'right']} style={{ flex: 1, paddingTop: 20 }}>
-      <KeyboardAvoidingView style={{ flex: 1 }} behavior="padding" keyboardVerticalOffset={headerHeight}>
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? undefined : 'padding'}
+        keyboardVerticalOffset={headerHeight}
+      >
         <GiftedChat
           keyboardShouldPersistTaps={'handled'}
           messages={chatMessages}


### PR DESCRIPTION
# Summary of Changes

Made keyboardavoidingview behaviour on the chat screen dependant on the platform. "padding" on android and undefined on ios"

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Breaking change guide

N/A

# Related Issues

https://github.com/bcgov/bc-wallet-mobile/issues/2395

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [ ] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
