### PR TITLE
Fix: PINCreate keyboard button no longer jumps

### DIFF
--- a/.changeset/thin-items-poke.md
+++ b/.changeset/thin-items-poke.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+pincreate screen views no longer keyboard avoiding

--- a/packages/core/src/screens/PINCreate.tsx
+++ b/packages/core/src/screens/PINCreate.tsx
@@ -118,7 +118,7 @@ const PINCreate: React.FC<PINCreateProps> = ({ setAuthenticated, explainedStatus
   }, [])
 
   return explained ? (
-    <KeyboardView>
+    <KeyboardView keyboardAvoiding={false}>
       <View style={style.screenContainer}>
         <View style={style.contentContainer}>
           <PINHeader />


### PR DESCRIPTION
# Summary of Changes

make keyboardview on pincreate screen keyboardavoiding

# Screenshots, videos, or gifs

[pincreate.webm](https://github.com/user-attachments/assets/c997fae2-32e5-4997-9389-02ca05f2dd2d)


# Breaking change guide

N/A

# Related Issues

[Replace this text with issue #'s that are relevant to this PR. If there are none, simply enter N/A](https://github.com/bcgov/bc-wallet-mobile/issues/2395)

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [ ] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
