### PR TITLE
fix: allow explicit undefined values in ThemeBuilder (pre-req for issue #2587)

### DIFF
--- a/.changeset/metal-women-fail.md
+++ b/.changeset/metal-women-fail.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+Allow explicit undefined values for ThemeBuilder

--- a/packages/core/__tests__/utils/theme-builder.test.ts
+++ b/packages/core/__tests__/utils/theme-builder.test.ts
@@ -111,67 +111,148 @@ describe('Theme Builder', () => {
         expect(theme.Buttons.critical?.borderRadius).toEqual(-1)
         expect(theme.Buttons.critical?.width).toEqual(-1)
       })
+
+      it('should allow overriding properties to undefined', () => {
+        const theme = new ThemeBuilder(bifoldTheme)
+          .withOverrides((theme) => {
+            expect(theme).toStrictEqual(bifoldTheme)
+
+            return { Buttons: { critical: { padding: undefined } } }
+          })
+          .build()
+
+        expect(theme.Buttons.critical).toBeDefined()
+        expect(theme.Buttons.critical?.padding).toBeUndefined()
+      })
+
+      it('passing an no properties should not change the theme', () => {
+        const theme = new ThemeBuilder(bifoldTheme)
+          .withOverrides((theme) => {
+            expect(theme).toStrictEqual(bifoldTheme)
+            return {
+              Buttons: { critical: {} },
+            }
+          })
+          .build()
+
+        expect(theme).toStrictEqual(bifoldTheme)
+      })
+
+      it('should override a property to undefined at the property level', () => {
+        const theme = new ThemeBuilder(bifoldTheme)
+          .withOverrides((theme) => {
+            expect(theme).toStrictEqual(bifoldTheme)
+
+            return {
+              Buttons: {
+                criticalText: {
+                  fontSize: 12,
+                },
+                critical: undefined,
+              },
+            }
+          })
+          // This should not override the buttons.critical section
+          .withOverrides(() => ({
+            Buttons: { criticalText: { fontSize: 13 } },
+          }))
+          .build()
+
+        expect(theme.Buttons.critical).toBeUndefined()
+        expect(theme.Buttons.criticalText?.fontSize).toEqual(13)
+      })
+
+      it('should override a property to undefined at the theme section level', () => {
+        const theme = new ThemeBuilder(bifoldTheme)
+          .withOverrides((theme) => {
+            expect(theme).toStrictEqual(bifoldTheme)
+
+            return { Buttons: undefined }
+          })
+          // This should not override the buttons section
+          .withOverrides(() => ({}))
+          .build()
+
+        expect(theme.Buttons).toBeUndefined()
+      })
     })
-    describe('when passing an object', () => {})
-    it('should merge the new theme into the existing theme', () => {
-      const theme = new ThemeBuilder(bifoldTheme)
-        .withOverrides({
-          Buttons: {
-            critical: {
-              padding: 0,
-              margin: -1,
+
+    describe('when passing an object', () => {
+      it('should merge the new theme into the existing theme', () => {
+        const theme = new ThemeBuilder(bifoldTheme)
+          .withOverrides({
+            Buttons: {
+              critical: {
+                padding: 0,
+                margin: -1,
+              },
             },
-          },
-          TextTheme: {
-            headingOne: {
-              margin: -1,
+            TextTheme: {
+              headingOne: {
+                margin: -1,
+              },
             },
-          },
+          })
+          .build()
+
+        expect(theme.Buttons.critical).toStrictEqual({
+          ...bifoldTheme.Buttons.critical,
+          padding: 0,
+          margin: -1,
         })
-        .build()
-
-      expect(theme.Buttons.critical).toStrictEqual({
-        ...bifoldTheme.Buttons.critical,
-        padding: 0,
-        margin: -1,
+        expect(theme.TextTheme.headingOne).toStrictEqual({
+          ...bifoldTheme.TextTheme.headingOne,
+          margin: -1,
+        })
       })
-      expect(theme.TextTheme.headingOne).toStrictEqual({
-        ...bifoldTheme.TextTheme.headingOne,
-        margin: -1,
+
+      it('should override existing properties in the default theme', () => {
+        const theme = new ThemeBuilder(bifoldTheme).withOverrides({ Buttons: { critical: { padding: -1 } } }).build()
+
+        expect(theme.Buttons.critical).toStrictEqual({
+          ...bifoldTheme.Buttons.critical,
+          padding: -1,
+        })
       })
-    })
 
-    it('should override existing properties in the default theme', () => {
-      const theme = new ThemeBuilder(bifoldTheme).withOverrides({ Buttons: { critical: { padding: -1 } } }).build()
+      it('should add new nested properties to the theme', () => {
+        const theme = new ThemeBuilder(bifoldTheme)
+          .withOverrides({ Buttons: { critical: { aspectRatio: 'value' } } })
+          .build()
 
-      expect(theme.Buttons.critical).toStrictEqual({
-        ...bifoldTheme.Buttons.critical,
-        padding: -1,
+        expect(theme.Buttons.critical?.aspectRatio).toStrictEqual('value')
       })
-    })
 
-    it('should add new nested properties to the theme', () => {
-      const theme = new ThemeBuilder(bifoldTheme)
-        .withOverrides({ Buttons: { critical: { aspectRatio: 'value' } } })
-        .build()
+      it('should not override the entire theme when merging', () => {
+        const theme = new ThemeBuilder(bifoldTheme).withOverrides({} as any).build()
 
-      expect(theme.Buttons.critical?.aspectRatio).toStrictEqual('value')
-    })
+        expect(theme).toStrictEqual(bifoldTheme)
+      })
 
-    it('should not override the entire theme when merging', () => {
-      const theme = new ThemeBuilder(bifoldTheme).withOverrides({} as any).build()
+      it('should chain multiple merges', () => {
+        const theme = new ThemeBuilder(bifoldTheme)
+          .withOverrides({ Buttons: { critical: { padding: -1 } } })
+          .withOverrides({ Buttons: { critical: { borderRadius: -1 } } })
+          .build()
 
-      expect(theme).toStrictEqual(bifoldTheme)
-    })
+        expect(theme.Buttons.critical?.padding).toEqual(-1)
+        expect(theme.Buttons.critical?.borderRadius).toEqual(-1)
+      })
 
-    it('should chain multiple merges', () => {
-      const theme = new ThemeBuilder(bifoldTheme)
-        .withOverrides({ Buttons: { critical: { padding: -1 } } })
-        .withOverrides({ Buttons: { critical: { borderRadius: -1 } } })
-        .build()
+      it('should allow overriding properties to undefined', () => {
+        const theme = new ThemeBuilder(bifoldTheme)
+          .withOverrides({ Buttons: { critical: { padding: undefined } } })
+          .build()
 
-      expect(theme.Buttons.critical?.padding).toEqual(-1)
-      expect(theme.Buttons.critical?.borderRadius).toEqual(-1)
+        expect(theme.Buttons.critical).toBeDefined()
+        expect(theme.Buttons.critical?.padding).toBeUndefined()
+      })
+
+      it('passing an no properties should not change the theme', () => {
+        const theme = new ThemeBuilder(bifoldTheme).withOverrides({ Buttons: { critical: {} } }).build()
+
+        expect(theme).toStrictEqual(bifoldTheme)
+      })
     })
   })
 
@@ -223,6 +304,16 @@ describe('Theme Builder', () => {
       expect(theme.ColorPalette.brand.primary).toEqual('OVERRIDE')
       // Ensure the color palette is being applied to the dependent properties
       expect(theme.Inputs.inputSelected.borderColor).toEqual('OVERRIDE')
+    })
+
+    it('should be able to override a value to undefined', () => {
+      const theme = new ThemeBuilder(bifoldTheme)
+        .withOverrides({ ColorPalette: { brand: { primary: undefined } } })
+        .build()
+
+      expect(theme.ColorPalette.brand.primary).toBeUndefined()
+      // Ensure the color palette is being applied to the dependent properties
+      expect(theme.Inputs.inputSelected.borderColor).toBeUndefined()
     })
   })
 })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,7 +63,7 @@ import { defaultConfig, defaultHistoryEventsLogger } from './container-impl'
 import useBifoldAgentSetup from './hooks/useBifoldAgentSetup'
 import usePreventScreenCapture from './hooks/screen-capture'
 import { DefaultScreenLayoutOptions } from './navigators/defaultLayoutOptions'
-import { ThemeBuilder } from './theme-builder'
+import { DeepPartial, ThemeBuilder } from './theme-builder'
 
 export * from './navigators'
 export * from './services/storage'
@@ -229,4 +229,4 @@ export {
   DefaultScreenLayoutOptions,
   ThemeBuilder,
 }
-export type { IButton }
+export type { IButton, DeepPartial }

--- a/packages/core/src/theme-builder.ts
+++ b/packages/core/src/theme-builder.ts
@@ -21,16 +21,7 @@ import lodash from 'lodash'
 /**
  * DeepPartial is a utility type that recursively makes all properties of a type optional.
  */
-type DeepPartial<T> = {
-  [P in keyof T]?: T[P] extends object
-    ? T[P] extends (...args: any[]) => any
-      ? T[P] // keep functions as is
-      : // For object types, make all keys optional recursively:
-      Partial<T[P]> extends infer O
-      ? { [K in keyof O]?: DeepPartial<O[K]> }
-      : never
-    : T[P]
-}
+export type DeepPartial<T> = T extends object ? { [K in keyof T]?: DeepPartial<T[K]> } : T
 
 /**
  * ThemeBuilder is a utility class to extend an existing theme with additional properties.
@@ -52,6 +43,23 @@ export class ThemeBuilder {
   }
 
   /**
+   * Extension of the lodash.merge function that merges two objects deeply,
+   * while preserving explicit undefined values in the source object.
+   *
+   * @param {T} target - The target object to merge into.
+   * @param {DeepPartial<T>} source - The source object to merge from.
+   * @returns {*} {T} Returns the merged object.
+   */
+  private _merge<T extends object>(target: T, source: DeepPartial<T>): T {
+    return lodash.mergeWith({}, target, source, (objValue, srcValue, key, obj) => {
+      // If source explicitly sets the value to undefined, keep it as undefined
+      if (objValue !== srcValue && typeof srcValue === 'undefined') {
+        obj[key] = undefined
+      }
+    })
+  }
+
+  /**
    * Sets the color pallet for the theme.
    *
    * Note: This method is mostly a convenience method to set the color pallet for the theme.
@@ -61,7 +69,9 @@ export class ThemeBuilder {
    * @returns {*} {ThemeBuilder} Returns the instance of ThemeBuilder for method chaining.
    */
   setColorPalette(colorPalette: IColorPalette): this {
-    this._theme.ColorPalette = colorPalette
+    this.withOverrides({
+      ColorPalette: colorPalette,
+    })
 
     return this
   }
@@ -82,15 +92,15 @@ export class ThemeBuilder {
    *  Buttons: { critical: { padding: 0, margin: -1 } },
    * })) // => { Buttons: { critical: { padding: 0, margin: -1 } }}
    *
-   * @param {DeepPartial<ITheme> | ((theme: ITheme) => DeepPartial<ITheme>) } themeOverrides A partial theme object to merge with the current theme or a callback function that receives the current theme and returns a partial theme object.
+   * @param {DeepPartial<ITheme> | ((theme: ITheme) => DeepPartial<ITheme>) } themeOverrides A partial theme object to this._merge with the current theme or a callback function that receives the current theme and returns a partial theme object.
    * @returns {*} {ThemeBuilder} Returns the instance of ThemeBuilder for method chaining.
    */
   withOverrides(themeOverrides: DeepPartial<ITheme> | ((theme: ITheme) => DeepPartial<ITheme>)): this {
     const resolvedOverrides = typeof themeOverrides === 'function' ? themeOverrides(this._theme) : themeOverrides
 
-    // note: without the empty object, lodash.merge will mutate the original theme overrides,
+    // note: without the empty object, lodash.this._merge will mutate the original theme overrides,
     // and not properly update the nested properties
-    this._themeOverrides = lodash.merge({}, this._themeOverrides, resolvedOverrides)
+    this._themeOverrides = this._merge(this._themeOverrides, resolvedOverrides)
 
     // Rebuild the theme with the new overrides so following chained calls will use the updated theme.
     this._theme = this.build()
@@ -106,7 +116,13 @@ export class ThemeBuilder {
    */
   build(): ITheme {
     // Step 1. Merge the theme overrides onto the original theme, producing the new base theme.
-    const baseTheme = lodash.merge({}, this._theme, this._themeOverrides)
+    const baseTheme = this._merge(this._theme, this._themeOverrides)
+
+    if (lodash.isEqual(baseTheme, this._theme)) {
+      // If the base theme is equal to the current theme, return the current theme
+      // This avoids unnecessary recomputation of dependent themes
+      return this._theme
+    }
 
     // Step 2. Generate computed properties that depend on the base theme
     const dependentThemes: Partial<ITheme> = {
@@ -133,7 +149,8 @@ export class ThemeBuilder {
      * Because the `dependentThemes` contain additional properties that may have
      * been modified by the overrides previously.
      */
-    this._theme = lodash.merge({}, baseTheme, dependentThemes, this._themeOverrides)
+    const newBaseTheme = this._merge(baseTheme, dependentThemes)
+    this._theme = this._merge(newBaseTheme, this._themeOverrides)
 
     return this._theme
   }

--- a/packages/core/src/theme-builder.ts
+++ b/packages/core/src/theme-builder.ts
@@ -51,6 +51,8 @@ export class ThemeBuilder {
    * @returns {*} {T} Returns the merged object.
    */
   private _merge<T extends object>(target: T, source: DeepPartial<T>): T {
+    // note: without the empty object, lodash.merge will mutate the original theme overrides,
+    // and not properly update the nested properties
     return lodash.mergeWith({}, target, source, (objValue, srcValue, key, obj) => {
       // If source explicitly sets the value to undefined, keep it as undefined
       if (objValue !== srcValue && typeof srcValue === 'undefined') {
@@ -92,14 +94,12 @@ export class ThemeBuilder {
    *  Buttons: { critical: { padding: 0, margin: -1 } },
    * })) // => { Buttons: { critical: { padding: 0, margin: -1 } }}
    *
-   * @param {DeepPartial<ITheme> | ((theme: ITheme) => DeepPartial<ITheme>) } themeOverrides A partial theme object to this._merge with the current theme or a callback function that receives the current theme and returns a partial theme object.
+   * @param {DeepPartial<ITheme> | ((theme: ITheme) => DeepPartial<ITheme>) } themeOverrides A partial theme object to merge with the current theme or a callback function that receives the current theme and returns a partial theme object.
    * @returns {*} {ThemeBuilder} Returns the instance of ThemeBuilder for method chaining.
    */
   withOverrides(themeOverrides: DeepPartial<ITheme> | ((theme: ITheme) => DeepPartial<ITheme>)): this {
     const resolvedOverrides = typeof themeOverrides === 'function' ? themeOverrides(this._theme) : themeOverrides
 
-    // note: without the empty object, lodash.this._merge will mutate the original theme overrides,
-    // and not properly update the nested properties
     this._themeOverrides = this._merge(this._themeOverrides, resolvedOverrides)
 
     // Rebuild the theme with the new overrides so following chained calls will use the updated theme.


### PR DESCRIPTION
# Summary of Changes

This PR slightly modifies the ThemeBuilder to allow explicit undefined values in the ThemeBuilder overrides. Previously if you injected an undefined value for a property or theme section, lodash.merge would ignore and merge over top of it. This allows the individual properties to be ignored or removed from the theme if not needed.

This also fixes an issue with the ThemeBuilder method `setColorPalette` where the ColorPalette was not being updated correctly.

# Screenshots, videos, or gifs

N/A

# Breaking change guide

N/A

# Related Issues

[Update theme file in BC-Wallet and BCSC](https://github.com/orgs/bcgov/projects/108/views/8?pane=issue&itemId=122375740&issue=bcgov%7Cbc-wallet-mobile%7C2587)

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
