### PR TITLE
fix: face biometrics on android

### DIFF
--- a/.changeset/warm-words-sleep.md
+++ b/.changeset/warm-words-sleep.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+Prevent accidentally overwritten persisted state on load

--- a/packages/core/src/contexts/network.tsx
+++ b/packages/core/src/contexts/network.tsx
@@ -24,7 +24,7 @@ export const NetworkProvider = ({ children }: PropsWithChildren) => {
   const [isNetInfoModalDisplayed, setIsNetInfoModalDisplayed] = useState<boolean>(false)
   const { t } = useTranslation()
   const [hasShown, setHasShown] = useState(false)
-  const [, dispatch] = useStore()
+  const [store, dispatch] = useStore()
 
   const displayNetInfoModal = useCallback(() => {
     setIsNetInfoModalDisplayed(true)
@@ -85,6 +85,12 @@ export const NetworkProvider = ({ children }: PropsWithChildren) => {
   }, [dispatch, t])
 
   useEffect(() => {
+    // This early return prevents the dispatches from overwriting
+    // the persisted state until the state is loaded from storage
+    if (!store.stateLoaded) {
+      return
+    }
+
     const internetReachable = assertInternetReachable()
     if (internetReachable) {
       setHasShown(false)
@@ -98,7 +104,7 @@ export const NetworkProvider = ({ children }: PropsWithChildren) => {
     if (internetReachable === false && !hasShown) {
       showNetworkWarning()
     }
-  }, [showNetworkWarning, assertInternetReachable, hasShown, dispatch])
+  }, [store.stateLoaded, showNetworkWarning, assertInternetReachable, hasShown, dispatch])
 
   return (
     <NetworkContext.Provider


### PR DESCRIPTION
# Summary of Changes

A banner dispatch that happened right on app load was overwriting persisted storage before it was loaded. A more permanent solution is using a full state management lib that we have been planning to migrate to, like Zustand or Redux, but in the meantime this is a pretty sturdy fix.

# Screenshots, videos, or gifs

N/A

# Breaking change guide

N/A

# Related Issues

bcgov/bc-wallet-mobile#2571

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
