### PR TITLE
fix: improve credential definition ID normalization and error handling in parsing functions

### DIFF
--- a/.changeset/cold-candies-study.md
+++ b/.changeset/cold-candies-study.md
@@ -1,5 +1,5 @@
 ---
-'@bifold/core': minor
+'@bifold/core': patch
 ---
 
 improve credential definition ID normalization and error handling in parsing functions

--- a/.changeset/small-dots-sit.md
+++ b/.changeset/small-dots-sit.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': minor
+---
+
+improve credential definition ID normalization and error handling in parsing functions


### PR DESCRIPTION
@bryce-mcmath I think the updated dependencies caused an issue with this change we previously made. I added some more guards while I was at it. The most important bit is the change from `agent.modules.anoncreds.getCredentialDefinition(agent.context, credDefId)` to `agent.modules.anoncreds.getCredentialDefinition(credDefId)`