### PR TITLE
fix: fixed the package for release

### DIFF
--- a/.changeset/hip-paths-hope.md
+++ b/.changeset/hip-paths-hope.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+fixed pacakge for packed release

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
   "types": "lib/typescript/src/index.d.ts",
-  "react-native": "src/index.ts",
+  "react-native": "./lib/commonjs/index.js",
   "source": "src/index.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
# Summary of Changes

- current release of bifold is broken
- the root `react-native` is used by default when the release is being created and as such will fail if it is set to `.ts` path as those won't exist in the release


# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Breaking change guide

This is going to break hot reloading when bifold is linked to another project. A temprary fix is to set the react-native field back to this: 
`"react-native": "src/index.ts"`

# Related Issues

n/a

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
