### PR TITLE
fix: PIN masking for new PIN design to show last digit momentarily

### DIFF
--- a/.changeset/true-trees-run.md
+++ b/.changeset/true-trees-run.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+fix pin masking on new pin design

--- a/packages/core/src/components/inputs/PINInput.tsx
+++ b/packages/core/src/components/inputs/PINInput.tsx
@@ -1,7 +1,13 @@
 import React, { forwardRef, Ref, useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, TextInput, TouchableOpacity, View } from 'react-native'
-import { CodeField, Cursor, useClearByFocusCell } from 'react-native-confirmation-code-field'
+import {
+  CodeField,
+  Cursor,
+  useClearByFocusCell,
+  MaskSymbol,
+  isLastFilledCell,
+} from 'react-native-confirmation-code-field'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
 import { hitSlop, minPINLength } from '../../constants'
@@ -53,16 +59,12 @@ const PINInputComponent = (
   // filling with bullets when masked to prevent screen reader from reading the actual PIN
   // and to have the proper appearance when the PIN is masked
   const displayValue = useMemo(() => {
-    const trailingPINLength = PIN.length === 0 ? 0 : PIN.length - 1
     if (showPIN) {
-      return PINScreensConfig.useNewPINDesign ? PIN : PIN.split('').join(' ')
+      return PIN.split('').join(' ')
     } else {
-      return PINScreensConfig.useNewPINDesign
-        ? `${'●'.repeat(trailingPINLength)}${PIN.charAt(PIN.length - 1)}`
-        : '●'.repeat(PIN.length).split('').join(' ')
+      return '●'.repeat(PIN.length).split('').join(' ')
     }
-  }, [PIN, showPIN, PINScreensConfig])
-  //
+  }, [PIN, showPIN])
 
   const onChangeText = useCallback(
     (value: string) => {
@@ -126,7 +128,7 @@ const PINInputComponent = (
           accessibilityLabel={allyLabel}
           accessibilityRole={'text'}
           accessible
-          value={displayValue}
+          value={PINScreensConfig.useNewPINDesign ? PIN : displayValue}
           rootStyle={theme.codeFieldRoot}
           onChangeText={onChangeText}
           cellCount={PINScreensConfig.useNewPINDesign ? separatedPINCellCount : cellCount}
@@ -136,7 +138,17 @@ const PINInputComponent = (
             let child: React.ReactNode | string = ''
             // skip spaces
             if (symbol && symbol !== ' ') {
-              child = symbol
+              if (PINScreensConfig.useNewPINDesign) {
+                child = showPIN ? (
+                  symbol
+                ) : (
+                  <MaskSymbol maskSymbol="●" isLastFilledCell={isLastFilledCell({ index, value: displayValue })}>
+                    {symbol}
+                  </MaskSymbol>
+                )
+              } else {
+                child = symbol
+              }
             } else if (isFocused) {
               child = <Cursor />
             }


### PR DESCRIPTION
# Summary of Changes

PIN masking for new PIN design to show last digit momentarily. Uses built in functionality from the code field library we are using. 

# Testing Instructions

Replace this text with detailed instructions on how to test the changes included in this PR.

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Breaking change guide

Replace this text with any breaking changes included in this PR along with how to address them in downstream projects. If there are none, simply enter N/A

# Related Issues

Replace this text with issue #'s that are relevant to this PR. If there are none, simply enter N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [ ] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [ ] If applicable, screenshots, gifs, or video are included for UI changes
- [ ] If applicable, breaking changes are described above along with how to address them
- [ ] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [ ] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
