### PR TITLE
feat: respond to w3c jwt_vc credentials

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,15 +53,21 @@ import { TourProvider } from './contexts/tour/tour-provider'
 import { useDeveloperMode } from './hooks/developer-mode'
 import usePreventScreenCapture from './hooks/screen-capture'
 import useBifoldAgentSetup from './hooks/useBifoldAgentSetup'
+import { useOnboardingState } from './hooks/useOnboardingState'
 import { OpenIDCredentialRecordProvider } from './modules/openid/context/OpenIDCredentialRecordProvider'
 import { DefaultScreenLayoutOptions } from './navigators/defaultLayoutOptions'
 import { DefaultScreenOptionsDictionary, useDefaultStackOptions } from './navigators/defaultStackOptions'
+import { getOnboardingScreens } from './navigators/OnboardingScreens'
 import AttemptLockout from './screens/AttemptLockout'
 import Biometry from './screens/Biometry'
 import Developer from './screens/Developer'
+import NameWallet from './screens/NameWallet'
 import Onboarding from './screens/Onboarding'
 import OnboardingPages from './screens/OnboardingPages'
+import PINCreate from './screens/PINCreate'
+import PINEnter from './screens/PINEnter'
 import Preface from './screens/Preface'
+import PushNotifications from './screens/PushNotifications'
 import Scan from './screens/Scan'
 import Splash from './screens/Splash'
 import Terms from './screens/Terms'
@@ -205,6 +211,7 @@ export {
   ErrorBoundaryWrapper,
   ErrorModal,
   FauxHeader,
+  getOnboardingScreens,
   HomeFooterView as HomeContentView,
   homeTourSteps,
   IconButton,
@@ -217,15 +224,19 @@ export {
   Link,
   loadLoginAttempt,
   MaskType,
+  NameWallet,
   NavContainer,
   NetworkProvider,
   NotificationListItem,
   Onboarding,
   OnboardingPages,
   OpenIDCredentialRecordProvider,
+  PINCreate,
+  PINEnter,
   PINRules,
   Preface,
   proofRequestTourSteps,
+  PushNotifications,
   QrCodeScanError,
   QRRenderer,
   QRScannerTorch,
@@ -250,6 +261,7 @@ export {
   useBifoldAgentSetup,
   useDefaultStackOptions,
   useDeveloperMode,
+  useOnboardingState,
   usePreventScreenCapture,
   useTour,
   walletTimeout,

--- a/packages/core/src/screens/ProofRequest.tsx
+++ b/packages/core/src/screens/ProofRequest.tsx
@@ -371,9 +371,28 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, proofId }) => {
           .map((fullCredential: CredentialExchangeRecord) => getCredentialDefinitionIdForRecord(fullCredential))
           .filter((id) => id !== null)
       )
+
+      const credentialRecordIds = new Set(fullCredentials.map((cred) => cred.id))
+      fullCredentials.forEach((cred) => {
+        cred.credentials.forEach((c) => {
+          credentialRecordIds.add(c.credentialRecordId)
+        })
+      })
+
+      if (descriptorMetadata) {
+        Object.values(descriptorMetadata).forEach((metaArray) => {
+          metaArray.forEach((meta) => {
+            credentialRecordIds.add(meta.record.id)
+          })
+        })
+      }
+
       activeCreds.forEach((cred) => {
-        const isMissing = !schemaIds.has(cred.schemaId ?? '') && !credDefIds.has(cred.credDefId ?? '')
-        const isUserCredential = schemaIds.has(cred.schemaId ?? '') || credDefIds.has(cred.credDefId ?? '')
+        const hasCredentialRecord = cred.credExchangeRecord || credentialRecordIds.has(cred.credId)
+        const hasSchemaOrCredDef = schemaIds.has(cred.schemaId ?? '') || credDefIds.has(cred.credDefId ?? '')
+
+        const isMissing = !hasSchemaOrCredDef && !hasCredentialRecord
+        const isUserCredential = hasSchemaOrCredDef || hasCredentialRecord
 
         if (isMissing && !cred.credExchangeRecord) {
           missingCredentials.push(cred)

--- a/packages/core/src/utils/cred-def.ts
+++ b/packages/core/src/utils/cred-def.ts
@@ -20,6 +20,13 @@ function normalizeId(id?: string): string | undefined {
 export async function getCredentialName(credDefId?: string, schemaId?: string, agent?: Agent): Promise<string> {
   const normalizedCredDefId = normalizeId(credDefId)
   const normalizedSchemaId = normalizeId(schemaId)
+
+  if (normalizedCredDefId && normalizedSchemaId && normalizedCredDefId === normalizedSchemaId) {
+    if (!normalizedCredDefId.includes(':')) {
+      return normalizedSchemaId
+    }
+  }
+
   const isWebvh = !!(
     normalizedCredDefId?.toLowerCase().startsWith('did:webvh:') ||
     normalizedSchemaId?.toLowerCase().startsWith('did:webvh:')

--- a/packages/core/src/utils/helpers.ts
+++ b/packages/core/src/utils/helpers.ts
@@ -8,7 +8,6 @@ import {
   AnonCredsRequestedAttributeMatch,
   AnonCredsRequestedPredicate,
   AnonCredsRequestedPredicateMatch,
-  getCredentialsForAnonCredsProofRequest,
 } from '@credo-ts/anoncreds'
 import {
   Agent,
@@ -52,6 +51,7 @@ import { ChildFn } from '../types/tour'
 import { BifoldAgent } from './agent'
 import {
   createAnonCredsProofRequest,
+  createAnonCredsCredentialsFromDescriptorMetadata,
   filterInvalidProofRequestMatches,
   getDescriptorMetadata,
 } from './anonCredsProofRequestMapper'
@@ -880,14 +880,22 @@ export const retrieveCredentialsForProof = async (
 
       const presentationDefinition = presentationExchange.presentation_definition
       const descriptorMetadata = getDescriptorMetadata(difPexCredentialsForRequest)
+      const w3cToExchangeRecordMap = new Map<string, CredentialExchangeRecord>()
+      fullCredentials.forEach((credExRecord) => {
+        credExRecord.credentials.forEach((binding) => {
+          w3cToExchangeRecordMap.set(binding.credentialRecordId, credExRecord)
+        })
+      })
+
       const anonCredsProofRequest = createAnonCredsProofRequest(presentationDefinition, descriptorMetadata)
-      const anonCredsCredentialsForRequest = await getCredentialsForAnonCredsProofRequest(
-        agent.context,
+      const anonCredsCredentialsForRequest = createAnonCredsCredentialsFromDescriptorMetadata(
         anonCredsProofRequest,
-        { filterByNonRevocationRequirements: false }
+        descriptorMetadata,
+        fullCredentials
       )
 
       const filtered = filterInvalidProofRequestMatches(anonCredsCredentialsForRequest, descriptorMetadata)
+
       const processedAttributes = await processProofAttributes(
         t,
         anonCredsProofRequest,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7689,15 +7689,15 @@ __metadata:
 
 "@unimodules/core@file:./noop::locator=bifold-wallet-root%40workspace%3A.":
   version: 1.0.0
-  resolution: "@unimodules/core@file:./noop#./noop::hash=08da70&locator=bifold-wallet-root%40workspace%3A."
-  checksum: 10c0/e7a3061c158a19ea058c642d3ff32668e3b4df5aecf97e2496307fa90e42315f31158e4e3820c933e877f3a9b2f2143418e505aa3210aa5c6d275f4e6988987b
+  resolution: "@unimodules/core@file:./noop#./noop::hash=8b1a91&locator=bifold-wallet-root%40workspace%3A."
+  checksum: 10c0/be38d7766a460fa78a65144214f740c881f89c4c173fb7a5b659aed77471bfe58a266f1926525bb0f387e83d647d156f09e69eba816ab5ca8a768bd10696bd45
   languageName: node
   linkType: hard
 
 "@unimodules/react-native-adapter@file:./noop::locator=bifold-wallet-root%40workspace%3A.":
   version: 1.0.0
-  resolution: "@unimodules/react-native-adapter@file:./noop#./noop::hash=54c074&locator=bifold-wallet-root%40workspace%3A."
-  checksum: 10c0/9b8d172c38672e5c33a01574603a5ae02cf931d901637223f978cae5252199ebb6944085a30c669fe326a89db66b52ba8cd1e91fff8c798126eaa6f8f3bc2942
+  resolution: "@unimodules/react-native-adapter@file:./noop#./noop::hash=aa92a0&locator=bifold-wallet-root%40workspace%3A."
+  checksum: 10c0/596e6436fb9ac84203c7349bf088968717e3a567aa97ed926a0ec38898fe626aca4a19ffea343ec3f825400ba1038cbde5425554d284788a3ae038fe23f89b6a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
enable the ability to respond to jwt_vc proof requests using a credential in the wallet