### PR TITLE
fix: Reanimated worklet crash in sample app by adding app-level Babel config

### DIFF
--- a/packages/core/babel.config.js
+++ b/packages/core/babel.config.js
@@ -4,7 +4,7 @@ const plugins = [
     'module-resolver',
     {
       root: ['.'],
-      extensions: ['.tsx', 'ts'],
+      extensions: ['.tsx', '.ts', '.js', '.jsx', '.json'],
     },
   ],
 ]

--- a/samples/app/babel.config.js
+++ b/samples/app/babel.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  presets: ['module:@react-native/babel-preset'],
+  plugins: [
+    [
+      'module-resolver',
+      {
+        root: ['.'],
+        extensions: ['.tsx', '.ts', '.js', '.jsx', '.json'],
+      },
+    ],
+
+    // MUST be last:
+    'react-native-reanimated/plugin',
+  ],
+}


### PR DESCRIPTION
# Summary of Changes

After this PR #1742 
The sample app had no babel.config.js, so Reanimated worklets were not compiled after keyboard controller changes. This adds an explicit app-level Babel config (with react-native-reanimated/plugin) to prevent runtime crashes.

# Testing Instructions

Replace this text with detailed instructions on how to test the changes included in this PR.

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Breaking change guide

Replace this text with any breaking changes included in this PR along with how to address them in downstream projects. If there are none, simply enter N/A

# Related Issues

Replace this text with issue #'s that are relevant to this PR. If there are none, simply enter N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [ ] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [ ] If applicable, screenshots, gifs, or video are included for UI changes
- [ ] If applicable, breaking changes are described above along with how to address them
- [ ] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [ ] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
