### PR TITLE
fix: attestation pkg src for turbomodule support

### DIFF
--- a/.changeset/fancy-moose-bathe.md
+++ b/.changeset/fancy-moose-bathe.md
@@ -1,0 +1,5 @@
+---
+'@bifold/react-native-attestation': patch
+---
+
+fix for turbomodule support in attestation package

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,3 +2,4 @@ nodejs 20.19.2
 python 3.11.2
 java zulu-17.56.15
 yarn 4.9.2
+ruby 3.3.6

--- a/packages/react-native-attestation/package.json
+++ b/packages/react-native-attestation/package.json
@@ -8,6 +8,7 @@
   "source": "build/commonjs/index.js",
   "react-native": "build/commonjs/index.js",
   "files": [
+    "src",
     "build",
     "ios",
     "android",


### PR DESCRIPTION
# Summary of Changes

Quick fix for turbomodule support for projects that consume our `@bifold/react-native-attesation` package

Also added ruby to our mise config

# Testing Instructions

N/A

# Acceptance Criteria

N/A

# Screenshots, videos, or gifs

N/A

# Breaking change guide

N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
