### PR TITLE
fix: attestation turbo spec

### DIFF
--- a/.changeset/curvy-signs-poke.md
+++ b/.changeset/curvy-signs-poke.md
@@ -1,0 +1,5 @@
+---
+'@bifold/react-native-attestation': patch
+---
+
+fix typo in turbo module

--- a/packages/react-native-attestation/ios/Attestation.mm
+++ b/packages/react-native-attestation/ios/Attestation.mm
@@ -269,7 +269,7 @@ RCT_EXPORT_METHOD(appleAttestation:(NSString *)keyId
 }
 
 RCT_EXPORT_METHOD(getAppStoreReceipt:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject) {
+                  reject:(RCTPromiseRejectBlock)reject) {
     NSURL *appStoreReceiptURL = [[NSBundle mainBundle] appStoreReceiptURL];
     
     if (appStoreReceiptURL && [[NSFileManager defaultManager] fileExistsAtPath:[appStoreReceiptURL path]]) {


### PR DESCRIPTION
# Summary of Changes

With the new React Native, the TurboModule spec is more strict and with this typo the throws when called

# Testing Instructions

N/A

# Acceptance Criteria

N/A

# Screenshots, videos, or gifs

N/A

# Breaking change guide

N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
