### PR TITLE
chore: add buffer import to prevent need for polyfill

### DIFF
--- a/packages/core/src/utils/crypto.ts
+++ b/packages/core/src/utils/crypto.ts
@@ -1,4 +1,6 @@
 import { Argon2, Argon2Algorithm, Argon2Version } from '@openwallet-foundation/askar-react-native'
+// Buffer polyfill for React Native environment where Buffer is not available globally
+import { Buffer } from 'buffer'
 
 export const hashPIN = async (PIN: string, salt: string): Promise<string> => {
   const passwordBytes = Uint8Array.from(Buffer.from(PIN))


### PR DESCRIPTION
# Summary of Changes

This PR just imports Buffer where it is used to prevent the need for Buffer polyfills in downstream projects like this:
```
import { Buffer } from 'buffer'

if (typeof global.Buffer === 'undefined') {
  global.Buffer = Buffer
}
```

# Testing Instructions

N/A

# Acceptance Criteria

N/A

# Screenshots, videos, or gifs

N/A

# Breaking change guide

N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
