### PR TITLE
Rxjs as peer

### DIFF
--- a/packages/core/src/container-impl.ts
+++ b/packages/core/src/container-impl.ts
@@ -1,4 +1,4 @@
-import { DefaultOCABundleResolver } from '@bifold/oca/build/legacy'
+import { BrandingOverlayType, DefaultOCABundleResolver, RemoteOCABundleResolver } from '@bifold/oca/build/legacy'
 import { getProofRequestTemplates } from '@bifold/verifier'
 import { Agent } from '@credo-ts/core'
 import React, { createContext, useContext } from 'react'
@@ -60,6 +60,7 @@ import {
   Tours as ToursState,
 } from './types/state'
 import { hashPIN } from './utils/crypto'
+import { Config as ReactConfig } from 'react-native-config'
 
 export const defaultConfig: Config = {
   PINSecurity: {
@@ -150,7 +151,10 @@ export class MainContainer implements Container {
     this._container.registerInstance(TOKENS.OBJECT_SCREEN_CONFIG, DefaultScreenOptionsDictionary)
     this._container.registerInstance(TOKENS.OBJECT_LAYOUT_CONFIG, DefaultScreenLayoutOptions)
     this._container.registerInstance(TOKENS.UTIL_LOGGER, bifoldLoggerInstance)
-    this._container.registerInstance(TOKENS.UTIL_OCA_RESOLVER, new DefaultOCABundleResolver(bundle))
+    this._container.registerInstance(TOKENS.UTIL_OCA_RESOLVER, new RemoteOCABundleResolver(ReactConfig.OCA_URL ?? '', {
+      brandingOverlayType: BrandingOverlayType.Branding10,
+      verifyCacheIntegrity: true,
+    }))
     this._container.registerInstance(TOKENS.UTIL_LEDGERS, defaultIndyLedgers)
     this._container.registerInstance(TOKENS.UTIL_PROOF_TEMPLATE, getProofRequestTemplates)
     this._container.registerInstance(TOKENS.UTIL_ATTESTATION_MONITOR, { useValue: undefined })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -78,6 +78,13 @@ import { QrCodeScanError } from './types/error'
 import { RefreshOrchestrator } from './modules/openid/refresh/refreshOrchestrator'
 import { AgentBridge } from './services/AgentBridge'
 
+import { useOnboardingState } from './hooks/useOnboardingState'
+import PINCreate from './screens/PINCreate'
+import PINEnter from './screens/PINEnter'
+import PushNotifications from './screens/PushNotifications'
+import NameWallet from './screens/NameWallet'
+import { getOnboardingScreens } from './navigators/OnboardingScreens'
+
 export { animatedComponents } from './animated-components'
 export { EventTypes, LocalStorageKeys } from './constants'
 export { AnimatedComponentsProvider, useAnimatedComponents } from './contexts/animated-components'
@@ -260,5 +267,11 @@ export {
   walletTimeout,
   RefreshOrchestrator,
   AgentBridge,
+  useOnboardingState,
+  PINCreate,
+  PINEnter,
+  PushNotifications,
+  NameWallet,
+  getOnboardingScreens,
 }
 export type { BannerMessage, DeepPartial, IButton }

--- a/packages/core/src/modules/openid/context/OpenIDCredentialRecordProvider.tsx
+++ b/packages/core/src/modules/openid/context/OpenIDCredentialRecordProvider.tsx
@@ -216,7 +216,7 @@ export const OpenIDCredentialRecordProvider: React.FC<PropsWithChildren<OpenIDCr
 
     const params: OCABundleResolveAllParams = {
       identifiers: {
-        schemaId: '',
+        schemaId: credentialDisplay.schemaId,
         credentialDefinitionId: credentialDisplay.id,
       },
       meta: {
@@ -239,9 +239,9 @@ export const OpenIDCredentialRecordProvider: React.FC<PropsWithChildren<OpenIDCr
       logo: credentialDisplay.display.logo?.url,
     })
     const ocaBundle: CredentialOverlay<BrandingOverlay> = {
-      ..._bundle,
       presentationFields: bundle.presentationFields,
       brandingOverlay: brandingOverlay,
+      ..._bundle,
     }
 
     return ocaBundle
@@ -266,7 +266,7 @@ export const OpenIDCredentialRecordProvider: React.FC<PropsWithChildren<OpenIDCr
       }))
     })
 
-    agent.mdoc.getAll().then((creds) => {
+    agent.mdoc?.getAll().then((creds) => {
       setState((prev) => ({
         ...prev,
         mdocVcRecords: filterMdocCredentialsOnly(creds),

--- a/packages/core/src/modules/openid/display.tsx
+++ b/packages/core/src/modules/openid/display.tsx
@@ -230,6 +230,13 @@ function getMdocCredentialDisplay(
         }
       }
 
+      if(openidCredentialDisplay.logo) {
+        credentialDisplay.logo = {
+          url: openidCredentialDisplay.logo.url,
+          altText: openidCredentialDisplay.logo.alt_text,
+        }
+      }
+
       // NOTE: logo is used in issuer display (not sure if that's right though)
     }
   }
@@ -369,6 +376,7 @@ export function getCredentialForDisplay(
 
     return {
       id: `mdoc-${credentialRecord.id}` satisfies CredentialForDisplayId,
+      schemaId: openId4VcMetadata?.credential.id, // NOTE: Unsure whether this is a suitable way to set a 'schemaId' for an OpenID VC, may not be unique enough.
       createdAt: credentialRecord.createdAt,
       display: {
         ...credentialDisplay,

--- a/packages/core/src/modules/openid/metadata.tsx
+++ b/packages/core/src/modules/openid/metadata.tsx
@@ -24,6 +24,7 @@ export interface OpenId4VcCredentialMetadata {
     display?: OpenId4VciCredentialSupported['display']
     order?: OpenId4VciCredentialSupported['order']
     credential_subject?: CredentialSubjectRecord
+    id?: string
   }
   issuer: {
     display?: OpenId4VciIssuerMetadataDisplay[]
@@ -49,6 +50,7 @@ export function extractOpenId4VcCredentialMetadata(
       display: credentialMetadata.display,
       order: credentialMetadata.order,
       credential_subject: credentialMetadata.credential_subject,
+      id: credentialMetadata.id,
     },
     issuer: {
       display: serverMetadata.display,

--- a/packages/core/src/modules/openid/offerResolve.tsx
+++ b/packages/core/src/modules/openid/offerResolve.tsx
@@ -57,6 +57,12 @@ export const resolveOpenId4VciOffer = async ({
     uri: offerUri,
   })
 
+  // TODO: We need to have a trusted certificate loaded here before we are able to accept an mdoc offer from the issuer.
+  //   agent.x509.setTrustedCertificates([
+  //     `-----BEGIN CERTIFICATE-----
+  // -----END CERTIFICATE-----`
+  //   ])
+
   const resolvedCredentialOffer = await agent.modules.openId4VcHolder.resolveCredentialOffer(offerUri)
 
   if (authorization) {

--- a/packages/core/src/modules/openid/offerResolve.tsx
+++ b/packages/core/src/modules/openid/offerResolve.tsx
@@ -58,10 +58,10 @@ export const resolveOpenId4VciOffer = async ({
   })
 
   // TODO: We need to have a trusted certificate loaded here before we are able to accept an mdoc offer from the issuer.
-  //   agent.x509.setTrustedCertificates([
-  //     `-----BEGIN CERTIFICATE-----
-  // -----END CERTIFICATE-----`
-  //   ])
+//     agent.x509.setTrustedCertificates([
+//       `-----BEGIN CERTIFICATE-----
+// -----END CERTIFICATE-----`
+//     ])
 
   const resolvedCredentialOffer = await agent.modules.openId4VcHolder.resolveCredentialOffer(offerUri)
 

--- a/packages/core/src/modules/openid/screens/OpenIDCredentialDetails.tsx
+++ b/packages/core/src/modules/openid/screens/OpenIDCredentialDetails.tsx
@@ -18,7 +18,7 @@ import { OpenIDCredentialType, W3cCredentialDisplay } from '../types'
 import { TOKENS, useServices } from '../../../container-api'
 import { BrandingOverlay } from '@bifold/oca'
 import Record from '../../../components/record/Record'
-import { SdJwtVcRecord, W3cCredentialRecord } from '@credo-ts/core'
+import { SdJwtVcRecord, W3cCredentialRecord, MdocRecord } from '@credo-ts/core'
 import { buildOverlayFromW3cCredential } from '../../../utils/oca'
 import CredentialDetailSecondaryHeader from '../../../components/views/CredentialDetailSecondaryHeader'
 import CredentialCardLogo from '../../../components/views/CredentialCardLogo'
@@ -39,12 +39,13 @@ const paddingVertical = 16
 const OpenIDCredentialDetails: React.FC<OpenIDCredentialDetailsProps> = ({ navigation, route }) => {
   const { credentialId, type } = route.params
 
-  const [credential, setCredential] = useState<W3cCredentialRecord | SdJwtVcRecord | undefined>(undefined)
+  const [credential, setCredential] = useState<W3cCredentialRecord | SdJwtVcRecord | MdocRecord | undefined>(undefined)
   const [credentialDisplay, setCredentialDisplay] = useState<W3cCredentialDisplay>()
   const { t, i18n } = useTranslation()
   const { ColorPalette, TextTheme } = useTheme()
   const { agent } = useAgent()
-  const { removeCredential, getW3CCredentialById, getSdJwtCredentialById } = useOpenIDCredentials()
+  const { removeCredential, getW3CCredentialById, getSdJwtCredentialById, getMdocCredentialById } =
+    useOpenIDCredentials()
   const [bundleResolver] = useServices([TOKENS.UTIL_OCA_RESOLVER])
 
   const [isRemoveModalDisplayed, setIsRemoveModalDisplayed] = useState(false)
@@ -74,12 +75,14 @@ const OpenIDCredentialDetails: React.FC<OpenIDCredentialDetailsProps> = ({ navig
     const fetchCredential = async () => {
       if (credentialRemoved) return
       try {
-        let record: SdJwtVcRecord | W3cCredentialRecord | undefined
+        let record: SdJwtVcRecord | W3cCredentialRecord | MdocRecord | undefined
 
         if (type === OpenIDCredentialType.SdJwtVc) {
           record = await getSdJwtCredentialById(credentialId)
-        } else {
+        } else if (type == OpenIDCredentialType.W3cCredential) {
           record = await getW3CCredentialById(credentialId)
+        } else {
+          record = await getMdocCredentialById(credentialId)
         }
 
         setCredential(record)
@@ -92,7 +95,16 @@ const OpenIDCredentialDetails: React.FC<OpenIDCredentialDetailsProps> = ({ navig
       }
     }
     fetchCredential()
-  }, [credentialId, type, getSdJwtCredentialById, getW3CCredentialById, agent, t, credentialRemoved])
+  }, [
+    credentialId,
+    type,
+    getSdJwtCredentialById,
+    getW3CCredentialById,
+    getMdocCredentialById,
+    agent,
+    t,
+    credentialRemoved,
+  ])
 
   useEffect(() => {
     if (!credential) return

--- a/packages/core/src/modules/openid/types.tsx
+++ b/packages/core/src/modules/openid/types.tsx
@@ -78,6 +78,7 @@ export interface CredentialIssuerDisplay {
 
 export interface W3cCredentialDisplay {
   id: string
+  schemaId?: string
   createdAt: Date
   display: CredentialDisplay
   credential?: W3cCredentialJson

--- a/packages/core/src/screens/ListCredentials.tsx
+++ b/packages/core/src/screens/ListCredentials.tsx
@@ -1,6 +1,11 @@
 import { AnonCredsCredentialMetadataKey } from '@credo-ts/anoncreds'
-import { CredentialState, SdJwtVcRecord, W3cCredentialRecord } from '@credo-ts/core'
 import { useCredentialByState } from '@bifold/react-hooks'
+import {
+  CredentialState,
+  MdocRecord,
+  SdJwtVcRecord,
+  W3cCredentialRecord,
+} from '@credo-ts/core'
 import { useNavigation, useIsFocused } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React, { useEffect } from 'react'
@@ -40,7 +45,7 @@ const ListCredentials: React.FC = () => {
   const { start, stop } = useTour()
   const screenIsFocused = useIsFocused()
   const {
-    openIdState: { w3cCredentialRecords, sdJwtVcRecords },
+    openIdState: { w3cCredentialRecords, sdJwtVcRecords, mdocVcRecords },
   } = useOpenIDCredentials()
 
   let credentials: GenericCredentialExchangeRecord[] = [
@@ -48,6 +53,7 @@ const ListCredentials: React.FC = () => {
     ...useCredentialByState(CredentialState.Done),
     ...w3cCredentialRecords,
     ...sdJwtVcRecords,
+    ...mdocVcRecords,
   ]
 
   const CredentialEmptyList = credentialEmptyList as React.FC<EmptyListProps>
@@ -93,6 +99,11 @@ const ListCredentials: React.FC = () => {
             navigation.navigate(Screens.OpenIDCredentialDetails, {
               credentialId: cred.id,
               type: OpenIDCredentialType.SdJwtVc,
+            })
+          } else if (cred instanceof MdocRecord) {
+            navigation.navigate(Screens.OpenIDCredentialDetails, {
+              credentialId: cred.id,
+              type: OpenIDCredentialType.Mdoc,
             })
           } else {
             navigation.navigate(Screens.CredentialDetails, { credentialId: cred.id })

--- a/packages/core/src/utils/cred-def.ts
+++ b/packages/core/src/utils/cred-def.ts
@@ -22,6 +22,20 @@ function normalizeId(id?: string): string | undefined {
 export async function getCredentialName(credDefId?: string, schemaId?: string): Promise<string> {
   const normalizedCredDefId = normalizeId(credDefId)
   const normalizedSchemaId = normalizeId(schemaId)
+
+  if (normalizedCredDefId && normalizedSchemaId && normalizedCredDefId === normalizedSchemaId) {
+    // Identifiers are equal, return one of them
+    return normalizedCredDefId
+  }
+  // TODO: Was some support for WebVH removed here? The parseWebVHCredDefId function is gone.
+  
+  // const isWebvh = !!(
+  //   normalizedCredDefId?.toLowerCase().startsWith('did:webvh:') ||
+  //   normalizedSchemaId?.toLowerCase().startsWith('did:webvh:')
+  // )
+  // if (isWebvh) {
+  //   return parseWebVHCredDefId(normalizedCredDefId, normalizedSchemaId, agent)
+  // }
   return parseIndyCredDefId(normalizedCredDefId, normalizedSchemaId)
 }
 

--- a/packages/core/src/utils/cred-def.ts
+++ b/packages/core/src/utils/cred-def.ts
@@ -28,7 +28,7 @@ export async function getCredentialName(credDefId?: string, schemaId?: string): 
     return normalizedCredDefId
   }
   // TODO: Was some support for WebVH removed here? The parseWebVHCredDefId function is gone.
-  
+
   // const isWebvh = !!(
   //   normalizedCredDefId?.toLowerCase().startsWith('did:webvh:') ||
   //   normalizedSchemaId?.toLowerCase().startsWith('did:webvh:')

--- a/packages/core/src/utils/credential.ts
+++ b/packages/core/src/utils/credential.ts
@@ -1,11 +1,11 @@
 import { AnonCredsCredentialMetadataKey } from '@credo-ts/anoncreds'
-import { CredentialExchangeRecord, CredentialState } from '@credo-ts/core'
 import type { Agent } from '@credo-ts/core'
 import { ImageSourcePropType } from 'react-native'
-
 import { luminanceForHexColor } from './luminance'
 import { getSchemaName, getCredDefTag, fallbackDefaultCredentialNameValue, defaultCredDefTag } from './cred-def'
 import { BifoldLogger } from '../services/logger'
+import { CredentialExchangeRecord, CredentialState, W3cCredentialRecord } from '@credo-ts/core'
+import { getCredentialForDisplay } from '../modules/openid/display'
 
 export const isValidAnonCredsCredential = (credential: CredentialExchangeRecord) => {
   return (
@@ -32,7 +32,17 @@ export const toImageSource = (source: unknown): ImageSourcePropType => {
   return source as ImageSourcePropType
 }
 
-export const getCredentialIdentifiers = (credential: CredentialExchangeRecord) => {
+export const getCredentialIdentifiers = (credential: CredentialExchangeRecord | W3cCredentialRecord) => {
+  if (credential instanceof W3cCredentialRecord) {
+    const credentialDisplay = getCredentialForDisplay(credential)
+    const credentialType =
+      credentialDisplay.credential?.type?.find((t) => t !== 'VerifiableCredential') || credentialDisplay.id
+    return {
+      credentialDefinitionId: credentialType,
+      schemaId: undefined,
+    }
+  }
+
   return {
     credentialDefinitionId: credential.metadata.get(AnonCredsCredentialMetadataKey)?.credentialDefinitionId,
     schemaId: credential.metadata.get(AnonCredsCredentialMetadataKey)?.schemaId,

--- a/packages/core/src/utils/helpers.ts
+++ b/packages/core/src/utils/helpers.ts
@@ -951,6 +951,7 @@ export const retrieveCredentialsForProof = async (
 
       const presentationDefinition = presentationExchange.presentation_definition
       const descriptorMetadata = getDescriptorMetadata(difPexCredentialsForRequest)
+
       const anonCredsProofRequest = createAnonCredsProofRequest(presentationDefinition, descriptorMetadata)
       const anonCredsCredentialsForRequest = await getCredentialsForAnonCredsProofRequest(
         agent.context,

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -27,9 +27,6 @@
     "prepublishOnly": "yarn run build",
     "test": "jest"
   },
-  "dependencies": {
-    "rxjs": "^7.2.0"
-  },
   "devDependencies": {
     "@credo-ts/core": "0.5.19",
     "@credo-ts/question-answer": "0.5.19",
@@ -44,6 +41,7 @@
   "peerDependencies": {
     "@credo-ts/core": "0.5.19",
     "@credo-ts/question-answer": "0.5.19",
-    "react": ">=17.0.0 <19.0.0"
+    "react": ">=17.0.0 <19.0.0",
+    "rxjs": "^7.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2538,13 +2538,13 @@ __metadata:
     "@types/react": "npm:^18.2.14"
     jest: "npm:^29.7.0"
     rimraf: "npm:^6.1.2"
-    rxjs: "npm:^7.2.0"
     ts-jest: "npm:^29.2.5"
     typescript: "npm:~5.3.3"
   peerDependencies:
     "@credo-ts/core": 0.5.19
     "@credo-ts/question-answer": 0.5.19
     react: ">=17.0.0 <19.0.0"
+    rxjs: ^7.2.0
   bin:
     bifold: bin/bifold
   languageName: unknown
@@ -17715,7 +17715,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.2.0, rxjs@npm:^7.8.0":
+"rxjs@npm:^7.8.0":
   version: 7.8.2
   resolution: "rxjs@npm:7.8.2"
   dependencies:


### PR DESCRIPTION
Moved rxjs in bifold/react-hooks into peer dependency section. This seems to be the expected pattern for consuming applications like quartech-wallet and bc-mobile-wallet.