### PR TITLE
fix: add missing accessibilityLabel to interactable components

### DIFF
--- a/packages/core/__tests__/components/__snapshots__/BaseToast.test.tsx.snap
+++ b/packages/core/__tests__/components/__snapshots__/BaseToast.test.tsx.snap
@@ -2,6 +2,8 @@
 
 exports[`BaseToast Component Error renders correctly 1`] = `
 <View
+  accessibilityLabel="Hello World"
+  accessibilityRole="alert"
   accessibilityState={
     Object {
       "busy": undefined,
@@ -34,6 +36,7 @@ exports[`BaseToast Component Error renders correctly 1`] = `
       "opacity": 1,
     }
   }
+  testID="com.ariesbifold:id/Toast"
 >
   <View
     style={
@@ -145,6 +148,8 @@ exports[`BaseToast Component Error renders correctly 1`] = `
     </View>
     <View>
       <View
+        accessibilityLabel="Global.CloseNotification"
+        accessibilityRole="button"
         accessibilityState={
           Object {
             "busy": undefined,
@@ -165,6 +170,14 @@ exports[`BaseToast Component Error renders correctly 1`] = `
         accessible={true}
         collapsable={false}
         focusable={true}
+        hitSlop={
+          Object {
+            "bottom": 44,
+            "left": 44,
+            "right": 44,
+            "top": 44,
+          }
+        }
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -177,6 +190,7 @@ exports[`BaseToast Component Error renders correctly 1`] = `
             "opacity": 1,
           }
         }
+        testID="com.ariesbifold:id/ToastClose"
       >
         <Text
           allowFontScaling={false}
@@ -210,6 +224,8 @@ exports[`BaseToast Component Error renders correctly 1`] = `
 
 exports[`BaseToast Component Info renders correctly 1`] = `
 <View
+  accessibilityLabel="Hello World"
+  accessibilityRole="alert"
   accessibilityState={
     Object {
       "busy": undefined,
@@ -242,6 +258,7 @@ exports[`BaseToast Component Info renders correctly 1`] = `
       "opacity": 1,
     }
   }
+  testID="com.ariesbifold:id/Toast"
 >
   <View
     style={
@@ -353,6 +370,8 @@ exports[`BaseToast Component Info renders correctly 1`] = `
     </View>
     <View>
       <View
+        accessibilityLabel="Global.CloseNotification"
+        accessibilityRole="button"
         accessibilityState={
           Object {
             "busy": undefined,
@@ -373,6 +392,14 @@ exports[`BaseToast Component Info renders correctly 1`] = `
         accessible={true}
         collapsable={false}
         focusable={true}
+        hitSlop={
+          Object {
+            "bottom": 44,
+            "left": 44,
+            "right": 44,
+            "top": 44,
+          }
+        }
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -385,6 +412,7 @@ exports[`BaseToast Component Info renders correctly 1`] = `
             "opacity": 1,
           }
         }
+        testID="com.ariesbifold:id/ToastClose"
       >
         <Text
           allowFontScaling={false}
@@ -418,6 +446,8 @@ exports[`BaseToast Component Info renders correctly 1`] = `
 
 exports[`BaseToast Component Success renders correctly 1`] = `
 <View
+  accessibilityLabel="Hello World"
+  accessibilityRole="alert"
   accessibilityState={
     Object {
       "busy": undefined,
@@ -450,6 +480,7 @@ exports[`BaseToast Component Success renders correctly 1`] = `
       "opacity": 1,
     }
   }
+  testID="com.ariesbifold:id/Toast"
 >
   <View
     style={
@@ -561,6 +592,8 @@ exports[`BaseToast Component Success renders correctly 1`] = `
     </View>
     <View>
       <View
+        accessibilityLabel="Global.CloseNotification"
+        accessibilityRole="button"
         accessibilityState={
           Object {
             "busy": undefined,
@@ -581,6 +614,14 @@ exports[`BaseToast Component Success renders correctly 1`] = `
         accessible={true}
         collapsable={false}
         focusable={true}
+        hitSlop={
+          Object {
+            "bottom": 44,
+            "left": 44,
+            "right": 44,
+            "top": 44,
+          }
+        }
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -593,6 +634,7 @@ exports[`BaseToast Component Success renders correctly 1`] = `
             "opacity": 1,
           }
         }
+        testID="com.ariesbifold:id/ToastClose"
       >
         <Text
           allowFontScaling={false}
@@ -626,6 +668,8 @@ exports[`BaseToast Component Success renders correctly 1`] = `
 
 exports[`BaseToast Component Warn renders correctly 1`] = `
 <View
+  accessibilityLabel="Hello World"
+  accessibilityRole="alert"
   accessibilityState={
     Object {
       "busy": undefined,
@@ -658,6 +702,7 @@ exports[`BaseToast Component Warn renders correctly 1`] = `
       "opacity": 1,
     }
   }
+  testID="com.ariesbifold:id/Toast"
 >
   <View
     style={
@@ -769,6 +814,8 @@ exports[`BaseToast Component Warn renders correctly 1`] = `
     </View>
     <View>
       <View
+        accessibilityLabel="Global.CloseNotification"
+        accessibilityRole="button"
         accessibilityState={
           Object {
             "busy": undefined,
@@ -789,6 +836,14 @@ exports[`BaseToast Component Warn renders correctly 1`] = `
         accessible={true}
         collapsable={false}
         focusable={true}
+        hitSlop={
+          Object {
+            "bottom": 44,
+            "left": 44,
+            "right": 44,
+            "top": 44,
+          }
+        }
         onClick={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -801,6 +856,7 @@ exports[`BaseToast Component Warn renders correctly 1`] = `
             "opacity": 1,
           }
         }
+        testID="com.ariesbifold:id/ToastClose"
       >
         <Text
           allowFontScaling={false}

--- a/packages/core/__tests__/components/__snapshots__/CredentialCard11ActionFooter.test.tsx.snap
+++ b/packages/core/__tests__/components/__snapshots__/CredentialCard11ActionFooter.test.tsx.snap
@@ -14,6 +14,8 @@ exports[`CredentialCard11ActionFooter Component Matches snapshot 1`] = `
   />
   <View>
     <View
+      accessibilityLabel="sample"
+      accessibilityRole="button"
       accessibilityState={
         Object {
           "busy": undefined,
@@ -34,6 +36,14 @@ exports[`CredentialCard11ActionFooter Component Matches snapshot 1`] = `
       accessible={true}
       collapsable={false}
       focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 44,
+          "left": 44,
+          "right": 44,
+          "top": 44,
+        }
+      }
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}

--- a/packages/core/__tests__/components/__snapshots__/QRScanner.test.tsx.snap
+++ b/packages/core/__tests__/components/__snapshots__/QRScanner.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`QRScanner Component Focus animation does not render before tapping 1`] 
             "text": undefined,
           }
         }
-        accessible={true}
+        accessible={false}
         collapsable={false}
         focusable={true}
         onBlur={[Function]}
@@ -698,7 +698,7 @@ exports[`QRScanner Component Renders correctly on first tab 1`] = `
             "text": undefined,
           }
         }
-        accessible={true}
+        accessible={false}
         collapsable={false}
         focusable={true}
         onBlur={[Function]}
@@ -1853,7 +1853,7 @@ exports[`QRScanner Component Scanner with no tabs renders correctly 1`] = `
             "text": undefined,
           }
         }
-        accessible={true}
+        accessible={false}
         collapsable={false}
         focusable={true}
         onBlur={[Function]}

--- a/packages/core/__tests__/screens/__snapshots__/PINEnter.test.tsx.snap
+++ b/packages/core/__tests__/screens/__snapshots__/PINEnter.test.tsx.snap
@@ -58,6 +58,8 @@ exports[`PINEnter Screen PIN Enter renders correctly 1`] = `
         >
           <View>
             <View
+              accessibilityLabel="PINEnter.DeveloperMenuTrigger"
+              accessibilityRole="text"
               accessibilityState={
                 Object {
                   "busy": undefined,
@@ -831,6 +833,8 @@ exports[`PINEnter Screen PIN Enter renders correctly when logged out message is 
         >
           <View>
             <View
+              accessibilityLabel="PINEnter.DeveloperMenuTrigger"
+              accessibilityRole="text"
               accessibilityState={
                 Object {
                   "busy": undefined,

--- a/packages/core/__tests__/screens/__snapshots__/PasteUrl.test.tsx.snap
+++ b/packages/core/__tests__/screens/__snapshots__/PasteUrl.test.tsx.snap
@@ -44,6 +44,7 @@ exports[`PasteUrl Screen Paste URL renders correctly 1`] = `
           PasteUrl.PasteUrlDescription
         </Text>
         <TextInput
+          accessibilityLabel="PasteUrl.PasteUrlInput"
           multiline={true}
           numberOfLines={15}
           onChangeText={[Function]}
@@ -71,6 +72,8 @@ exports[`PasteUrl Screen Paste URL renders correctly 1`] = `
         }
       >
         <View
+          accessibilityLabel="PasteUrl.ScanDisabled"
+          accessibilityRole="button"
           accessibilityState={
             Object {
               "busy": undefined,
@@ -91,6 +94,14 @@ exports[`PasteUrl Screen Paste URL renders correctly 1`] = `
           accessible={true}
           collapsable={false}
           focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 44,
+              "left": 44,
+              "right": 44,
+              "top": 44,
+            }
+          }
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}

--- a/packages/core/__tests__/screens/__snapshots__/Settings.test.tsx.snap
+++ b/packages/core/__tests__/screens/__snapshots__/Settings.test.tsx.snap
@@ -1217,6 +1217,7 @@ exports[`Settings Screen Renders correctly 1`] = `
           }
         >
           <View
+            accessibilityLabel="Settings.VersionInfo"
             accessibilityState={
               Object {
                 "busy": undefined,

--- a/packages/core/jestSetup.js
+++ b/packages/core/jestSetup.js
@@ -100,11 +100,16 @@ process.env.TZ = 'UTC' // or 'America/Toronto' — pick one and keep it fixed
 // Freeze "now" without enabling fake timers (prevents act() overlaps)
 const FIXED_NOW = new Date('2024-01-01T00:00:00Z').valueOf()
 let dateNowSpy
+let consoleDebugSpy
 
 beforeAll(() => {
   dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => FIXED_NOW)
+  if (!process.env.TEST_VERBOSE) {
+    consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
+  }
 })
 
 afterAll(() => {
   if (dateNowSpy) dateNowSpy.mockRestore()
+  if (consoleDebugSpy) consoleDebugSpy.mockRestore()
 })

--- a/packages/core/jestSetup.js
+++ b/packages/core/jestSetup.js
@@ -101,11 +101,16 @@ process.env.TZ = 'UTC' // or 'America/Toronto' — pick one and keep it fixed
 // Freeze "now" without enabling fake timers (prevents act() overlaps)
 const FIXED_NOW = new Date('2024-01-01T00:00:00Z').valueOf()
 let dateNowSpy
+let consoleDebugSpy
 
 beforeAll(() => {
   dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => FIXED_NOW)
+  if (!process.env.TEST_VERBOSE) {
+    consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
+  }
 })
 
 afterAll(() => {
   if (dateNowSpy) dateNowSpy.mockRestore()
+  if (consoleDebugSpy) consoleDebugSpy.mockRestore()
 })

--- a/packages/core/src/components/chat/ActionSlider.tsx
+++ b/packages/core/src/components/chat/ActionSlider.tsx
@@ -67,7 +67,7 @@ const ActionSlider: React.FC<Props> = ({ actions, onDismiss }) => {
 
   return (
     <SafeAreaModal animationType="slide" transparent={true} onRequestClose={onDismiss}>
-      <TouchableOpacity style={styles.outsideListener} onPress={onDismiss} />
+      <TouchableOpacity accessible={false} style={styles.outsideListener} onPress={onDismiss} />
       <View style={styles.centeredView}>
         <View style={styles.modalView}>
           <TouchableOpacity

--- a/packages/core/src/components/inputs/SingleSelectBlock.tsx
+++ b/packages/core/src/components/inputs/SingleSelectBlock.tsx
@@ -41,7 +41,16 @@ const SingleSelectBlock: React.FC<Props> = ({ selection, onSelect, initialSelect
   return (
     <View style={styles.container}>
       {selection.map((item) => (
-        <TouchableOpacity key={item.id} style={styles.row} onPress={() => handleSelect(item)} hitSlop={hitSlop}>
+        <TouchableOpacity
+          key={item.id}
+          style={styles.row}
+          onPress={() => handleSelect(item)}
+          hitSlop={hitSlop}
+          accessibilityLabel={item.value}
+          accessibilityRole="radio"
+          accessibilityState={{ selected: item.id === selected.id }}
+          testID={item.id}
+        >
           <ThemedText style={Inputs.singleSelectText}>{item.value}</ThemedText>
           {item.id === selected.id ? <Icon name={'check'} size={25} color={Inputs.singleSelectIcon.color} /> : null}
         </TouchableOpacity>

--- a/packages/core/src/components/misc/CredentialCard11ActionFooter.tsx
+++ b/packages/core/src/components/misc/CredentialCard11ActionFooter.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { StyleSheet, View, TouchableOpacity } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
+import { hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 import { GenericFn } from '../../types/fn'
 import { testIdWithKey } from '../../utils/testable'
@@ -40,7 +41,14 @@ const CredentialActionFooter = ({ onPress, text, testID, textColor }: Credential
     <View>
       <View style={styles.seperator}></View>
       <View>
-        <TouchableOpacity onPress={onPress} testID={testIdWithKey(testID)} style={styles.touchable}>
+        <TouchableOpacity
+          onPress={onPress}
+          testID={testIdWithKey(testID)}
+          style={styles.touchable}
+          accessibilityLabel={text}
+          accessibilityRole="button"
+          hitSlop={hitSlop}
+        >
           <ThemedText style={styles.credActionText}>{text}</ThemedText>
           <Icon
             style={[styles.credActionText, { fontSize: styles.credActionText.fontSize + 5 }]}

--- a/packages/core/src/components/misc/ScanCamera.tsx
+++ b/packages/core/src/components/misc/ScanCamera.tsx
@@ -149,6 +149,7 @@ const ScanCamera: React.FC<ScanCameraProps> = ({ handleCodeScan, error, enableCa
             format={format}
           />
           <Pressable
+            accessible={false}
             testID={testIdWithKey('ScanCameraTapArea')}
             style={StyleSheet.absoluteFill}
             onPressIn={(e) => {

--- a/packages/core/src/components/misc/ScanCamera.tsx
+++ b/packages/core/src/components/misc/ScanCamera.tsx
@@ -156,6 +156,7 @@ const ScanCamera: React.FC<ScanCameraProps> = ({ handleCodeScan, error, enableCa
             format={format}
           />
           <Pressable
+            accessible={false}
             testID={testIdWithKey('ScanCameraTapArea')}
             style={StyleSheet.absoluteFill}
             onPressIn={(e) => {

--- a/packages/core/src/components/misc/VerifierCredentialCard.tsx
+++ b/packages/core/src/components/misc/VerifierCredentialCard.tsx
@@ -205,6 +205,7 @@ const VerifierCredentialCard: React.FC<VerifierCredentialCardProps> = ({
                 onChangeValue(schemaId, item.label || item.name || '', item.name || '', currentValue)
               }}
               testID={testIdWithKey('PredicateInput')}
+              accessibilityLabel={t('ProofRequest.PredicateInput', { label: ylabel })}
             >
               {currentValue}
             </TextInput>

--- a/packages/core/src/components/toast/BaseToast.tsx
+++ b/packages/core/src/components/toast/BaseToast.tsx
@@ -2,6 +2,9 @@ import React from 'react'
 import { View, useWindowDimensions, StyleSheet, TouchableOpacity } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
+import { useTranslation } from 'react-i18next'
+
+import { hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 import { GenericFn } from '../../types/fn'
 import { testIdWithKey } from '../../utils/testable'
@@ -25,6 +28,7 @@ export enum ToastType {
 }
 
 const BaseToast: React.FC<BaseToastProps> = ({ title, body, toastType, onPress = () => null }) => {
+  const { t } = useTranslation()
   const { TextTheme, borderRadius, borderWidth, ColorPalette } = useTheme()
   const { width } = useWindowDimensions()
   const iconSize = 24
@@ -96,7 +100,13 @@ const BaseToast: React.FC<BaseToastProps> = ({ title, body, toastType, onPress =
   }
 
   return (
-    <TouchableOpacity activeOpacity={1} onPress={() => onPress()}>
+    <TouchableOpacity
+      activeOpacity={1}
+      onPress={() => onPress()}
+      accessibilityLabel={title}
+      accessibilityRole="alert"
+      testID={testIdWithKey('Toast')}
+    >
       <View style={[styles.container, { backgroundColor, borderColor, width: width - width * 0.1 }]}>
         <View style={{ flex: 1, flexDirection: 'row' }}>
           <Icon style={styles.icon} name={iconName} color={iconColor} size={iconSize} />
@@ -116,6 +126,10 @@ const BaseToast: React.FC<BaseToastProps> = ({ title, body, toastType, onPress =
             onPress={() => {
               Toast.hide()
             }}
+            accessibilityLabel={t('Global.CloseNotification')}
+            accessibilityRole="button"
+            testID={testIdWithKey('ToastClose')}
+            hitSlop={hitSlop}
           >
             <Icon style={styles.icon} name={'close'} color={iconColor} size={iconSize} />
           </TouchableOpacity>

--- a/packages/core/src/components/views/Banner.tsx
+++ b/packages/core/src/components/views/Banner.tsx
@@ -150,6 +150,8 @@ export const BannerSection: React.FC<BannerSectionProps> = ({
     <TouchableOpacity
       style={{ ...styles.container, backgroundColor: bannerColor(type) }}
       testID={testIdWithKey(`button-${type}`)}
+      accessibilityLabel={title}
+      accessibilityRole="button"
       onPress={() => {
         if (variant === 'summary' && onToggle) {
           onToggle()

--- a/packages/core/src/localization/en/en.json
+++ b/packages/core/src/localization/en/en.json
@@ -45,6 +45,7 @@
     "Requested": "Requested",
     "Updated": "Updated",
     "Close": "Close",
+    "CloseNotification": "Close notification",
     "Remove": "Remove",
     "GotIt": "Got it",
     "Send": "Send",
@@ -324,7 +325,8 @@
     "ForgotPINLink": "Forgot your PIN?",
     "ForgotPINModalTitle": "Forgot your PIN?",
     "ForgotPINModalDescription": "Forgot your PIN? You'll need to reinstall and setup your wallet again.",
-    "Loading": "Logging in"
+    "Loading": "Logging in",
+    "DeveloperMenuTrigger": "App information"
   },
   "AttemptLockout": {
     "Title": "Your wallet is temporarily locked",
@@ -620,7 +622,9 @@
     "ErrorTextboxEmpty": "Textbox Empty",
     "ErrorTextboxEmptyDescription": "Please add a URL intended for digital wallets and try again.",
     "ErrorInvalidUrl": "URL not recognized",
-    "ErrorInvalidUrlDescription": "Check if the URL is intended for digital wallets and if it was copied correctly, then try again."
+    "ErrorInvalidUrlDescription": "Check if the URL is intended for digital wallets and if it was copied correctly, then try again.",
+    "PasteUrlInput": "URL input",
+    "ScanDisabled": "Submit disabled, enter a URL first"
   },
   "Connection": {
     "JustAMoment": "Just a moment while we make a secure connection...",
@@ -706,6 +710,8 @@
     "RequestProcessing": "Just a moment...",
     "OfferDelay": "Offer delay",
     "ChangeCredential": "Change credential",
+    "SelectCredential": "Select credential",
+    "PredicateInput": "Enter value for {{label}}",
     "GetThisCredential": "Get this credential",
     "RejectThisProof?": "Reject this Proof Request?",
     "DeclineThisProof?": "Decline this Proof Request?",
@@ -796,7 +802,8 @@
     "ConfigureMediator": "Configure Mediator",
     "ChangeMediator": "Change Mediator",
     "ChangeMediatorDescription": "Changing the mediator will restart the app. Do you want to continue?",
-    "GenericErrorMessages": "Generic error messages"
+    "GenericErrorMessages": "Generic error messages",
+    "VersionInfo": "Version information"
   },
   "AutoLockTimes": {
     "FiveMinutes": "Five Minutes",

--- a/packages/core/src/localization/en/en.json
+++ b/packages/core/src/localization/en/en.json
@@ -45,6 +45,7 @@
     "Requested": "Requested",
     "Updated": "Updated",
     "Close": "Close",
+    "CloseNotification": "Close notification",
     "Remove": "Remove",
     "GotIt": "Got it",
     "Send": "Send",
@@ -324,7 +325,8 @@
     "ForgotPINLink": "Forgot your PIN?",
     "ForgotPINModalTitle": "Forgot your PIN?",
     "ForgotPINModalDescription": "Forgot your PIN? You'll need to reinstall and setup your wallet again.",
-    "Loading": "Logging in"
+    "Loading": "Logging in",
+    "DeveloperMenuTrigger": "App information"
   },
   "AttemptLockout": {
     "Title": "Your wallet is temporarily locked",
@@ -620,7 +622,9 @@
     "ErrorTextboxEmpty": "Textbox Empty",
     "ErrorTextboxEmptyDescription": "Please add a URL intended for digital wallets and try again.",
     "ErrorInvalidUrl": "URL not recognized",
-    "ErrorInvalidUrlDescription": "Check if the URL is intended for digital wallets and if it was copied correctly, then try again."
+    "ErrorInvalidUrlDescription": "Check if the URL is intended for digital wallets and if it was copied correctly, then try again.",
+    "PasteUrlInput": "URL input",
+    "ScanDisabled": "Submit disabled, enter a URL first"
   },
   "Connection": {
     "JustAMoment": "Just a moment while we make a secure connection...",
@@ -706,6 +710,8 @@
     "RequestProcessing": "Just a moment...",
     "OfferDelay": "Offer delay",
     "ChangeCredential": "Change credential",
+    "SelectCredential": "Select credential",
+    "PredicateInput": "Enter value for {{label}}",
     "GetThisCredential": "Get this credential",
     "RejectThisProof?": "Reject this Proof Request?",
     "DeclineThisProof?": "Decline this Proof Request?",
@@ -799,7 +805,8 @@
     "ConfigureMediator": "Configure Mediator",
     "ChangeMediator": "Change Mediator",
     "ChangeMediatorDescription": "Changing the mediator will restart the app. Do you want to continue?",
-    "GenericErrorMessages": "Generic error messages"
+    "GenericErrorMessages": "Generic error messages",
+    "VersionInfo": "Version information"
   },
   "AutoLockTimes": {
     "FiveMinutes": "Five Minutes",

--- a/packages/core/src/localization/fr/fr.json
+++ b/packages/core/src/localization/fr/fr.json
@@ -46,6 +46,7 @@
     "Updated": "Mis à jour",
     "Remove": "Supprimer",
     "Close": "Fermer",
+    "CloseNotification": "Close notification (FR)",
     "GotIt": "Got it (FR)",
     "Send": "Envoyer",
     "Reset": "Reset (FR)",
@@ -334,7 +335,8 @@
     "ForgotPINLink": "Forgot your PIN? (FR)",
     "ForgotPINModalTitle": "Forgot your PIN? (FR)",
     "ForgotPINModalDescription": "For security purposes, you're unable to recover or reset your PIN. You will need to reinstall your wallet and add your credentials again. (FR)",
-    "Loading": "Logging in (FR)"
+    "Loading": "Logging in (FR)",
+    "DeveloperMenuTrigger": "App information (FR)"
   },
   "AttemptLockout": {
     "Title": "Votre portefeuille est temporairement verrouillé",
@@ -626,7 +628,9 @@
     "ErrorTextboxEmpty": "La zone de texte est vide",
     "ErrorTextboxEmptyDescription": "Veuillez ajouter une URL destinée aux portefeuilles numériques et réessayer.",
     "ErrorInvalidUrl": "URL non reconnue",
-    "ErrorInvalidUrlDescription": "Vérifiez si l'URL est destinée aux portefeuilles numériques et si elle a été copiée correctement, puis réessayez."
+    "ErrorInvalidUrlDescription": "Vérifiez si l'URL est destinée aux portefeuilles numériques et si elle a été copiée correctement, puis réessayez.",
+    "PasteUrlInput": "URL input (FR)",
+    "ScanDisabled": "Submit disabled, enter a URL first (FR)"
   },
   "Connection": {
     "JustAMoment": "Veuillez patienter pendant que nous établissons une connexion sécurisée...",
@@ -711,6 +715,8 @@
     "RequestProcessing": "Juste un instant...",
     "OfferDelay": "Retard de l'offre",
     "ChangeCredential": "Modifier l'attestations d'identification",
+    "SelectCredential": "Select credential (FR)",
+    "PredicateInput": "Enter value for {{label}} (FR)",
     "GetThisCredential": "Obtenir cette attestation d'identification",
     "RejectThisProof?": "Rejeter cette preuve?",
     "AcceptingProof": "Acceptation de la preuve",
@@ -789,7 +795,8 @@
     "ConfigureMediator": "Configurer le médiateur",
     "ChangeMediator": "Change mediator (FR)",
     "ChangeMediatorDescription": "Changing the mediator will restart the app. Do you want to continue? (FR)",
-    "GenericErrorMessages": "Generic error messages (FR)"
+    "GenericErrorMessages": "Generic error messages (FR)",
+    "VersionInfo": "Version information (FR)"
   },
   "AutoLockTimes": {
     "FiveMinutes": "Five Minutes (FR)",

--- a/packages/core/src/localization/fr/fr.json
+++ b/packages/core/src/localization/fr/fr.json
@@ -46,6 +46,7 @@
     "Updated": "Mis à jour",
     "Remove": "Supprimer",
     "Close": "Fermer",
+    "CloseNotification": "Close notification (FR)",
     "GotIt": "Got it (FR)",
     "Send": "Envoyer",
     "Reset": "Reset (FR)",
@@ -334,7 +335,8 @@
     "ForgotPINLink": "Forgot your PIN? (FR)",
     "ForgotPINModalTitle": "Forgot your PIN? (FR)",
     "ForgotPINModalDescription": "For security purposes, you're unable to recover or reset your PIN. You will need to reinstall your wallet and add your credentials again. (FR)",
-    "Loading": "Logging in (FR)"
+    "Loading": "Logging in (FR)",
+    "DeveloperMenuTrigger": "App information (FR)"
   },
   "AttemptLockout": {
     "Title": "Votre portefeuille est temporairement verrouillé",
@@ -626,7 +628,9 @@
     "ErrorTextboxEmpty": "La zone de texte est vide",
     "ErrorTextboxEmptyDescription": "Veuillez ajouter une URL destinée aux portefeuilles numériques et réessayer.",
     "ErrorInvalidUrl": "URL non reconnue",
-    "ErrorInvalidUrlDescription": "Vérifiez si l'URL est destinée aux portefeuilles numériques et si elle a été copiée correctement, puis réessayez."
+    "ErrorInvalidUrlDescription": "Vérifiez si l'URL est destinée aux portefeuilles numériques et si elle a été copiée correctement, puis réessayez.",
+    "PasteUrlInput": "URL input (FR)",
+    "ScanDisabled": "Submit disabled, enter a URL first (FR)"
   },
   "Connection": {
     "JustAMoment": "Veuillez patienter pendant que nous établissons une connexion sécurisée...",
@@ -711,6 +715,8 @@
     "RequestProcessing": "Juste un instant...",
     "OfferDelay": "Retard de l'offre",
     "ChangeCredential": "Modifier l'attestations d'identification",
+    "SelectCredential": "Select credential (FR)",
+    "PredicateInput": "Enter value for {{label}} (FR)",
     "GetThisCredential": "Obtenir cette attestation d'identification",
     "RejectThisProof?": "Rejeter cette preuve?",
     "AcceptingProof": "Acceptation de la preuve",
@@ -792,7 +798,8 @@
     "ConfigureMediator": "Configurer le médiateur",
     "ChangeMediator": "Change mediator (FR)",
     "ChangeMediatorDescription": "Changing the mediator will restart the app. Do you want to continue? (FR)",
-    "GenericErrorMessages": "Generic error messages (FR)"
+    "GenericErrorMessages": "Generic error messages (FR)",
+    "VersionInfo": "Version information (FR)"
   },
   "AutoLockTimes": {
     "FiveMinutes": "Five Minutes (FR)",

--- a/packages/core/src/localization/pt-br/pt-br.json
+++ b/packages/core/src/localization/pt-br/pt-br.json
@@ -44,6 +44,7 @@
     "Requested": "Requested",
     "Updated": "Updated",
     "Close": "Fechar",
+    "CloseNotification": "Close notification (PT-BR)",
     "Remove": "Remover",
     "GotIt": "Got it (PT-BR)",
     "Send": "Enviar",
@@ -306,7 +307,8 @@
     "ForgotPINLink": "Forgot your PIN? (PT-BR)",
     "ForgotPINModalTitle": "Forgot your PIN? (PT-BR)",
     "ForgotPINModalDescription": "For security purposes, you're unable to recover or reset your PIN. You will need to reinstall your wallet and add your credentials again. (PT-BR)",
-    "Loading": "Logging in (PT-BR)"
+    "Loading": "Logging in (PT-BR)",
+    "DeveloperMenuTrigger": "App information (PT-BR)"
   },
   "AttemptLockout": {
     "Title": "Your wallet is temporarily locked (PT-BR)",
@@ -598,7 +600,9 @@
     "ErrorTextboxEmpty": "Textbox Empty (PT-BR)",
     "ErrorTextboxEmptyDescription": "Please add a URL intended for digital wallets and try again. (PT-BR)",
     "ErrorInvalidUrl": "URL not recognized (PT-BR)",
-    "ErrorInvalidUrlDescription": "Check if the URL is intended for digital wallets and if it was copied correctly, then try again. (PT-BR)"
+    "ErrorInvalidUrlDescription": "Check if the URL is intended for digital wallets and if it was copied correctly, then try again. (PT-BR)",
+    "PasteUrlInput": "URL input (PT-BR)",
+    "ScanDisabled": "Submit disabled, enter a URL first (PT-BR)"
   },
   "Connection": {
     "JustAMoment": "Aguarde um momento enquanto fazemos uma conexão segura...",
@@ -685,6 +689,8 @@
     "RequestProcessing": "Só um momento...",
     "OfferDelay": "Atrasar oferta",
     "ChangeCredential": "Escolher credencial",
+    "SelectCredential": "Select credential (PT-BR)",
+    "PredicateInput": "Enter value for {{label}} (PT-BR)",
     "GetThisCredential": "Obter esta credencial",
     "RejectThisProof?": "Rejeitar esta Requisição de Prova?",
     "DeclineThisProof?": "Recusar esta Requisição de Prova?",
@@ -765,7 +771,8 @@
     "ConfigureMediator": "Configurar Mediator",
     "ChangeMediator": "Change mediator (PT-BR)",
     "ChangeMediatorDescription": "Changing the mediator will restart the app. Do you want to continue? (PT-BR)",
-    "GenericErrorMessages": "Generic error messages (PT-BR)"
+    "GenericErrorMessages": "Generic error messages (PT-BR)",
+    "VersionInfo": "Version information (PT-BR)"
   },
   "AutoLockTimes": {
     "FiveMinutes": "Five Minutes (PT-BR)",

--- a/packages/core/src/localization/pt-br/pt-br.json
+++ b/packages/core/src/localization/pt-br/pt-br.json
@@ -44,6 +44,7 @@
     "Requested": "Requested",
     "Updated": "Updated",
     "Close": "Fechar",
+    "CloseNotification": "Close notification (PT-BR)",
     "Remove": "Remover",
     "GotIt": "Got it (PT-BR)",
     "Send": "Enviar",
@@ -306,7 +307,8 @@
     "ForgotPINLink": "Forgot your PIN? (PT-BR)",
     "ForgotPINModalTitle": "Forgot your PIN? (PT-BR)",
     "ForgotPINModalDescription": "For security purposes, you're unable to recover or reset your PIN. You will need to reinstall your wallet and add your credentials again. (PT-BR)",
-    "Loading": "Logging in (PT-BR)"
+    "Loading": "Logging in (PT-BR)",
+    "DeveloperMenuTrigger": "App information (PT-BR)"
   },
   "AttemptLockout": {
     "Title": "Your wallet is temporarily locked (PT-BR)",
@@ -598,7 +600,9 @@
     "ErrorTextboxEmpty": "Textbox Empty (PT-BR)",
     "ErrorTextboxEmptyDescription": "Please add a URL intended for digital wallets and try again. (PT-BR)",
     "ErrorInvalidUrl": "URL not recognized (PT-BR)",
-    "ErrorInvalidUrlDescription": "Check if the URL is intended for digital wallets and if it was copied correctly, then try again. (PT-BR)"
+    "ErrorInvalidUrlDescription": "Check if the URL is intended for digital wallets and if it was copied correctly, then try again. (PT-BR)",
+    "PasteUrlInput": "URL input (PT-BR)",
+    "ScanDisabled": "Submit disabled, enter a URL first (PT-BR)"
   },
   "Connection": {
     "JustAMoment": "Aguarde um momento enquanto fazemos uma conexão segura...",
@@ -685,6 +689,8 @@
     "RequestProcessing": "Só um momento...",
     "OfferDelay": "Atrasar oferta",
     "ChangeCredential": "Escolher credencial",
+    "SelectCredential": "Select credential (PT-BR)",
+    "PredicateInput": "Enter value for {{label}} (PT-BR)",
     "GetThisCredential": "Obter esta credencial",
     "RejectThisProof?": "Rejeitar esta Requisição de Prova?",
     "DeclineThisProof?": "Recusar esta Requisição de Prova?",
@@ -768,7 +774,8 @@
     "ConfigureMediator": "Configurar Mediator",
     "ChangeMediator": "Change mediator (PT-BR)",
     "ChangeMediatorDescription": "Changing the mediator will restart the app. Do you want to continue? (PT-BR)",
-    "GenericErrorMessages": "Generic error messages (PT-BR)"
+    "GenericErrorMessages": "Generic error messages (PT-BR)",
+    "VersionInfo": "Version information (PT-BR)"
   },
   "AutoLockTimes": {
     "FiveMinutes": "Five Minutes (PT-BR)",

--- a/packages/core/src/modules/history/ui/components/HistoryListItem.tsx
+++ b/packages/core/src/modules/history/ui/components/HistoryListItem.tsx
@@ -3,8 +3,25 @@ import { useTranslation } from 'react-i18next'
 import { StyleSheet, TouchableOpacity, View } from 'react-native'
 
 import { useTheme } from '../../../../contexts/theme'
+import { testIdWithKey } from '../../../../utils/testable'
 import { CustomRecord, HistoryCardType } from '../../types'
 import { ThemedText } from '../../../../components/texts/ThemedText'
+
+const cardTitleKeys: Record<HistoryCardType, string> = {
+  [HistoryCardType.CardAccepted]: 'History.CardTitle.CardAccepted',
+  [HistoryCardType.CardDeclined]: 'History.CardTitle.CardDeclined',
+  [HistoryCardType.CardExpired]: 'History.CardTitle.CardExpired',
+  [HistoryCardType.CardRemoved]: 'History.CardTitle.CardRemoved',
+  [HistoryCardType.CardRevoked]: 'History.CardTitle.CardRevoked',
+  [HistoryCardType.CardUpdates]: 'History.CardTitle.CardUpdates',
+  [HistoryCardType.PinChanged]: 'History.CardTitle.WalletPinUpdated',
+  [HistoryCardType.InformationSent]: 'History.CardTitle.InformationSent',
+  [HistoryCardType.InformationNotSent]: 'History.CardTitle.InformationNotSent',
+  [HistoryCardType.Connection]: 'History.CardTitle.Connection',
+  [HistoryCardType.ConnectionRemoved]: 'History.CardTitle.ConnectionRemoved',
+  [HistoryCardType.ActivateBiometry]: 'History.CardTitle.ActivateBiometry',
+  [HistoryCardType.DeactivateBiometry]: 'History.CardTitle.DeactivateBiometry',
+}
 
 interface Props {
   item: CustomRecord
@@ -58,7 +75,7 @@ const HistoryListItem: React.FC<Props> = ({ item }) => {
       case HistoryCardType.CardAccepted: {
         return {
           icon: <Assets.svg.historyCardAcceptedIcon />,
-          title: <ThemedText variant="headingThree">{t('History.CardTitle.CardAccepted')}</ThemedText>,
+          title: <ThemedText variant="headingThree">{t(cardTitleKeys[HistoryCardType.CardAccepted])}</ThemedText>,
           description: <ThemedText>{item.content.correspondenceName}</ThemedText>,
         }
       }
@@ -67,7 +84,7 @@ const HistoryListItem: React.FC<Props> = ({ item }) => {
           icon: <Assets.svg.historyCardDeclinedIcon />,
           title: (
             <ThemedText variant="headerTitle" style={{ color: styles.historyCardRevoked.color }}>
-              {t('History.CardTitle.CardDeclined')}
+              {t(cardTitleKeys[HistoryCardType.CardDeclined])}
             </ThemedText>
           ),
           description: <ThemedText>{item.content.correspondenceName}</ThemedText>,
@@ -76,7 +93,7 @@ const HistoryListItem: React.FC<Props> = ({ item }) => {
       case HistoryCardType.CardExpired: {
         return {
           icon: <Assets.svg.historyCardExpiredIcon />,
-          title: <ThemedText variant="headerTitle">{t('History.CardTitle.CardExpired')}</ThemedText>,
+          title: <ThemedText variant="headerTitle">{t(cardTitleKeys[HistoryCardType.CardExpired])}</ThemedText>,
           description: (
             <ThemedText>
               {t('History.CardDescription.CardExpired', { cardName: item.content.correspondenceName })}
@@ -89,7 +106,7 @@ const HistoryListItem: React.FC<Props> = ({ item }) => {
           icon: <Assets.svg.historyCardRemovedIcon />,
           title: (
             <ThemedText variant="headerTitle" style={{ color: styles.historyCardRevoked.color }}>
-              {t('History.CardTitle.CardRemoved')}
+              {t(cardTitleKeys[HistoryCardType.CardRemoved])}
             </ThemedText>
           ),
           description: <ThemedText>{item.content.correspondenceName}</ThemedText>,
@@ -100,7 +117,7 @@ const HistoryListItem: React.FC<Props> = ({ item }) => {
           icon: <Assets.svg.historyCardRevokedIcon />,
           title: (
             <ThemedText variant="headerTitle" style={{ color: styles.historyCardRevoked.color }}>
-              {t('History.CardTitle.CardRevoked')}
+              {t(cardTitleKeys[HistoryCardType.CardRevoked])}
             </ThemedText>
           ),
           description: (
@@ -113,7 +130,7 @@ const HistoryListItem: React.FC<Props> = ({ item }) => {
       case HistoryCardType.CardUpdates: {
         return {
           icon: <Assets.svg.historyCardUpdatesIcon />,
-          title: <ThemedText variant="headingThree">{t('History.CardTitle.CardUpdates')}</ThemedText>,
+          title: <ThemedText variant="headingThree">{t(cardTitleKeys[HistoryCardType.CardUpdates])}</ThemedText>,
           description: <ThemedText>{item.content.correspondenceName}</ThemedText>,
         }
       }
@@ -122,7 +139,7 @@ const HistoryListItem: React.FC<Props> = ({ item }) => {
           icon: <Assets.svg.historyPinUpdatedIcon />,
           title: (
             <ThemedText variant="headerTitle" style={{ color: styles.infoBox.color }}>
-              {t('History.CardTitle.WalletPinUpdated')}
+              {t(cardTitleKeys[HistoryCardType.PinChanged])}
             </ThemedText>
           ),
           description: <ThemedText>{t('History.CardDescription.WalletPinUpdated')}</ThemedText>,
@@ -133,7 +150,7 @@ const HistoryListItem: React.FC<Props> = ({ item }) => {
           icon: <Assets.svg.historyInformationSentIcon />,
           title: (
             <ThemedText variant="headingThree" style={{ color: styles.successColor.color }}>
-              {t('History.CardTitle.InformationSent')}
+              {t(cardTitleKeys[HistoryCardType.InformationSent])}
             </ThemedText>
           ),
           description: <ThemedText>{item.content.correspondenceName}</ThemedText>,
@@ -144,7 +161,7 @@ const HistoryListItem: React.FC<Props> = ({ item }) => {
           icon: <Assets.svg.historyInformationNotSentIcon />,
           title: (
             <ThemedText variant="headerTitle" style={{ color: styles.historyCardRevoked.color }}>
-              {t('History.CardTitle.InformationNotSent')}
+              {t(cardTitleKeys[HistoryCardType.InformationNotSent])}
             </ThemedText>
           ),
           description: <ThemedText>{item.content.correspondenceName}</ThemedText>,
@@ -153,7 +170,7 @@ const HistoryListItem: React.FC<Props> = ({ item }) => {
       case HistoryCardType.Connection: {
         return {
           icon: <Assets.svg.historyConnectionIcon />,
-          title: <ThemedText variant="headingThree">{t('History.CardTitle.Connection')}</ThemedText>,
+          title: <ThemedText variant="headingThree">{t(cardTitleKeys[HistoryCardType.Connection])}</ThemedText>,
           description: <ThemedText>{item.content.correspondenceName}</ThemedText>,
         }
       }
@@ -162,7 +179,7 @@ const HistoryListItem: React.FC<Props> = ({ item }) => {
           icon: <Assets.svg.historyConnectionRemovedIcon />,
           title: (
             <ThemedText variant="headingThree" style={{ color: styles.historyCardRevoked.color }}>
-              {t('History.CardTitle.ConnectionRemoved')}
+              {t(cardTitleKeys[HistoryCardType.ConnectionRemoved])}
             </ThemedText>
           ),
           description: <ThemedText>{item.content.correspondenceName}</ThemedText>,
@@ -171,7 +188,7 @@ const HistoryListItem: React.FC<Props> = ({ item }) => {
       case HistoryCardType.ActivateBiometry: {
         return {
           icon: <Assets.svg.historyActivateBiometryIcon />,
-          title: <ThemedText variant="headingThree">{t('History.CardTitle.ActivateBiometry')}</ThemedText>,
+          title: <ThemedText variant="headingThree">{t(cardTitleKeys[HistoryCardType.ActivateBiometry])}</ThemedText>,
           description: <ThemedText>{item.content.correspondenceName}</ThemedText>,
         }
       }
@@ -180,7 +197,7 @@ const HistoryListItem: React.FC<Props> = ({ item }) => {
           icon: <Assets.svg.historyDeactivateBiometryIcon />,
           title: (
             <ThemedText variant="headingThree" style={{ color: styles.historyCardRevoked.color }}>
-              {t('History.CardTitle.DeactivateBiometry')}
+              {t(cardTitleKeys[HistoryCardType.DeactivateBiometry])}
             </ThemedText>
           ),
           description: <ThemedText>{item.content.correspondenceName}</ThemedText>,
@@ -242,6 +259,9 @@ const HistoryListItem: React.FC<Props> = ({ item }) => {
       onPress={() => {
         //TODO: navigate to history details
       }}
+      accessibilityLabel={`${item.content.type && item.content.type in cardTitleKeys ? t(cardTitleKeys[item.content.type as HistoryCardType]) : ''} ${'correspondenceName' in item.content ? (item.content.correspondenceName ?? '') : ''}`.trim()}
+      accessibilityRole="button"
+      testID={testIdWithKey('HistoryItem')}
     >
       {renderCard(item)}
     </TouchableOpacity>

--- a/packages/core/src/modules/openid/screens/OpenIDProofChangeCredential.tsx
+++ b/packages/core/src/modules/openid/screens/OpenIDProofChangeCredential.tsx
@@ -5,6 +5,7 @@ import { FlatList, StyleSheet, TouchableOpacity, View } from 'react-native'
 import { MdocRecord, SdJwtVcRecord, W3cCredentialRecord, W3cV2CredentialRecord } from '@credo-ts/core'
 import React, { useEffect, useState } from 'react'
 import RecordLoading from '../../../components/animated/RecordLoading'
+import { hitSlop } from '../../../constants'
 import { ThemedText } from '../../../components/texts/ThemedText'
 import { useTheme } from '../../../contexts/theme'
 import ScreenLayout from '../../../layout/ScreenLayout'
@@ -116,8 +117,10 @@ const OpenIDProofCredentialSelect: React.FC<Props> = ({ route, navigation }: Pro
             <View style={styles.pageMargin}>
               <TouchableOpacity
                 accessibilityRole="button"
+                accessibilityLabel={t('ProofRequest.SelectCredential')}
                 testID={testIdWithKey(`select:${item.credential.id}`)}
                 onPress={() => changeCred(item)}
+                hitSlop={hitSlop}
                 style={[
                   item.credential.id === selectedCredentialID ? SelectedCredTheme : undefined,
                   { marginBottom: 10 },

--- a/packages/core/src/screens/PINEnter.tsx
+++ b/packages/core/src/screens/PINEnter.tsx
@@ -408,6 +408,8 @@ const PINEnter: React.FC<PINEnterProps> = ({ setAuthenticated }) => {
         <Pressable
           onPress={enableHiddenDevModeTrigger ? incrementDeveloperMenuCounter : () => {}}
           testID={testIdWithKey('DeveloperCounter')}
+          accessibilityLabel={t('PINEnter.DeveloperMenuTrigger')}
+          accessibilityRole="text"
         >
           {HelpText}
         </Pressable>

--- a/packages/core/src/screens/PasteUrl.tsx
+++ b/packages/core/src/screens/PasteUrl.tsx
@@ -6,6 +6,7 @@ import { StyleSheet, View, TextInput, ScrollView, TouchableOpacity } from 'react
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import Button, { ButtonType } from '../components/buttons/Button'
+import { hitSlop } from '../constants'
 import InfoBox, { InfoBoxType } from '../components/misc/InfoBox'
 import SafeAreaModal from '../components/modals/SafeAreaModal'
 import { TOKENS, useServices } from '../container-api'
@@ -93,6 +94,7 @@ const PasteUrl: React.FC<PasteProps> = ({ navigation }) => {
           <ThemedText style={styles.description}>{t('PasteUrl.PasteUrlDescription')}</ThemedText>
           <TextInput
             testID={testIdWithKey('PastedUrl')}
+            accessibilityLabel={t('PasteUrl.PasteUrlInput')}
             style={styles.textBox}
             numberOfLines={15}
             multiline
@@ -103,6 +105,9 @@ const PasteUrl: React.FC<PasteProps> = ({ navigation }) => {
         <View style={styles.buttonContainer}>
           <TouchableOpacity
             testID={testIdWithKey('ScanPastedUrlDisabled')}
+            accessibilityLabel={t('PasteUrl.ScanDisabled')}
+            accessibilityRole="button"
+            hitSlop={hitSlop}
             disabled={pastedContent.length > 0}
             onPress={() => {
               setErrorMessage({

--- a/packages/core/src/screens/ProofChangeCredential.tsx
+++ b/packages/core/src/screens/ProofChangeCredential.tsx
@@ -10,7 +10,7 @@ import { DeviceEventEmitter, FlatList, StyleSheet, TouchableOpacity, View } from
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import RecordLoading from '../components/animated/RecordLoading'
-import { EventTypes } from '../constants'
+import { EventTypes, hitSlop } from '../constants'
 import { useTheme } from '../contexts/theme'
 import { useAllCredentialsForProof } from '../hooks/proofs'
 import { BifoldError } from '../types/error'
@@ -151,8 +151,10 @@ const ProofChangeCredential: React.FC<ProofChangeProps> = ({ route, navigation }
             <View style={styles.pageMargin}>
               <TouchableOpacity
                 accessibilityRole="button"
+                accessibilityLabel={t('ProofRequest.SelectCredential')}
                 testID={testIdWithKey(`select:${item.credId}`)}
                 onPress={() => changeCred(item.credId ?? '')}
+                hitSlop={hitSlop}
                 style={[item.credId === selectedCred ? SelectedCredTheme : undefined, { marginBottom: 10 }]}
               >
                 <CredentialCardGen

--- a/packages/core/src/screens/Settings.tsx
+++ b/packages/core/src/screens/Settings.tsx
@@ -397,6 +397,7 @@ const Settings: React.FC<SettingsProps> = ({ navigation }) => {
             <TouchableWithoutFeedback
               onPress={incrementDeveloperMenuCounter}
               disabled={store.preferences.developerModeEnabled}
+              accessibilityLabel={t('Settings.VersionInfo')}
             >
               <View>
                 <ThemedText testID={testIdWithKey('Version')}>

--- a/packages/remote-logs/src/__tests__/logger.comprehensive.test.ts
+++ b/packages/remote-logs/src/__tests__/logger.comprehensive.test.ts
@@ -36,7 +36,9 @@ jest.mock('@credo-ts/core', () => ({
   },
 }))
 
-jest.mock('@bifold/core', () => ({
+jest.mock(
+  '@bifold/core',
+  () => ({
   BifoldLogger: class BifoldLogger {},
   AbstractBifoldLogger: class AbstractBifoldLogger {
     public logLevel = 2 // LogLevel.debug
@@ -80,7 +82,9 @@ jest.mock('@bifold/core', () => ({
       this.message = message
     }
   },
-}))
+}),
+  { virtual: true }
+)
 
 jest.mock('../transports', () => ({
   lokiTransport: jest.fn(),


### PR DESCRIPTION
## Summary

Adds missing `accessibilityLabel` (and where absent, `accessibilityRole`, `hitSlop`, `testID`) to 15 interactable components across 14 files in `@bifold/core` so Android Voice Access and iOS Voice Control can assign numbered commands to every tappable element.

### Non-semantic overlays — marked `accessible={false}`

- `ActionSlider` dismiss overlay (`TouchableOpacity`) — tap-outside-to-close, no meaningful label
- `ScanCamera` tap-to-focus area (`Pressable`) — camera overlay, no meaningful label

Closes #1809

### Labels derived from existing props

- `SingleSelectBlock` — `accessibilityLabel={item.value}`, adds `accessibilityRole="radio"` and `accessibilityState={{ selected }}`
- `CredentialCard11ActionFooter` — `accessibilityLabel={text}`, adds `accessibilityRole="button"` and `hitSlop`
- `BaseToast` outer touchable — `accessibilityLabel={title}`, `accessibilityRole="alert"`, `testID`
- `BaseToast` close button — new `Global.CloseNotification` key, `accessibilityRole="button"`, `hitSlop`, `testID`
- `Banner` — `accessibilityLabel={title}`, `accessibilityRole="button"`
- `HistoryListItem` — composite label from card-type title + correspondence name; extracts a shared `cardTitleKeys` map for DRY translation key resolution

### Labels from new i18n keys

| Component | Key |
|---|---|
| `PINEnter` developer menu trigger | `PINEnter.DeveloperMenuTrigger` |
| `PasteUrl` URL text input | `PasteUrl.PasteUrlInput` |
| `PasteUrl` disabled submit button | `PasteUrl.ScanDisabled` |
| `ProofChangeCredential` select button | `ProofRequest.SelectCredential` |
| `OpenIDProofChangeCredential` select button | `ProofRequest.SelectCredential` (shared) |
| `VerifierCredentialCard` predicate input | `ProofRequest.PredicateInput` (interpolated with field label) |
| `Settings` version info trigger | `Settings.VersionInfo` |

New keys added to `en.json`, `fr.json`, and `pt-br.json` (FR and PT-BR entries marked with language suffix pending translation).

## Test plan

- [ ] Run the app on Android with Voice Access enabled — every button/input should receive a numbered command label
- [ ] Run the app on iOS with Voice Control enabled — every button/input should be addressable by name
- [ ] Verify `SingleSelectBlock` announces selected state correctly with TalkBack / VoiceOver
- [ ] Verify `BaseToast` close button is reachable and announced as "Close notification"
- [ ] Verify `HistoryListItem` rows announce card type + correspondence name
- [ ] Verify `VerifierCredentialCard` predicate inputs announce the field label
- [ ] Confirm no visual regression — `accessible={false}` overlays remain invisible to sighted users