### PR TITLE
fix: app store receipt error bubbling

### DIFF
--- a/.changeset/tender-islands-serve.md
+++ b/.changeset/tender-islands-serve.md
@@ -1,0 +1,5 @@
+---
+'@bifold/react-native-attestation': patch
+---
+
+bubble up errors from app store receipt method in attestation package

--- a/packages/react-native-attestation/README.md
+++ b/packages/react-native-attestation/README.md
@@ -26,6 +26,7 @@ if (Platform.OS === 'ios') {
   const attestationAsBuffer = await appleAttestation(keyId, nonce);
 
   // Legacy App Store receipt (for compatibility)
+  // Throws if the receipt is missing or unreadable.
   const appStoreReceipt = await getAppStoreReceipt();
 } else if (Platform.OS === 'android') {
   const available = await isPlayIntegrityAvailable();

--- a/packages/react-native-attestation/ios/Attestation.mm
+++ b/packages/react-native-attestation/ios/Attestation.mm
@@ -271,6 +271,7 @@ RCT_EXPORT_METHOD(appleAttestation:(NSString *)keyId
 RCT_EXPORT_METHOD(getAppStoreReceipt:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
     NSURL *appStoreReceiptURL = [[NSBundle mainBundle] appStoreReceiptURL];
+    NSString *missingReceiptMessage = @"No App Store receipt is available.";
     
     if (appStoreReceiptURL && [[NSFileManager defaultManager] fileExistsAtPath:[appStoreReceiptURL path]]) {
         NSError *error;
@@ -281,10 +282,11 @@ RCT_EXPORT_METHOD(getAppStoreReceipt:(RCTPromiseResolveBlock)resolve
             NSString *receiptString = [receiptData base64EncodedStringWithOptions:0];
             resolve(receiptString);
         } else {
-            reject(@"receipt_error", @"Failed to read App Store receipt", error);
+            NSString *readErrorMessage = @"Failed to read App Store receipt.";
+            reject(@"receipt_error", readErrorMessage, errorWithReason(readErrorMessage, 24));
         }
     } else {
-        resolve([NSNull null]); // No receipt available
+        reject(@"receipt_missing", missingReceiptMessage, errorWithReason(missingReceiptMessage, 23));
     }
 }
 

--- a/packages/react-native-attestation/src/NativeAttestation.ts
+++ b/packages/react-native-attestation/src/NativeAttestation.ts
@@ -8,7 +8,7 @@ export interface Spec extends TurboModule {
   appleKeyAttestation(keyId: string, challenge: string): Promise<Buffer>;
   isPlayIntegrityAvailable(): Promise<boolean>;
   googleAttestation(nonce: string): Promise<string>;
-  getAppStoreReceipt(): Promise<string | null>;
+  getAppStoreReceipt(): Promise<string>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('Attestation');

--- a/packages/react-native-attestation/src/index.ts
+++ b/packages/react-native-attestation/src/index.ts
@@ -94,7 +94,7 @@ export const isPlayIntegrityAvailable = async (): Promise<boolean> => {
   return Attestation.isPlayIntegrityAvailable();
 };
 
-export const getAppStoreReceipt = async (): Promise<string | null> => {
+export const getAppStoreReceipt = async (): Promise<string> => {
   if (Platform.OS !== 'ios') {
     throw new Error('getAppStoreReceipt is only available on iOS');
   }


### PR DESCRIPTION
# Summary of Changes

Bubbles up errors in app store receipt attestation method instead of silently returning null

# Testing Instructions

N/A

# Acceptance Criteria

N/A

# Screenshots, videos, or gifs

<img width="538" height="127" alt="Screenshot 2026-03-31 at 2 53 16 PM" src="https://github.com/user-attachments/assets/d5b98609-6856-4127-9fbb-712b09f2f49b" />

# Breaking change guide

N/A

# Related Issues

bcgov/bc-wallet-mobile#3542

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
