### PR TITLE
fix: add separate translation for tab bar accessibility

### DIFF
--- a/.changeset/eager-states-sip.md
+++ b/.changeset/eager-states-sip.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+Add separate accessibility label for tab bar buttons

--- a/packages/core/src/localization/en/en.json
+++ b/packages/core/src/localization/en/en.json
@@ -810,6 +810,11 @@
     "Scan": "Scan",
     "Credentials": "Credentials"
   },
+  "TabStackAccessibility": {
+    "Home": "Notifications tab {{notifications}} notifications",
+    "Scan": "Scan tab",
+    "Credentials": "Credentials tab"
+  },
   "RootStack": {
     "Contacts": "Contacts",
     "Settings": "Settings"

--- a/packages/core/src/localization/fr/fr.json
+++ b/packages/core/src/localization/fr/fr.json
@@ -803,6 +803,11 @@
     "Scan": "Numériser",
     "Credentials": "Justificatifs"
   },
+  "TabStackAccessibility": {
+    "Home": "Notifications tab {{notifications}} notifications (FR)",
+    "Scan": "Scan tab (FR)",
+    "Credentials": "Credentials tab (FR)"
+  },
   "RootStack": {
     "Contacts": "Contacts",
     "Settings": "Paramètres"

--- a/packages/core/src/localization/pt-br/pt-br.json
+++ b/packages/core/src/localization/pt-br/pt-br.json
@@ -779,6 +779,11 @@
     "Scan": "Scanear",
     "Credentials": "Credenciais"
   },
+  "TabStackAccessibility": {
+    "Home": "Notifications tab {{notifications}} notifications (PT-BR)",
+    "Scan": "Scan tab (PT-BR)",
+    "Credentials": "Credentials tab (PT-BR)"
+  },
   "RootStack": {
     "Contacts": "Contatos",
     "Settings": "Configurações"

--- a/packages/core/src/navigators/TabStack.tsx
+++ b/packages/core/src/navigators/TabStack.tsx
@@ -174,7 +174,7 @@ const TabStack: React.FC = () => {
               </AttachTourStep>
             ),
             tabBarShowLabel: false,
-            tabBarAccessibilityLabel: `${t('TabStack.Home')} (${notifications.length ?? 0})`,
+            tabBarAccessibilityLabel: t('TabStackAccessibility.Home', { notifications: notifications?.length ?? 0 }),
             tabBarTestID: testIdWithKey(t('TabStack.Home')),
             tabBarBadge: notifications.length || undefined,
             tabBarBadgeStyle: {
@@ -248,7 +248,7 @@ const TabStack: React.FC = () => {
               </View>
             ),
             tabBarShowLabel: false,
-            tabBarAccessibilityLabel: t('TabStack.Scan'),
+            tabBarAccessibilityLabel: t('TabStackAccessibility.Scan'),
             tabBarTestID: testIdWithKey(t('TabStack.Scan')),
           }}
           listeners={({ navigation }) => ({
@@ -291,7 +291,7 @@ const TabStack: React.FC = () => {
               </AttachTourStep>
             ),
             tabBarShowLabel: false,
-            tabBarAccessibilityLabel: t('TabStack.Credentials'),
+            tabBarAccessibilityLabel: t('TabStackAccessibility.Credentials'),
             tabBarTestID: testIdWithKey(t('TabStack.Credentials')),
           }}
         />


### PR DESCRIPTION
# Summary of Changes

Added separate accessibility label translations for tab bar

# Testing Instructions

Use screen reader on bottom tabs

# Acceptance Criteria

Correct accessibility labels

# Screenshots, videos, or gifs

N/A

# Breaking change guide

N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
