### PR TITLE
fix: proof request screen error handling

### DIFF
--- a/.changeset/twenty-suns-joke.md
+++ b/.changeset/twenty-suns-joke.md
@@ -1,0 +1,5 @@
+---
+"@bifold/core": patch
+---
+
+fix proof request screen error handling

--- a/packages/core/src/screens/ProofRequest.tsx
+++ b/packages/core/src/screens/ProofRequest.tsx
@@ -4,23 +4,18 @@ import {
   AnonCredsRequestedPredicateMatch,
   DidCommRequestPresentationV1Message,
 } from '@credo-ts/anoncreds'
-import {
-  DifPexInputDescriptorToCredentials,
-  CredoError,
-  SubmissionEntryCredential,
-  ClaimFormat,
-} from '@credo-ts/core'
+import { DifPexInputDescriptorToCredentials, CredoError, SubmissionEntryCredential, ClaimFormat } from '@credo-ts/core'
 import { useConnectionById, useProofById } from '@bifold/react-hooks'
 import {
   DidCommCredentialExchangeRecord,
   CredentialRecordBinding,
   DidCommRequestPresentationV2Message,
-  DidCommProofState
+  DidCommProofState,
 } from '@credo-ts/didcomm'
 import { Attribute, Predicate } from '@bifold/oca/build/legacy'
 import { useIsFocused } from '@react-navigation/native'
 import moment from 'moment'
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   DeviceEventEmitter,
@@ -116,6 +111,7 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, proofId }) => {
   const [attestationLoading, setAttestationLoading] = useState(false)
   const [showDetailsModal, setShowDetailsModal] = useState(false)
   const [showErrorModal, setShowErrorModal] = useState(false)
+  const isHandlingLocalProofExit = useRef(false)
 
   const [store, dispatch] = useStore()
   const credProofPromise = useAllCredentialsForProof(proofId)
@@ -184,10 +180,24 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, proofId }) => {
   })
 
   useEffect(() => {
-    if (proof && proof?.state !== DidCommProofState.RequestReceived) {
-      setShowErrorModal(true)
+    if (!proof) {
+      return
     }
-  }, [t, proof])
+    if (proof.state === DidCommProofState.RequestReceived) {
+      setShowErrorModal(false)
+      isHandlingLocalProofExit.current = false
+      return
+    }
+
+    if (proof.state === DidCommProofState.Declined || proof.state === DidCommProofState.Abandoned) {
+      if (!isHandlingLocalProofExit.current) {
+        navigation.getParent()?.navigate(TabStacks.HomeStack, { screen: Screens.Home })
+      }
+      return
+    }
+
+    setShowErrorModal(true)
+  }, [navigation, proof])
 
   useEffect(() => {
     if (!attestationMonitor) {
@@ -510,12 +520,12 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, proofId }) => {
           Object.entries(descriptorMetadata).map(([descriptorId, meta]) => {
             const activeCredentialIds = activeCreds.map((cred) => cred.credId)
             const selectedRecord = meta.find((item) => activeCredentialIds.includes(item.record.id))
-            if (!selectedRecord) { 
+            if (!selectedRecord) {
               throw new Error(t('ProofRequest.CredentialMetadataNotFound'))
             }
             const recordReturn: SubmissionEntryCredential = {
               claimFormat: ClaimFormat.JwtVc,
-              credentialRecord: selectedRecord.record
+              credentialRecord: selectedRecord.record,
             }
             return [descriptorId, [recordReturn]]
           })
@@ -598,13 +608,17 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, proofId }) => {
   ])
 
   const handleDeclineTouched = useCallback(async () => {
+    isHandlingLocalProofExit.current = true
     try {
       if (agent && proof) {
         const connectionId = proof.connectionId ?? ''
         const connection = await agent.modules.didcomm.connections.findById(connectionId)
 
         if (connection) {
-          await agent.modules.didcomm.proofs.sendProblemReport({ proofExchangeRecordId: proof.id, description: t('ProofRequest.Declined') })
+          await agent.modules.didcomm.proofs.sendProblemReport({
+            proofExchangeRecordId: proof.id,
+            description: t('ProofRequest.Declined'),
+          })
         }
 
         await agent.modules.didcomm.proofs.declineRequest({ proofExchangeRecordId: proof.id })
@@ -636,11 +650,15 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, proofId }) => {
   ])
 
   const handleCancelTouched = useCallback(async () => {
+    isHandlingLocalProofExit.current = true
     try {
       toggleCancelModalVisible()
 
       if (agent && proof) {
-        await agent.modules.didcomm.proofs.sendProblemReport({ proofExchangeRecordId: proof.id, description: t('ProofRequest.Declined') })
+        await agent.modules.didcomm.proofs.sendProblemReport({
+          proofExchangeRecordId: proof.id,
+          description: t('ProofRequest.Declined'),
+        })
         await agent.modules.didcomm.proofs.declineRequest({ proofExchangeRecordId: proof.id })
 
         if (proof.connectionId && goalCode?.endsWith('verify.once')) {


### PR DESCRIPTION
# Summary of Changes

This PR fixes a proof request screen bug where a proof that had already been legitimately declined or abandoned could be treated as an error state. The screen now dismisses cleanly for externally-ended proof flows, while
  avoiding duplicate navigation when the decline/cancel action was already initiated locally from the same screen

# Testing Instructions

Replace this text with detailed instructions on how to test the changes included in this PR.

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Breaking change guide

Replace this text with any breaking changes included in this PR along with how to address them in downstream projects. If there are none, simply enter N/A

# Related Issues

Replace this text with issue #'s that are relevant to this PR. If there are none, simply enter N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [ ] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [ ] If applicable, screenshots, gifs, or video are included for UI changes
- [ ] If applicable, breaking changes are described above along with how to address them
- [ ] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [ ] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
