### PR TITLE
fix: header icon color set to white for all onboarding screens

### DIFF
--- a/.changeset/twenty-views-sort.md
+++ b/.changeset/twenty-views-sort.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+Fix header icon on onboarding screens set to white

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -1080,7 +1080,7 @@ export function createOnboardingTheme(theme: { ColorPalette: IColorPalette; Text
   return {
     ...textStyles,
     ...viewStyles,
-    headerTintColor: ColorPalette.grayscale.white,
+    headerTintColor: theme.ColorPalette.brand.headerIcon,
     imageDisplayOptions: {
       fill: ColorPalette.notification.infoText,
     },

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -1079,7 +1079,7 @@ export function createOnboardingTheme(theme: { ColorPalette: IColorPalette; Text
   return {
     ...textStyles,
     ...viewStyles,
-    headerTintColor: ColorPalette.grayscale.white,
+    headerTintColor: theme.ColorPalette.brand.headerIcon,
     imageDisplayOptions: {
       fill: ColorPalette.notification.infoText,
     },


### PR DESCRIPTION
# Summary of Changes

Fix for header icon color set to white for all onboarding screens

# Testing Instructions

Open onboarding screens and see correct header icon colors

# Acceptance Criteria

Header icon color properly set

# Screenshots, videos, or gifs

<img width="433" height="901" alt="Screenshot 2026-05-05 at 2 16 16 PM" src="https://github.com/user-attachments/assets/dbbcbd46-f6fc-4a37-a9e6-daeab0da0851" />

# Breaking change guide

N/A

# Related Issues

Replace this text with issue #'s that are relevant to this PR. If there are none, simply enter N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
