### PR TITLE
fix: limit camera scan to fire once

### DIFF
--- a/.changeset/heavy-papers-jam.md
+++ b/.changeset/heavy-papers-jam.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': major
+---
+
+fix camera scan

--- a/packages/core/src/components/misc/ScanCamera.tsx
+++ b/packages/core/src/components/misc/ScanCamera.tsx
@@ -43,6 +43,7 @@ const ScanCamera: React.FC<ScanCameraProps> = ({ handleCodeScan, error, enableCa
     [OrientationType['LANDSCAPE-RIGHT']]: '90deg',
   }
   const [invalidQrCodes, setInvalidQrCodes] = useState(new Set<string>())
+  const hasFiredRef = useRef(false)
   const [focusPoint, setFocusPoint] = useState<{ x: number; y: number } | null>(null)
   const focusOpacity = useRef(new Animated.Value(0)).current
   const focusScale = useRef(new Animated.Value(1)).current
@@ -70,11 +71,16 @@ const ScanCamera: React.FC<ScanCameraProps> = ({ handleCodeScan, error, enableCa
       if (error?.data === value) {
         setInvalidQrCodes((prev) => new Set([...prev, value]))
         if (enableCameraOnError) {
+          hasFiredRef.current = false
           return setCameraActive(true)
         }
       }
 
+      if (hasFiredRef.current) {
+        return
+      }
       if (cameraActive) {
+        hasFiredRef.current = true
         Vibration.vibrate()
         handleCodeScan(value)
         return setCameraActive(false)
@@ -126,6 +132,7 @@ const ScanCamera: React.FC<ScanCameraProps> = ({ handleCodeScan, error, enableCa
 
   useEffect(() => {
     if (error?.data && enableCameraOnError) {
+      hasFiredRef.current = false
       setCameraActive(true)
     }
   }, [error, enableCameraOnError])


### PR DESCRIPTION
Signed-off-by: Kjartan Einarsson <kjartanreinarsson@gmail.com>

# Summary of Changes

Fixes a bug in `ScanCamera` where a QR code could be processed multiple times in rapid succession. Added a `hasFiredRef` guard so `handleCodeScan` only fires once per scan, and reset it when the camera is reactivated after an error.

# Testing Instructions

1. Open any flow that uses the QR scanner (e.g. scan a connection invitation).
2. Scan a valid QR code and confirm `handleCodeScan` is invoked exactly once (no duplicate navigation, vibration, or downstream calls).
3. Trigger an error scan (invalid QR) with `enableCameraOnError` enabled, then scan a valid code — confirm the next scan still fires correctly.

# Acceptance Criteria

- A single QR scan results in exactly one call to `handleCodeScan`.
- Re-enabling the camera after an error allows subsequent scans to fire normally.

# Screenshots, videos, or gifs

N/A

# Breaking change guide

N/A

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
