### PR TITLE
feat(core): export reusable screens and connection hooks from package…

### DIFF
--- a/.changeset/wacky-dolls-itch.md
+++ b/.changeset/wacky-dolls-itch.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+additional exports - no behavior change

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -270,3 +270,21 @@ export {
   AgentBridge,
 }
 export type { BannerMessage, DeepPartial, IButton }
+
+// Reusable screens for embedding in consumer-side nav graphs that don't register
+// Bifold's ConnectionStack / ContactStack hierarchy verbatim.
+export { default as CredentialOffer } from './screens/CredentialOffer'
+export { default as ProofRequest } from './screens/ProofRequest'
+
+// Loading view used by consumer-side connection-loading screens while a proof
+// or credential-offer notification is awaited.
+export {
+  default as LoadingPlaceholder,
+  LoadingPlaceholderWorkflowType,
+} from './components/views/LoadingPlaceholder'
+
+// Hooks that let consumers detect when a notification (offer / proof) has
+// arrived for a freshly received out-of-band invitation.
+export { useNotifications } from './hooks/notifications'
+export type { NotificationItemType, NotificationReturnType, NotificationsInputProps } from './hooks/notifications'
+export { useConnectionByOutOfBandId, useOutOfBandById, useOutOfBandByConnectionId } from './hooks/connections'


### PR DESCRIPTION
# Summary of Changes

Adds package-root exports for `CredentialOffer`, `ProofRequest`, `LoadingPlaceholder` (+ workflow type),
  `useNotifications` (+ related types), and the three out-of-band/connection lookup hooks (`useOutOfBandById`,
  `useConnectionByOutOfBandId`, `useOutOfBandByConnectionId`).

  These already exist internally — surfacing them from the root lets consumer apps (e.g. BC Wallet's BCSC theme)
  build a custom connection-loading screen on top of Bifold's reusable pieces without registering the full
  `ConnectionStack` / `ContactStack` hierarchy, and retire a yarn-patch carrying the same symbols.

  Pure additive — no behavior change.

# Testing Instructions

Replace this text with detailed instructions on how to test the changes included in this PR.

# Acceptance Criteria

Replace this text with the acceptance criteria that must be met for this PR to be approved.

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Breaking change guide

Replace this text with any breaking changes included in this PR along with how to address them in downstream projects. If there are none, simply enter N/A

# Related Issues

Replace this text with issue #'s that are relevant to this PR. If there are none, simply enter N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
