### PR TITLE
feat(core): export Connection screen and URL classifiers for consumer-side reuse

### DIFF
--- a/.changeset/export-connection-screen.md
+++ b/.changeset/export-connection-screen.md
@@ -2,4 +2,4 @@
 '@bifold/core': patch
 ---
 
-Export `Connection` screen for consumer-side reuse — no behavior change.
+Export `Connection` screen and URL classifiers (`isDidCommInvitation`, `isOpenIdCredentialOffer`, `isOpenIdPresentationRequest`, `isMediatorInvitation`) for consumer-side reuse — no behavior change.

--- a/.changeset/export-connection-screen.md
+++ b/.changeset/export-connection-screen.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+Export `Connection` screen for consumer-side reuse — no behavior change.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -273,6 +273,7 @@ export type { BannerMessage, DeepPartial, IButton }
 
 // Reusable screens for embedding in consumer-side nav graphs that don't register
 // Bifold's ConnectionStack / ContactStack hierarchy verbatim.
+export { default as Connection } from './screens/Connection'
 export { default as CredentialOffer } from './screens/CredentialOffer'
 export { default as ProofRequest } from './screens/ProofRequest'
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -289,3 +289,8 @@ export {
 export { useNotifications } from './hooks/notifications'
 export type { NotificationItemType, NotificationReturnType, NotificationsInputProps } from './hooks/notifications'
 export { useConnectionByOutOfBandId, useOutOfBandById, useOutOfBandByConnectionId } from './hooks/connections'
+
+// URL classifiers consumer-side scan dispatchers use to recognize and reject
+// OpenID / mediator URIs before parsing them as DIDComm OOB invitations.
+export { isDidCommInvitation, isOpenIdCredentialOffer, isOpenIdPresentationRequest } from './utils/parsers'
+export { isMediatorInvitation } from './utils/mediatorhelpers'


### PR DESCRIPTION
## Summary

Adds two groups of exports to `packages/core/src/index.ts`, both pure re-exports — no behavior change:

1. **`Connection` screen** — alongside the existing `CredentialOffer` and `ProofRequest` exports in the reusable-screens block.
2. **URL classifiers** — `isDidCommInvitation`, `isOpenIdCredentialOffer`, `isOpenIdPresentationRequest` from `utils/parsers`, and `isMediatorInvitation` from `utils/mediatorhelpers`.

## Motivation

Follow-up to #1838, which exposed `CredentialOffer`, `ProofRequest`, `LoadingPlaceholder`, and the connection-related hooks for consumers that don't register Bifold's `ConnectionStack` / `ContactStack` verbatim.

**`Connection`**: BC Wallet's BCSC theme is currently re-implementing the OOB → connection → proof/offer state machine that already lives in `Connection.tsx`, only because the screen wasn't reachable from a consumer's nav graph. Exporting it lets BCSC wrap it with a navigation adapter (intercepting hardcoded routes like `TabStacks.HomeStack` and `Screens.Chat`) and delete its local copy — same pattern used today for `CredentialOffer` / `ProofRequest`.

**URL classifiers**: BCSC's scan dispatcher currently duplicates `isOpenIdCredentialOffer`, `isOpenIdPresentationRequest`, `isDidCommInvitation`, and `isMediatorInvitation` byte-for-byte. Re-exporting keeps consumer-side classification in lockstep with Bifold's `InvitationQrTypes` — if a new prefix (e.g. a future OpenID variant) is added to Bifold, it won't silently slip past consumer-side dispatchers.

## Changes

- `packages/core/src/index.ts`:
  - Add `export { default as Connection } from './screens/Connection'`
  - Add `export { isDidCommInvitation, isOpenIdCredentialOffer, isOpenIdPresentationRequest } from './utils/parsers'`
  - Add `export { isMediatorInvitation } from './utils/mediatorhelpers'`
- `.changeset/export-connection-screen.md`: `@bifold/core` patch.

## Test plan

- [x] `yarn workspace @bifold/core build` clean
- [x] All five exports appear in `packages/core/lib/typescript/src/index.d.ts` and `packages/core/lib/commonjs/index.js`
- No behavior change; existing screen + helper tests still cover the underlying code.