### PR TITLE
fix: text color on proof request

### DIFF
--- a/.changeset/breezy-moose-say.md
+++ b/.changeset/breezy-moose-say.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+fix text color on proof request

--- a/packages/core/src/components/misc/AttributeRow.tsx
+++ b/packages/core/src/components/misc/AttributeRow.tsx
@@ -3,6 +3,7 @@ import { View, Image } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import { ThemedText } from '../texts/ThemedText'
 import type { CardAttribute } from '../../wallet/ui-types'
+import { useTheme } from '../../contexts/theme'
 
 type Props = {
   item: CardAttribute
@@ -17,6 +18,7 @@ function isDataImage(value: unknown): value is string {
 }
 
 export const CredentialAttributeRow: React.FC<Props> = ({ item, textColor, showPiiWarning, isNotInWallet, styles }) => {
+  const { ColorPalette, ListItems } = useTheme()
   const warn = showPiiWarning && (item.isPII ?? false) && !item.predicate?.present
 
   const predicateFailed = item.predicate?.present && item.predicate.satisfied === false
@@ -26,8 +28,8 @@ export const CredentialAttributeRow: React.FC<Props> = ({ item, textColor, showP
     const errorText = isNotInWallet
       ? 'Not available in your wallet'
       : predicateFailed
-      ? 'Predicate not satisfied'
-      : 'Missing attribute'
+        ? 'Predicate not satisfied'
+        : 'Missing attribute'
 
     return (
       <View style={styles.cardAttributeContainer}>
@@ -35,6 +37,7 @@ export const CredentialAttributeRow: React.FC<Props> = ({ item, textColor, showP
           <Icon
             style={{ paddingTop: 2, paddingHorizontal: 2 }}
             name="close"
+            color={ListItems.proofError.color}
             size={styles.recordAttributeText.fontSize}
           />
           <ThemedText variant="labelSubtitle" style={[styles.textContainer, { opacity: 0.8 }]}>
@@ -55,6 +58,7 @@ export const CredentialAttributeRow: React.FC<Props> = ({ item, textColor, showP
           <Icon
             style={{ paddingTop: 2, paddingHorizontal: 2 }}
             name="warning"
+            color={ColorPalette.notification.warnIcon}
             size={styles.recordAttributeText.fontSize}
           />
         )}

--- a/packages/core/src/hooks/credential-card-styles.ts
+++ b/packages/core/src/hooks/credential-card-styles.ts
@@ -37,7 +37,7 @@ const useCredentialCardStyles = (
     secondaryFromHelper ??
     (isOverlay(overlayOrColors)
       ? overlayOrColors.brandingOverlay?.primaryBackgroundColor
-      : overlayOrColors.secondaryBackgroundColor ?? overlayOrColors.primaryBackgroundColor)
+      : (overlayOrColors.secondaryBackgroundColor ?? overlayOrColors.primaryBackgroundColor))
 
   const styles = StyleSheet.create({
     container: {
@@ -114,10 +114,7 @@ const useCredentialCardStyles = (
       paddingVertical: 4,
     },
     textContainer: {
-      color:
-        proof && (brandingOverlayType === 'Branding10' || brandingOverlayType === BrandingOverlayType.Branding10)
-          ? TextTheme.normal.color
-          : credentialTextColor(ColorPalette, primaryBg),
+      color: credentialTextColor(ColorPalette, primaryBg),
       flexShrink: 1,
       ...((brandingOverlayType === 'Branding11' || brandingOverlayType === BrandingOverlayType.Branding11) && {
         fontSize: 16,


### PR DESCRIPTION
# Summary of Changes

  Restores credential-card text/icon contrast that broke when `CredentialCard11.tsx`

  - `hooks/credential-card-styles.ts` — removed the leftover `proof && Branding10 → TextTheme.normal.color` branch that forced dark text on dark cards. Now always uses `credentialTextColor(ColorPalette, primaryBg)`.
  - `components/misc/AttributeRow.tsx` — the warning and error `<Icon>` had no `color` prop and defaulted to black. Restored `notification.warnIcon` and `proofError.color` (matching the old `CredentialCard11`).

  # Testing Instructions

  1. Trigger a proof request against a credential with a dark OCA primary background (e.g. BC College — DEMO Student Card) that asks for a PII-flagged attribute.
  2. On the Proof Request screen verify the credential card: issuer + name + attribute value + "Get this credential" are readable (white on dark), and the PII warning icon is coloured (not black).
  3. Repeat with a light-background credential — text should be dark grey, still readable.
  4. Trigger a proof for a credential not in the wallet — the red close icon should be visible.

  # Acceptance Criteria

  - Card text is readable on both dark- and light-background credentials, in proof and non-proof contexts.
  - PII warning and missing-attribute icons render in their themed colours, not default black.
  - Existing snapshot tests pass without updates.

  # Screenshots, videos, or gifs

  Before / after of the BC College Student Card on the Proof Request screen.

  # Breaking change guide

  N/A

  # Pull Request Checklist

  - [x] All commits contain a DCO `Signed-off-by` line
  - [x] If applicable, screenshots, gifs, or video are included for UI changes
  - [x] If applicable, breaking changes are described above along with how to address them
  - [x] If applicable, added changeset(s)
  - [x] Added sufficient tests so that overall code coverage is not reduced