### PR TITLE
README fix: "any device" -> "iOS and Android"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Bifold Wallet is an open-source project designed to enhance the way we inter
 
 - **Unified Digital Identity Management:** Emphasizing security and user-friendliness, Bifold excels in consolidating and managing digital identities across various standards like AnonCreds and W3C VC Data Model. This capability positions Bifold as a pivotal resource for secure and private handling of digital identities, accessible to all.
 
-- **Seamless Multi-Platform Use:** Thanks to its React Native architecture, Bifold delivers a smooth experience on any device, enabling users to manage their digital identities whether they are using a phone or a tablet. This cross-platform flexibility means that developers can create applications once and deploy them on both iOS and Android, ensuring a consistent and accessible user experience.
+- **Seamless Use Across Popular Mobile Platforms:** Thanks to its React Native architecture, Bifold delivers a smooth experience on any iOS or Android device, enabling users to manage their digital identities whether they are using a phone or a tablet. This cross-platform flexibility means that developers can create applications once and deploy them on the mobile devices that the majority of people actually use, ensuring a consistent and accessible user experience.
 
 - **Community-Driven Development:** Bifold is more than a tool; it's a community initiative aimed at fostering collaboration and sharing innovations. By bringing together diverse groups, from organizations to individuals, Bifold encourages the pooling of resources and knowledge to facilitate the broader adoption and understanding of verifiable credentials.
 


### PR DESCRIPTION
Currently, the README incorrectly claims that Bifold can be used on any device. This is not at all true, as React Native is currently unable to be run natively on desktop platforms, Windows tablets, mobile linux, or (at this time) HarmonyOS.

# Summary of Changes

The README now correctly identifies iOS and Android as the target platforms

# Future Work

In practice, Remote Attestation (which is technically optional but highly recommended by the OWF in practice) precludes additional OSes such as LineageOS. But I couldn't think of a snappy way to get that across in the README, so I left that out.