### PR TITLE
feat(core): export FileCache for external use

### DIFF
--- a/.changeset/export-file-cache.md
+++ b/.changeset/export-file-cache.md
@@ -1,0 +1,7 @@
+---
+"@bifold/core": minor
+---
+
+Export `FileCache` and `CacheDataFile` from `@bifold/core` so downstream packages can subclass `FileCache` without duplicating the implementation.
+
+Also corrects `CacheDataFile.updatedAt` from `Date` to `string` — `JSON.parse` returns a string and the previous type was inaccurate.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,11 @@
       "require": "./lib/commonjs/index.js",
       "types": "./lib/typescript/src/index.d.ts"
     },
+    "./utils/file-cache": {
+      "import": "./lib/module/utils/fileCache.js",
+      "require": "./lib/commonjs/utils/fileCache.js",
+      "types": "./lib/typescript/src/utils/fileCache.d.ts"
+    },
     "./utils/ledger": {
       "import": "./lib/module/utils/ledger.js",
       "require": "./lib/commonjs/utils/ledger.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -108,6 +108,8 @@ export {
   removeExistingInvitationsById,
   useCredentialConnectionLabel,
 } from './utils/helpers'
+export { FileCache } from './utils/fileCache'
+export type { CacheDataFile } from './utils/fileCache'
 export { getIndyLedgers, IndyLedger, readIndyLedgersFromFile, writeIndyLedgersToFile } from './utils/ledger'
 export { statusBarStyleForColor, StatusBarStyles } from './utils/luminance'
 export { migrateToAskar } from './utils/migration'

--- a/packages/core/src/utils/fileCache.ts
+++ b/packages/core/src/utils/fileCache.ts
@@ -5,7 +5,7 @@ import { BifoldLogger } from '../services/logger'
 
 export type CacheDataFile = {
   fileEtag: string
-  updatedAt: Date
+  updatedAt: string
 }
 
 export class FileCache {
@@ -33,7 +33,7 @@ export class FileCache {
     this._fileEtag = value
     this.saveCacheData({
       fileEtag: value,
-      updatedAt: new Date(),
+      updatedAt: new Date().toISOString(),
     }).catch((error) => {
       this.log?.error(`Failed to save cache data, ${error}`)
     })


### PR DESCRIPTION
## Summary

- Exports `FileCache` and `CacheDataFile` from `@bifold/core`
- Adds a `./utils/file-cache` subpath export to the package manifest

## Why

Downstream packages need to subclass `FileCache` to build their own remote caching resolvers — the same pattern used internally by `RemoteProofBundleResolver`. Without this export they would have to copy the implementation, which defeats the purpose of having a shared base class.

## Test plan

- [ ] Existing tests pass (`yarn test` in `packages/core`)
- [ ] TypeScript types resolve correctly from the new subpath export