### PR TITLE
chore: set FileCache changeset to patch to avoid unintended major bump

### DIFF
--- a/.changeset/export-file-cache.md
+++ b/.changeset/export-file-cache.md
@@ -1,5 +1,5 @@
 ---
-"@bifold/core": patch
+'@bifold/core': patch
 ---
 
 Export `FileCache` and `CacheDataFile` from `@bifold/core` so downstream packages can subclass `FileCache` without duplicating the implementation.

--- a/.changeset/export-file-cache.md
+++ b/.changeset/export-file-cache.md
@@ -1,5 +1,5 @@
 ---
-"@bifold/core": minor
+"@bifold/core": patch
 ---
 
 Export `FileCache` and `CacheDataFile` from `@bifold/core` so downstream packages can subclass `FileCache` without duplicating the implementation.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,6 +11,7 @@ on:
       - 'packages/**'
       - 'package.json'
       - 'yarn.lock'
+      - '.changeset/**'
 
 permissions:
   pull-requests: write

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,5 +1,6 @@
 name: Update Release PR or Publish
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
## Problem

The pending release PR #1866 currently computes **`4.0.0`** (a major bump). It should be **`3.0.15`** (a patch).

## Root cause

`.changeset/export-file-cache.md` (added in #1865, the `FileCache` export) declares `@bifold/core: minor`. Because `.changeset/config.json` uses `fixed: [["@bifold/*"]]`, a `minor` bump anywhere in that group gets escalated to a **major**. Verified locally with `changeset version` against current `main`:

| changeset bump | resulting version |
| --- | --- |
| `minor` (current) | **4.0.0** |
| `patch` (this PR) | **3.0.15** ✅ |
| `minor`, `fixed` disabled | 3.1.0 (confirms the escalation comes from the `fixed` group) |

The `FileCache` export is a small addition and was intended as a patch.

## Changes

1. **`.changeset/export-file-cache.md`**: `minor` → `patch`. This makes the next release **`3.0.15`**.
2. **`.github/workflows/publish.yaml`**: add a `workflow_dispatch` trigger. The release workflow's `paths:` filter does not include `.changeset/**`, so a changeset-only edit wouldn't re-trigger it. Editing this workflow file (a tracked trigger path) ensures the release PR regenerates on merge, and `workflow_dispatch` also adds a manual trigger for the future.

## After merge

The release workflow re-runs and updates #1866 from `4.0.0` to **`3.0.15`**. Then merge #1866 to publish.

---

> **Heads-up (separate issue):** `fixed: [["@bifold/*"]]` escalates *any* `minor` changeset to a `major`, so a normal `3.x` → `3.(x+1).0` minor release isn't currently possible — every feature would jump a major. Worth addressing separately (e.g. `linked` instead of `fixed`).
