### PR TITLE
feat: added new error parsing to bifold object

### DIFF
--- a/.changeset/frank-worlds-joke.md
+++ b/.changeset/frank-worlds-joke.md
@@ -1,0 +1,5 @@
+---
+'@bifold/remote-logs': patch
+---
+
+added better error serialization

--- a/packages/remote-logs/src/__tests__/logger.comprehensive.test.ts
+++ b/packages/remote-logs/src/__tests__/logger.comprehensive.test.ts
@@ -459,12 +459,7 @@ describe('RemoteLogger', () => {
         rawMsg: [
           {
             message: 'Error Title',
-            data: {
-              title: 'Error Title',
-              description: 'Error Description',
-              code: 1001,
-              message: 'Error Message',
-            },
+            error: bifoldError,
           },
         ],
         level: { severity: 3, text: 'error' },

--- a/packages/remote-logs/src/logger.ts
+++ b/packages/remote-logs/src/logger.ts
@@ -1,9 +1,9 @@
-import { BifoldError, AbstractBifoldLogger } from '@bifold/core'
+import { AbstractBifoldLogger, BifoldError } from '@bifold/core'
 import { LogLevel } from '@credo-ts/core'
 import { DeviceEventEmitter, EmitterSubscription } from 'react-native'
 import { logger } from 'react-native-logs'
 
-import { RemoteLoggerOptions, lokiTransport, consoleTransport } from './transports'
+import { RemoteLoggerOptions, consoleTransport, lokiTransport } from './transports'
 
 export enum RemoteLoggerEventTypes {
   ENABLE_REMOTE_LOGGING = 'RemoteLogging.Enable',
@@ -168,11 +168,12 @@ export class RemoteLogger extends AbstractBifoldLogger {
 
   public report(bifoldError: BifoldError): void {
     this._log?.info?.({ message: 'Sending Loki report' })
-    const { title, description, code, message } = bifoldError
 
     lokiTransport({
-      msg: title,
-      rawMsg: [{ message: title, data: { title, description, code, message } }],
+      msg: bifoldError.title,
+      // Preserve the original error instance so downstream serializers can
+      // extract stack/cause and any custom fields consistently.
+      rawMsg: [{ message: bifoldError.title, error: bifoldError }],
       level: { severity: 3, text: 'error' },
       options: {
         lokiUrl: this.lokiUrl,

--- a/packages/remote-logs/src/transports/loki.ts
+++ b/packages/remote-logs/src/transports/loki.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
+import { LogLevel } from '@credo-ts/core'
 import axios from 'axios'
 import { Buffer } from 'buffer'
 import { transportFunctionType } from 'react-native-logs'
-import { LogLevel } from '@credo-ts/core'
 
 export interface RemoteLoggerOptions {
   lokiUrl?: string
@@ -23,6 +23,46 @@ export type LokiTransportProps = {
   }
   options?: RemoteLoggerOptions
 }
+
+// Fields stripped from cause errors: stack is redundant; config/request/response
+// can contain PII we want to omit
+const CAUSE_OMIT = new Set(['stack', 'config', 'request', 'response'])
+
+// Extract the response body from an error, if present
+const extractResponseData = (error: Error): Record<string, unknown> => {
+  const data = (error as { response?: { data?: unknown } }).response?.data
+  if (typeof data === 'string') {
+    return { responseData: data }
+  }
+  return {}
+}
+
+const serializeError = (error: Error, depth = 0): Record<string, unknown> => {
+  const ownProps = Object.fromEntries(
+    Object.entries(error)
+      // filter stack — handled explicitly below
+      .filter(([k]) => k !== 'stack' && (depth === 0 || !CAUSE_OMIT.has(k)))
+      .map(([k, v]) => [k, v instanceof Error ? serializeError(v, depth + 1) : v])
+  )
+
+  return {
+    name: error.name,
+    message: error.message,
+    ...(depth === 0 && {
+      stack:
+        error.stack
+          ?.split('\n')
+          .slice(1)
+          .map((l) => l.trim()) ?? [],
+    }),
+    cause: error.cause instanceof Error ? serializeError(error.cause, depth + 1) : error.cause,
+    ...ownProps,
+    ...(depth > 0 && extractResponseData(error)),
+  }
+}
+
+const errorReplacer = (_key: string, value: unknown): unknown =>
+  value instanceof Error ? serializeError(value) : value
 
 export const lokiTransport: transportFunctionType = (props: LokiTransportProps) => {
   // Loki requires a timestamp with nanosecond precision
@@ -55,7 +95,7 @@ export const lokiTransport: transportFunctionType = (props: LokiTransportProps) 
           level: props.level.text,
           ...lokiLabels,
         },
-        values: [[`${Date.now()}${timestampEndPadding}`, JSON.stringify({ message, data, error })]],
+        values: [[`${Date.now()}${timestampEndPadding}`, JSON.stringify({ message, data, error }, errorReplacer)]],
       },
     ],
   }

--- a/packages/remote-logs/tsconfig.json
+++ b/packages/remote-logs/tsconfig.json
@@ -12,7 +12,7 @@
 
     /* Language and Environment */
     "target": "ES2017" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-    "lib": [] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
+    "lib": ["ES2022.Error"] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */


### PR DESCRIPTION
# Summary of Changes

- modified error serialization to include more information 

# Testing Instructions

- link bc wallet
- trigger errors

# Acceptance Criteria

- errors still displayed in the app
- the app launches as expected 

# Screenshots, videos, or gifs

new loki object:
```json
{
  "message": "Something went wrong",
  "error": {
    "name": "Error",
    "message": "Server rejected the request — check request payload\nDebug: [network.err_209_bad_request.2107] Request failed with status code 400: email_address is invalid\nScreen: Email Entry\nRequest: POST /evidence/v1/emails/\nReport ID: a382e4a5-8ef3-4f51-bb68-99564e3b7fc6",
    "stack": [
      "at construct (native)",
      "at apply (native)",
      "at _construct (http://192.168.4.45:8081/index.bundle//&platform=ios&dev=true&lazy=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&excludeSource=true&sourcePaths=url-server&app=ca.bc.gov.BCWallet:21606:106)",
      "at Wrapper (http://192.168.4.45:8081/index.bundle//&platform=ios&dev=true&lazy=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&excludeSource=true&sourcePaths=url-server&app=ca.bc.gov.BCWallet:21580:64)",
      "at construct (native)",
      "at _callSuper (http://192.168.4.45:8081/index.bundle//&platform=ios&dev=true&lazy=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&excludeSource=true&sourcePaths=url-server&app=ca.bc.gov.BCWallet:964568:170)",
      "at AppError (http://192.168.4.45:8081/index.bundle//&platform=ios&dev=true&lazy=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&excludeSource=true&sourcePaths=url-server&app=ca.bc.gov.BCWallet:964631:25)",
      "at fromErrorDefinition (http://192.168.4.45:8081/index.bundle//&platform=ios&dev=true&lazy=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&excludeSource=true&sourcePaths=url-server&app=ca.bc.gov.BCWallet:964766:28)",
      "at getAppErrorFromAxiosError (http://192.168.4.45:8081/index.bundle//&platform=ios&dev=true&lazy=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&excludeSource=true&sourcePaths=url-server&app=ca.bc.gov.BCWallet:965793:93)",
      "at ?anon_0_ (http://192.168.4.45:8081/index.bundle//&platform=ios&dev=true&lazy=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&excludeSource=true&sourcePaths=url-server&app=ca.bc.gov.BCWallet:962278:118)",
      "at next (native)",
      "at asyncGeneratorStep (http://192.168.4.45:8081/index.bundle//&platform=ios&dev=true&lazy=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&excludeSource=true&sourcePaths=url-server&app=ca.bc.gov.BCWallet:23642:19)",
      "at _next (http://192.168.4.45:8081/index.bundle//&platform=ios&dev=true&lazy=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&excludeSource=true&sourcePaths=url-server&app=ca.bc.gov.BCWallet:23656:29)",
      "at anonymous (http://192.168.4.45:8081/index.bundle//&platform=ios&dev=true&lazy=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&excludeSource=true&sourcePaths=url-server&app=ca.bc.gov.BCWallet:23661:14)",
      "at tryCallTwo (address at InternalBytecode.js:1:1222)",
      "at doResolve (address at InternalBytecode.js:1:2541)",
      "at Promise (address at InternalBytecode.js:1:1318)",
      "at anonymous (http://192.168.4.45:8081/index.bundle//&platform=ios&dev=true&lazy=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&excludeSource=true&sourcePaths=url-server&app=ca.bc.gov.BCWallet:23653:25)",
      "at apply (native)",
      "at anonymous (http://192.168.4.45:8081/index.bundle//&platform=ios&dev=true&lazy=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&excludeSource=true&sourcePaths=url-server&app=ca.bc.gov.BCWallet:962309:28)",
      "at tryCallOne (address at InternalBytecode.js:1:1180)",
      "at anonymous (address at InternalBytecode.js:1:1874)"
    ],
    "cause": {
      "name": "AxiosError",
      "message": "Request failed with status code 400",
      "isAxiosError": true,
      "code": "ERR_BAD_REQUEST",
      "status": 400,
      "responseData": "email_address is invalid"
    },
    "title": "Something went wrong",
    "description": "We couldn't complete your request at this time. Please try again later.\n\nIf the issue persists, close and re-open the app to try again.",
    "code": 2107
  }
}

```

# Breaking change guide

Replace this text with any breaking changes included in this PR along with how to address them in downstream projects. If there are none, simply enter N/A

# Related Issues


# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
