### PR TITLE
feat: usePreventDoublePress hook

### DIFF
--- a/.changeset/deep-spoons-yawn.md
+++ b/.changeset/deep-spoons-yawn.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+Disabled double presses on button components. Added usePreventDoublePress hook for disabling duplicate onPress events.

--- a/packages/core/__tests__/hooks/usePreventDoublePress.test.ts
+++ b/packages/core/__tests__/hooks/usePreventDoublePress.test.ts
@@ -21,15 +21,10 @@ describe('usePreventDoublePress', () => {
     expect(callback).toHaveBeenCalledWith('a', 1)
   })
 
-  it('returns undefined when undefined callback is provided', () => {
+  it('returns undefined when no callback is provided', () => {
     const { result } = renderHook(() => usePreventDoublePress())
 
     expect(result.current.preventDoublePress(undefined)).toBeUndefined()
-  })
-
-  it('returns null when null callback is provided', () => {
-    const { result } = renderHook(() => usePreventDoublePress())
-
     expect(result.current.preventDoublePress(null)).toBeUndefined()
   })
 

--- a/packages/core/__tests__/hooks/usePreventDoublePress.test.ts
+++ b/packages/core/__tests__/hooks/usePreventDoublePress.test.ts
@@ -1,0 +1,111 @@
+import { act, renderHook } from '@testing-library/react-native'
+
+import { usePreventDoublePress } from '../../src/hooks/usePreventDoublePress'
+
+describe('usePreventDoublePress', () => {
+  it('invokes the wrapped callback', async () => {
+    const { result } = renderHook(() => usePreventDoublePress())
+    const callback = jest.fn()
+
+    await act(() => result.current.preventDoublePress(callback)())
+
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('forwards arguments to the wrapped callback', async () => {
+    const { result } = renderHook(() => usePreventDoublePress())
+    const callback = jest.fn()
+
+    await act(() => result.current.preventDoublePress(callback)('a', 1))
+
+    expect(callback).toHaveBeenCalledWith('a', 1)
+  })
+
+  it('does not throw when no callback is provided', async () => {
+    const { result } = renderHook(() => usePreventDoublePress())
+
+    await expect(act(() => result.current.preventDoublePress()())).resolves.not.toThrow()
+  })
+
+  it('sets isPressing to true while the callback is pending and false once it resolves', async () => {
+    const { result } = renderHook(() => usePreventDoublePress())
+    let resolveCallback!: () => void
+    const callback = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCallback = resolve
+        })
+    )
+
+    expect(result.current.isPressing).toBe(false)
+
+    let pressPromise!: Promise<void>
+    await act(async () => {
+      pressPromise = result.current.preventDoublePress(callback)()
+    })
+
+    expect(result.current.isPressing).toBe(true)
+
+    await act(async () => {
+      resolveCallback()
+      await pressPromise
+    })
+
+    expect(result.current.isPressing).toBe(false)
+  })
+
+  it('ignores a second press while the first callback is still running', async () => {
+    const { result } = renderHook(() => usePreventDoublePress())
+    let resolveCallback!: () => void
+    const callback = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCallback = resolve
+        })
+    )
+    const wrapped = result.current.preventDoublePress(callback)
+
+    let firstPress!: Promise<void>
+    await act(async () => {
+      firstPress = wrapped()
+    })
+    await act(async () => {
+      wrapped()
+    })
+
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveCallback()
+      await firstPress
+    })
+  })
+
+  it('allows a new press once the previous callback has resolved', async () => {
+    const { result } = renderHook(() => usePreventDoublePress())
+    const callback = jest.fn().mockResolvedValue(undefined)
+    const wrapped = result.current.preventDoublePress(callback)
+
+    await act(async () => wrapped())
+    await act(async () => wrapped())
+
+    expect(callback).toHaveBeenCalledTimes(2)
+  })
+
+  it('resets the guard even when the callback rejects', async () => {
+    const { result } = renderHook(() => usePreventDoublePress())
+    const error = new Error('boom')
+    const callback = jest.fn().mockRejectedValue(error)
+    const wrapped = result.current.preventDoublePress(callback)
+
+    await act(async () => {
+      await expect(wrapped()).rejects.toThrow('boom')
+    })
+    expect(result.current.isPressing).toBe(false)
+
+    const secondCallback = jest.fn()
+    await act(() => result.current.preventDoublePress(secondCallback)())
+
+    expect(secondCallback).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/__tests__/hooks/usePreventDoublePress.test.ts
+++ b/packages/core/__tests__/hooks/usePreventDoublePress.test.ts
@@ -21,10 +21,16 @@ describe('usePreventDoublePress', () => {
     expect(callback).toHaveBeenCalledWith('a', 1)
   })
 
-  it('does not throw when no callback is provided', async () => {
+  it('returns undefined when undefined callback is provided', () => {
     const { result } = renderHook(() => usePreventDoublePress())
 
-    await expect(act(() => result.current.preventDoublePress()())).resolves.not.toThrow()
+    expect(result.current.preventDoublePress(undefined)).toBeUndefined()
+  })
+
+  it('returns null when null callback is provided', () => {
+    const { result } = renderHook(() => usePreventDoublePress())
+
+    expect(result.current.preventDoublePress(null)).toBeUndefined()
   })
 
   it('sets isPressing to true while the callback is pending and false once it resolves', async () => {

--- a/packages/core/__tests__/hooks/usePreventDoublePress.test.ts
+++ b/packages/core/__tests__/hooks/usePreventDoublePress.test.ts
@@ -21,11 +21,16 @@ describe('usePreventDoublePress', () => {
     expect(callback).toHaveBeenCalledWith('a', 1)
   })
 
-  it('returns undefined when no callback is provided', () => {
+  it('returns undefined when undefined callback is provided', () => {
     const { result } = renderHook(() => usePreventDoublePress())
 
     expect(result.current.preventDoublePress(undefined)).toBeUndefined()
-    expect(result.current.preventDoublePress(null)).toBeUndefined()
+  })
+
+  it('returns null when null callback is provided', () => {
+    const { result } = renderHook(() => usePreventDoublePress())
+
+    expect(result.current.preventDoublePress(null)).toBeNull()
   })
 
   it('sets isPressing to true while the callback is pending and false once it resolves', async () => {

--- a/packages/core/src/components/buttons/Button.tsx
+++ b/packages/core/src/components/buttons/Button.tsx
@@ -5,6 +5,8 @@ import { useTheme } from '../../contexts/theme'
 
 import { ThemedText } from '../texts/ThemedText'
 import { Button, ButtonProps, ButtonType } from './Button-api'
+import { usePreventDoublePress } from '../../hooks/usePreventDoublePress'
+import { TOKENS, useServices } from '../../container-api'
 
 const ButtonImpl = ({
   title,
@@ -19,6 +21,8 @@ const ButtonImpl = ({
   ref,
 }: ButtonProps) => {
   const { Buttons, heavyOpacity } = useTheme()
+  const [logger] = useServices([TOKENS.UTIL_LOGGER])
+  const { preventDoublePress } = usePreventDoublePress()
   const buttonStyles = {
     [ButtonType.Critical]: {
       color: Buttons.critical,
@@ -73,7 +77,7 @@ const ButtonImpl = ({
 
   return (
     <TouchableOpacity
-      onPress={onPress}
+      onPress={preventDoublePress(onPress, logger)}
       accessible
       accessibilityLabel={accessibilityLabel}
       accessibilityHint={accessibilityHint}

--- a/packages/core/src/components/buttons/Button.tsx
+++ b/packages/core/src/components/buttons/Button.tsx
@@ -6,7 +6,6 @@ import { useTheme } from '../../contexts/theme'
 import { ThemedText } from '../texts/ThemedText'
 import { Button, ButtonProps, ButtonType } from './Button-api'
 import { usePreventDoublePress } from '../../hooks/usePreventDoublePress'
-import { TOKENS, useServices } from '../../container-api'
 
 const ButtonImpl = ({
   title,
@@ -21,7 +20,6 @@ const ButtonImpl = ({
   ref,
 }: ButtonProps) => {
   const { Buttons, heavyOpacity } = useTheme()
-  const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const { preventDoublePress } = usePreventDoublePress()
   const buttonStyles = {
     [ButtonType.Critical]: {
@@ -77,7 +75,7 @@ const ButtonImpl = ({
 
   return (
     <TouchableOpacity
-      onPress={preventDoublePress(onPress, logger)}
+      onPress={preventDoublePress(onPress)}
       accessible
       accessibilityLabel={accessibilityLabel}
       accessibilityHint={accessibilityHint}

--- a/packages/core/src/components/buttons/IconButton.tsx
+++ b/packages/core/src/components/buttons/IconButton.tsx
@@ -6,6 +6,7 @@ import { hitSlop } from '../../constants'
 import { useTheme } from '../../contexts/theme'
 import { ThemedText } from '../texts/ThemedText'
 import { TOKENS, useServices } from '../../container-api'
+import { usePreventDoublePress } from '../../hooks/usePreventDoublePress'
 
 const defaultIconSize = 26
 
@@ -35,6 +36,7 @@ const IconButton: React.FC<IconButtonProps> = ({
 }) => {
   const { ColorPalette } = useTheme()
   const [logger] = useServices([TOKENS.UTIL_LOGGER])
+  const { preventDoublePress } = usePreventDoublePress()
 
   const style = StyleSheet.create({
     container: {
@@ -99,7 +101,7 @@ const IconButton: React.FC<IconButtonProps> = ({
       accessibilityLabel={accessibilityLabel}
       accessibilityRole={'button'}
       testID={testID}
-      onPress={onPress}
+      onPress={preventDoublePress(onPress, logger)}
       hitSlop={hitSlop}
     >
       <View style={style.container}>{layoutForButtonLocation(buttonLocation)}</View>

--- a/packages/core/src/components/buttons/IconButton.tsx
+++ b/packages/core/src/components/buttons/IconButton.tsx
@@ -101,7 +101,7 @@ const IconButton: React.FC<IconButtonProps> = ({
       accessibilityLabel={accessibilityLabel}
       accessibilityRole={'button'}
       testID={testID}
-      onPress={preventDoublePress(onPress, logger)}
+      onPress={preventDoublePress(onPress)}
       hitSlop={hitSlop}
     >
       <View style={style.container}>{layoutForButtonLocation(buttonLocation)}</View>

--- a/packages/core/src/components/buttons/ToggleButton.tsx
+++ b/packages/core/src/components/buttons/ToggleButton.tsx
@@ -4,7 +4,6 @@ import Icon from 'react-native-vector-icons/MaterialIcons'
 import { useTheme } from '../../contexts/theme'
 import { useTranslation } from 'react-i18next'
 import { usePreventDoublePress } from '../../hooks/usePreventDoublePress'
-import { TOKENS, useServices } from '../../container-api'
 
 interface ToggleButtonProps {
   isEnabled: boolean
@@ -28,7 +27,6 @@ const ToggleButton: React.FC<ToggleButtonProps> = ({
   const { ColorPalette } = useTheme()
   const [toggleAnim] = useState(new Animated.Value(isEnabled ? 1 : 0))
   const { t } = useTranslation()
-  const [logger] = useServices([TOKENS.UTIL_LOGGER])
   const { preventDoublePress } = usePreventDoublePress()
 
   useEffect(() => {
@@ -58,7 +56,7 @@ const ToggleButton: React.FC<ToggleButtonProps> = ({
       accessibilityState={{
         checked: isEnabled,
       }}
-      onPress={isAvailable && !disabled ? preventDoublePress(toggleAction, logger) : undefined} // Prevent onPress if not available or disabled
+      onPress={isAvailable && !disabled ? preventDoublePress(toggleAction) : undefined} // Prevent onPress if not available or disabled
       disabled={!isAvailable || disabled}
     >
       <Animated.View

--- a/packages/core/src/components/buttons/ToggleButton.tsx
+++ b/packages/core/src/components/buttons/ToggleButton.tsx
@@ -3,6 +3,8 @@ import { Pressable, Animated } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import { useTheme } from '../../contexts/theme'
 import { useTranslation } from 'react-i18next'
+import { usePreventDoublePress } from '../../hooks/usePreventDoublePress'
+import { TOKENS, useServices } from '../../container-api'
 
 interface ToggleButtonProps {
   isEnabled: boolean
@@ -26,6 +28,8 @@ const ToggleButton: React.FC<ToggleButtonProps> = ({
   const { ColorPalette } = useTheme()
   const [toggleAnim] = useState(new Animated.Value(isEnabled ? 1 : 0))
   const { t } = useTranslation()
+  const [logger] = useServices([TOKENS.UTIL_LOGGER])
+  const { preventDoublePress } = usePreventDoublePress()
 
   useEffect(() => {
     Animated.timing(toggleAnim, {
@@ -54,7 +58,7 @@ const ToggleButton: React.FC<ToggleButtonProps> = ({
       accessibilityState={{
         checked: isEnabled,
       }}
-      onPress={isAvailable && !disabled ? toggleAction : undefined} // Prevent onPress if not available or disabled
+      onPress={isAvailable && !disabled ? preventDoublePress(toggleAction, logger) : undefined} // Prevent onPress if not available or disabled
       disabled={!isAvailable || disabled}
     >
       <Animated.View

--- a/packages/core/src/hooks/usePreventDoublePress.ts
+++ b/packages/core/src/hooks/usePreventDoublePress.ts
@@ -1,5 +1,4 @@
 import { useCallback, useMemo, useRef, useState } from 'react'
-import { BifoldLogger } from '../services/logger'
 
 /**
  * Prevents double press on a button by disabling the button while the callback is executing.
@@ -10,7 +9,7 @@ import { BifoldLogger } from '../services/logger'
  * const MyButton = () => {
  *   const { preventDoublePress } = usePreventDoublePress();
  *   const handlePress = async () => {};
- *   return <Button onPress={preventDoublePress(handlePress, logger)} title="Press me" />;
+ *   return <Button onPress={preventDoublePress(handlePress)} title="Press me" />;
  * }
  * ```
  * @returns An object containing the `preventDoublePress` function.
@@ -24,14 +23,19 @@ export const usePreventDoublePress = () => {
    * Prevents double press on a button by disabling the button while the callback is executing.
    *
    * @param callback The callback to execute when the button is pressed.
-   * @param logger Optional logger to log double press events.
    * @returns A function that can be used as an onPress handler for a button.
    */
   const preventDoublePress = useCallback(
-    <T extends (...args: never[]) => unknown>(callback?: T | null, logger?: BifoldLogger) =>
-      async (...args: Parameters<T>) => {
+    <TFunction extends ((...args: any[]) => any) | null | undefined>(callback: TFunction) => {
+      if (!callback) {
+        return callback
+      }
+
+      return async (...args: Parameters<NonNullable<TFunction>>) => {
         if (isPressingRef.current) {
-          logger?.debug('[usePreventDoublePress] Double press detected, ignoring.')
+          // Using console.debug here to prevent introducing a new dependency for a single debug log
+          // eslint-disable-next-line no-console
+          console.debug('[usePreventDoublePress] Double press detected, ignoring.')
           return
         }
 
@@ -44,7 +48,8 @@ export const usePreventDoublePress = () => {
           setIsPressing(false)
           isPressingRef.current = false
         }
-      },
+      }
+    },
     []
   )
 

--- a/packages/core/src/hooks/usePreventDoublePress.ts
+++ b/packages/core/src/hooks/usePreventDoublePress.ts
@@ -1,0 +1,52 @@
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { BifoldLogger } from '../services/logger'
+
+/**
+ * Prevents double press on a button by disabling the button while the callback is executing.
+ *
+ * @example
+ * ```tsx
+ * import { usePreventDoublePress } from './hooks/usePreventDoublePress';
+ * const MyButton = () => {
+ *   const { preventDoublePress } = usePreventDoublePress();
+ *   const handlePress = async () => {};
+ *   return <Button onPress={preventDoublePress(handlePress, logger)} title="Press me" />;
+ * }
+ * ```
+ * @returns An object containing the `preventDoublePress` function.
+ */
+export const usePreventDoublePress = () => {
+  // Note: Using a ref to prevent double presses on the same tick
+  const isPressingRef = useRef(false)
+  const [isPressing, setIsPressing] = useState(false)
+
+  /**
+   * Prevents double press on a button by disabling the button while the callback is executing.
+   *
+   * @param callback The callback to execute when the button is pressed.
+   * @param logger Optional logger to log double press events.
+   * @returns A function that can be used as an onPress handler for a button.
+   */
+  const preventDoublePress = useCallback(
+    <T extends (...args: never[]) => unknown>(callback?: T | null, logger?: BifoldLogger) =>
+      async (...args: Parameters<T>) => {
+        if (isPressingRef.current) {
+          logger?.debug('[usePreventDoublePress] Double press detected, ignoring.')
+          return
+        }
+
+        setIsPressing(true)
+        isPressingRef.current = true
+
+        try {
+          await callback?.(...args)
+        } finally {
+          setIsPressing(false)
+          isPressingRef.current = false
+        }
+      },
+    []
+  )
+
+  return useMemo(() => ({ isPressing, preventDoublePress }), [isPressing, preventDoublePress])
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -78,6 +78,7 @@ import { DeepPartial, ThemeBuilder } from './theme-builder'
 import * as types from './types'
 import { CredentialListFooterProps } from './types/credential-list-footer'
 import { QrCodeScanError } from './types/error'
+import { usePreventDoublePress } from './hooks/usePreventDoublePress'
 
 export { animatedComponents } from './animated-components'
 export { EventTypes, LocalStorageKeys } from './constants'
@@ -271,6 +272,7 @@ export {
   useDeveloperMode,
   usePreventScreenCapture,
   useTour,
+  usePreventDoublePress,
   walletTimeout,
 }
 export type { BannerMessage, DeepPartial, IButton }


### PR DESCRIPTION
# Summary of Changes

This PR creates a new hook `usePreventDoublePress` and applies to existing Bifold button components. Preventing double presses from firing multiple async operations at the same time.

# Testing Instructions

- Double press a Bifold Button.tsx (check log displays)

# Acceptance Criteria

- [ ] Tests pass
- [ ] Duplicate onPress events are ignored when using `preventDoublePress`

# Screenshots, videos, or gifs

Replace this text with embedded media for UI changes if they are included in this PR. If there are none, simply enter N/A

# Breaking change guide

Replace this text with any breaking changes included in this PR along with how to address them in downstream projects. If there are none, simply enter N/A

# Related Issues

Replace this text with issue #'s that are relevant to this PR. If there are none, simply enter N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
