### PR TITLE
fix: env is authority on mediator

### DIFF
--- a/.changeset/good-things-hunt.md
+++ b/.changeset/good-things-hunt.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+make env mediator authority

--- a/packages/core/src/container-impl.ts
+++ b/packages/core/src/container-impl.ts
@@ -2,6 +2,7 @@ import { DefaultOCABundleResolver } from '@bifold/oca/build/legacy'
 import { getProofRequestTemplates } from '@bifold/verifier'
 import { Agent } from '@credo-ts/core'
 import React, { createContext, useContext } from 'react'
+import RNConfig from 'react-native-config'
 import { DependencyContainer } from 'tsyringe'
 
 import * as bundle from './assets/oca-bundles.json'
@@ -219,9 +220,18 @@ export class MainContainer implements Container {
         loadState<StoreOnboardingState>(LocalStorageKeys.Onboarding, (val) => (onboarding = val)),
       ])
 
+      const preferencesState = { ...defaultState.preferences, ...preferences }
+
+      if (RNConfig.MEDIATOR_URL) {
+        preferencesState.selectedMediator = RNConfig.MEDIATOR_URL
+        if (!preferencesState.availableMediators.includes(RNConfig.MEDIATOR_URL)) {
+          preferencesState.availableMediators = [RNConfig.MEDIATOR_URL, ...preferencesState.availableMediators]
+        }
+      }
+
       const state = {
         loginAttempt: { ...defaultState.loginAttempt, ...loginAttempt },
-        preferences: { ...defaultState.preferences, ...preferences },
+        preferences: preferencesState,
         migration: { ...defaultState.migration, ...migration },
         tours: { ...defaultState.tours, ...tours },
         onboarding: { ...defaultState.onboarding, ...onboarding },


### PR DESCRIPTION
# Summary of Changes

The configurable mediator feature was persisting the current mediator and ignoring MEDIATOR_URL, even if it changed. This makes it impossible to effectively update your MEDIATOR_URL.

# Testing Instructions

Change your MEDIATOR URL and do a new build, agent should initialize successfully with the new mediator

# Acceptance Criteria

Works

# Screenshots, videos, or gifs

N/A

# Breaking change guide

The configurable mediator feature will only keep an alternate mediator selected until the next full restart, after that, different mediators will need to be selected again.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [x] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated checks have passed
