### PR TITLE
fix: handle accept new url invitations

### DIFF
--- a/.changeset/honest-eyes-retire.md
+++ b/.changeset/honest-eyes-retire.md
@@ -1,0 +1,5 @@
+---
+'@bifold/core': patch
+---
+
+oob invitation url update

--- a/packages/core/src/utils/parsers.tsx
+++ b/packages/core/src/utils/parsers.tsx
@@ -63,7 +63,13 @@ export const isDidCommInvitation = (url: string) => {
     return true
   }
 
-  if (url.includes('c_i=') || url.includes('oob=') || url.includes('oobUrl=') || url.includes('d_m=')) {
+  if (
+    url.includes('c_i=') ||
+    url.includes('oob=') ||
+    url.includes('oobUrl=') ||
+    url.includes('d_m=') ||
+    url.includes('/i/')
+  ) {
     return true
   }
 


### PR DESCRIPTION
# Summary of Changes

`isDidCommInvitation()` now also treats URLs containing a `/i/` path segment as DIDComm invitations, alongside the existing `c_i=`, `oob=`, `oobUrl=`, and `d_m=` markers. This lets the wallet accept the newer `/i/` short-link invitation URL format.

# Testing Instructions

1. Scan (or deep-link) a DIDComm invitation URL that uses the `/i/` short-link format and confirm it is recognized and processed as an invitation.
2. Confirm existing invitation formats (`c_i=`, `oob=`, `oobUrl=`, `d_m=`) still resolve as before.

# Acceptance Criteria

- URLs containing `/i/` are detected as DIDComm invitations by `isDidCommInvitation()`.
- Existing invitation URL formats continue to be detected (no regression).

# Screenshots, videos, or gifs

N/A

# Breaking change guide

N/A — additive change; broadens invitation URL detection.

# Related Issues

N/A

# Pull Request Checklist

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this)
- [x] If applicable, screenshots, gifs, or video are included for UI changes
- [x] If applicable, breaking changes are described above along with how to address them
- [x] If applicable, added [changeset(s)](https://github.com/changesets/changesets)
- [ ] Added sufficient [tests](../packages/core/__tests__/) so that overall code coverage is not reduced
